### PR TITLE
v0.5.0: VSM-aligned DOM restructure + use[of=...] primitive + cross-axis cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ project follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-04-14
+
+### Added
+- **VSM-aligned taxa**: `principal` (S5) and `audit` (S3*) as new top-level
+  taxa; `operation`, `coordination`, `control`, `intelligence` as aliases
+  of `capability`/`state`/`actor`. Legacy taxon names remain fully functional.
+- **`use[of=...]` entity** — first-class permissioned projection of a
+  world resource into the action axis. Carries action-axis permission
+  properties: `editable`, `visible`, `show`, `allow`, `deny`,
+  `allow-pattern`, `deny-pattern`. Additive to world-axis permissions on
+  `file`/`dir`/`tool`/`network` — the two axes are semantically
+  independent (see spec §3a).
+- **`@audit { ... }` at-rule** for declaring audit-taxon entries
+  (observation, manifest) outside the world.
+- **Cross-axis cascade specificity**: selectors that join more taxa-axes
+  are more specific. Specificity tuple widened from `(ids, cls, types)`
+  to `(axis_count, principal, world, state, actor, capability, audit, other)`.
+  Single-axis v0.4 rules retain identical ordering because `axis_count=1`
+  is uniform across them.
+- **Byte-compat snapshot suite** across all 5 fixtures × 3 compilers
+  (nsjail, bwrap, lackpy-namespace) guards compiler output against
+  unintended drift.
+- **Resolver determinism property test** across all fixtures and a
+  50-run stability check.
+- **Taxon-alias resolution** in registry (`resolve_taxon`) — entity,
+  property, matcher, and validator lookups all route through canonical
+  names transparently.
+
+### Changed
+- `ComplexSelector.specificity` type widened from `tuple[int, int, int]`
+  to `tuple[int, ...]`.
+- `umwelt.registry` public API exports `register_taxon_alias` and
+  `resolve_taxon`.
+
+### Notes
+- Compilers (nsjail, bwrap, lackpy-namespace) continue to read world-axis
+  entities directly in v0.5. The v0.6 work will decide which compilers
+  should migrate to reading the action-axis (e.g., lackpy for per-tool
+  gating via `use[of=tool#X]`).
+- Kibitzer-hooks compiler deferred to v0.6. Security pass deferred to v0.7.
+- Evaluation framework (`docs/vision/evaluation-framework.md`) introduced
+  as the reference for claims verified/open per milestone. v0.5 verifies
+  or strengthens claims A1, A2, A3, A5, A6, B1-continuity, G1, H1, H3, I1,
+  I3.
+
 ## [0.4.0] — 2026-04-13
 
 The lackpy-namespace, diff, and PyPI milestone. Adds the first

--- a/docs/guide/entity-reference.md
+++ b/docs/guide/entity-reference.md
@@ -6,10 +6,102 @@ Every entity type, attribute, and property registered by the sandbox consumer. T
 
 ---
 
+## VSM alias taxa (v0.5+)
+
+v0.5 introduces a Viable System Model (VSM) aligned naming for taxa. The Beer names are **aliases** — existing names still work, and the VSM names resolve to the same matchers:
+
+| VSM taxon | Legacy taxon | Beer's system |
+|---|---|---|
+| `principal` | *(new)* | S5 — Identity / commissioning authority |
+| `world` | `world` | S0 — Environment |
+| `audit` | *(new)* | S3\* — Audit bypass channel |
+| `control` | `state` | S3 — Current-moment regulation |
+| `coordination` | `state` | S2 — Anti-oscillation / harness |
+| `intelligence` | `actor` | S4 — The inferencer |
+| `operation` | `capability` | S1 — Tools and effects |
+
+All seven taxa participate in cross-axis cascade specificity: selectors that name more axes win. See the design note at `docs/vision/notes/vsm-alignment.md` for the rationale.
+
+---
+
+## principal taxon
+
+**What it models:** the commissioning authority — the human or outer agent who defined this view.
+**VSM concept:** S5 (Identity / policy).
+
+Minimal in v0.5. Richer principal modeling (cross-delegate lineage, grade lattice) is v1.1+.
+
+### `principal` — the commissioning authority
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `name` | str | | Principal name (used as `#id` in selectors) |
+
+| Property | Type | Comparison | Description |
+|---|---|---|---|
+| `intent` | str | exact | Human-readable statement of purpose for this delegation |
+| `grade` | str | exact | Trust grade: `personal`, `team`, `org` (v1.1+) |
+
+**Selector examples:**
+```css
+principal#Teague { intent: "code review"; }
+principal#Teague world#sandbox { /* rules for this principal's world */ }
+```
+
+---
+
+## audit taxon
+
+**What it models:** observations from outside the delegate's world — the S3\* bypass channel.
+**VSM concept:** S3\* (Audit — direct observation without S2/S3 interference).
+
+Audit sits *outside* the world hierarchy. Entries in `@audit { ... }` are never subject to world-scoped context qualifiers. No audit compiler ships in v0.5; these entities are the contract for v0.7's observation consumer.
+
+### `observation` — an observation entry
+
+Something a Layer-2 observer reported (e.g. from `blq`, `ratchet-detect`, `strace`).
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `id` | str | | Observation identifier (used as `#id` in selectors) |
+| `source` | str | | Observer tool that produced this entry |
+
+| Property | Type | Comparison | Description |
+|---|---|---|---|
+| `enabled` | bool | exact | Whether this observation source is active |
+
+**Selector examples:**
+```css
+@audit {
+  observation#coach    { source: "kibitzer"; enabled: true; }
+  observation#ratchet  { source: "ratchet-detect"; enabled: true; }
+}
+```
+
+---
+
+### `manifest` — the workspace manifest
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `id` | str | | Manifest identifier |
+| `path` | str | | Path to the manifest file |
+
+**Selector examples:**
+```css
+@audit {
+  manifest#current { path: ".umwelt/manifest.json"; }
+}
+```
+
+---
+
 ## world taxon
 
 **What it models:** the actor's coupled world — filesystem, mounts, network, environment, resources.
 **Ma concept:** world coupling axis.
+
+**World-axis vs action-axis:** Properties like `editable`, `visible`, and `allow` on world entities (`file`, `dir`, `network`, `tool`) are **world-axis** — they express a property of the resource itself (e.g. a read-only mount, a denied network endpoint). These are distinct from the same-named properties on `use` entities, which are **action-axis** — they express what a specific delegate's access path permits. OS-altitude compilers (nsjail, bwrap) read world-axis properties; language-altitude compilers (lackpy, kibitzer) read action-axis properties. A full enforcement decision conjoins both. See the `use` entity (under the capability/operation taxon) and `docs/vision/notes/vsm-alignment.md`.
 
 ### `world` — named environment (root)
 
@@ -277,6 +369,48 @@ kit[name="python-dev"] { allow: true; }
 
 ---
 
+### `use` — action-axis permission (v0.5+)
+
+A permissioned projection of a world resource onto a specific delegate. `use[of=...]` is the **action-axis** counterpart to world-axis resource properties — it expresses what permissions a delegate holds on a resource through a particular access path.
+
+The `of=` attribute takes a selector string pointing into the world axis. `use` entities do not appear in the world hierarchy; they cross-link operation-axis with world-axis.
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `of` | str | | Selector matching the target world entity (e.g. `"file#/src/auth.py"`) |
+| `of-kind` | str | | Kind-scoped: matches all uses of resources of this type (e.g. `"file"`, `"network"`) |
+| `of-like` | str | | Prefix-like match against a world entity selector |
+
+| Property | Type | Comparison | Description |
+|---|---|---|---|
+| `editable` | bool | exact | Whether the delegate's access path grants edit rights |
+| `visible` | bool | exact | Whether the delegate's access path reveals the resource |
+| `show` | str | exact | What the delegate sees through this access: `body`, `outline`, `signature` |
+| `allow` | bool | exact | Whether the delegate can invoke this capability through this access |
+| `deny` | str | exact | Deny pattern for invocations through this access |
+| `allow-pattern` | list | `pattern-in` | Glob patterns for invocations permitted through this access |
+| `deny-pattern` | list | `pattern-in` | Glob patterns for invocations denied through this access |
+
+**Selector examples:**
+```css
+/* default deny-edit on all uses */
+use { editable: false; }
+
+/* grant edit on all Python source files in implement mode */
+mode.implement use[of-like="file#/src"] { editable: true; }
+
+/* specific use in a specific context */
+inferencer#opus tool[name="Edit"] use[of="file#/src/auth.py"] { editable: true; }
+
+/* tool-level gating via use */
+use[of-kind="network"] { allow: false; }
+use[of="exec#bash"] { allow: true; allow-pattern: "git *", "pytest *"; }
+```
+
+**Relationship to world-axis properties:** `use.editable` and `file.editable` are independent. A write succeeds only when both allow it: the resource must be editable (world-axis) AND the delegate must hold an editable use (action-axis). This matches the OS-level distinction between a read-only mount (world-axis) and a user's file-permission bits (action-axis).
+
+---
+
 ## state taxon
 
 **What it models:** what the Harness tracks across turns — hooks, jobs, budgets.
@@ -396,10 +530,10 @@ These entity types are documented in the [entity model spec](../vision/entity-mo
 | Entity | Taxon | When | Description |
 |---|---|---|---|
 | `node` | world | v1.1 | Code construct inside a file (function, class, method). Evaluated via pluckit/sitting_duck. |
-| `effect` | capability | v1.1 | Effect signature declared by a tool: read, write, exec, spawn. |
-| `observation` | state | v1.1 | Something a Layer-2 observer reported. |
-| `manifest` | state | v1.1 | The workspace manifest. |
+| `effect` | operation | v1.1 | Effect signature declared by a tool: read, write, exec, spawn. |
 | `source` | world (proposed) | v1.1+ | Logical file grouping for monorepos. See [design notes](../vision/notes/world-as-root-and-linker-role.md). |
+
+*Note: `observation` and `manifest` moved from this table to the `audit` taxon section above — they are registered in v0.5.*
 
 ---
 
@@ -422,7 +556,14 @@ Properties with prefixed names carry built-in comparison semantics:
 ## The hierarchy
 
 ```
-world#env-name                        ← root (named environment)
+@audit {                               ← audit taxon (S3* — outside world)
+  observation#coach                    ← observation entries
+  manifest#current
+}
+
+principal#Teague                       ← principal taxon (S5)
+
+world#env-name                        ← world taxon (S0 — root of environment)
 ├── mount[path="/workspace/src"]      ← workspace topology
 │   ├── dir[name="src"]
 │   │   ├── dir[name="auth"]
@@ -437,18 +578,20 @@ world#env-name                        ← root (named environment)
 ├── resource[kind="wall-time"]
 ├── network                           ← network access
 ├── env[name="CI"]                    ← env vars
-└── exec[name="bash"]                 ← executable binaries (v0.3)
+└── exec[name="bash"]                 ← executable binaries
 
-tool[name="Read"]                     ← capability taxon (flat, not nested)
+tool[name="Read"]                     ← operation taxon / capability (S1 — flat, not nested)
 tool[name="Edit"]
 tool[name="Bash"]
 kit[name="python-dev"]
+use[of="file#/src/auth.py"]           ← action-axis cross-link (operation taxon)
 
-hook[event="after-change"]            ← state taxon
-job[id="run-1"]
+hook[event="after-change"]            ← coordination taxon / state (S2)
+
+job[id="run-1"]                       ← control taxon / state (S3)
 budget[kind="wall-time"]
 
-inferencer[model="claude-sonnet-4-6"]  ← actor taxon (minimal v1)
+inferencer[model="claude-sonnet-4-6"]  ← intelligence taxon / actor (S4)
 ```
 
-Navigate with CSS descendant selectors. Cross-taxon compound selectors (e.g. `world#dev tool[name="Bash"]`) are context qualifiers, not structural descent.
+Navigate with CSS descendant selectors. Cross-taxon compound selectors (e.g. `world#dev tool[name="Bash"]`) are context qualifiers, not structural descent. VSM alias names (`operation`, `coordination`, `control`, `intelligence`) are interchangeable with the legacy names (`capability`, `state`, `actor`).

--- a/docs/superpowers/plans/2026-04-14-umwelt-v05.md
+++ b/docs/superpowers/plans/2026-04-14-umwelt-v05.md
@@ -1,0 +1,1957 @@
+# umwelt v0.5 Implementation Plan — VSM-Aligned DOM Restructure
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the VSM-aligned taxa (principal/world/audit/control/coordination/intelligence/operation), introduce `use[of=...]` as the action-axis permission primitive, and add cross-axis cascade specificity — while preserving byte-identical compiler output for every v0.4 fixture via a legacy-shim that synthesizes `use` rules from old-form declarations.
+
+**Architecture:** Additive migration, not a rename. New taxa register as aliases alongside existing ones. `use` enters as a new entity type with an `of=` attribute whose value is a nested selector matched against world entities. A desugar pass synthesizes `use` rules from `file { editable: true; }`-style legacy forms so the new shape is present in every parsed view. Compilers in v0.5 continue reading the legacy path; v0.6+ migrates them to read `use` exclusively and eventually removes the shim.
+
+**Tech Stack:** Python 3.10+, existing umwelt infrastructure (tinycss2 parser, plugin registry, selector engine, cascade resolver). No new dependencies.
+
+**Prerequisite:** v0.4.0 tagged. 484 tests passing. nsjail + bwrap + lackpy-namespace compilers shipping.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md`.
+
+---
+
+## File structure
+
+```
+src/umwelt/registry/taxa.py                          # MODIFY — add aliases
+src/umwelt/sandbox/vocabulary.py                     # MODIFY — register new taxa + entities
+src/umwelt/sandbox/entities.py                       # MODIFY — add UseEntity, PrincipalEntity, ObservationEntity, ManifestEntity, ModeEntity
+src/umwelt/sandbox/use_matcher.py                    # CREATE — matcher for use[of=...]
+src/umwelt/sandbox/principal_matcher.py              # CREATE — matcher for principal entities
+src/umwelt/sandbox/audit_matcher.py                  # CREATE — matcher for audit entities
+src/umwelt/sandbox/control_matcher.py                # CREATE — matcher for mode/budget/job
+src/umwelt/sandbox/desugar.py                        # MODIFY — add use-synthesis shim
+src/umwelt/parser.py                                 # MODIFY — parse @audit { ... } at-rule
+src/umwelt/ast.py                                    # MODIFY — AuditBlock AST node
+src/umwelt/selector/specificity.py                   # MODIFY — axis_count-first specificity
+src/umwelt/selector/parse.py                         # MODIFY — parse of= attribute as selector-valued
+src/umwelt/cascade/resolver.py                       # MODIFY — specificity comparator
+
+tests/registry/test_taxon_aliases.py                 # CREATE
+tests/sandbox/test_use_entity.py                     # CREATE
+tests/sandbox/test_use_matcher.py                    # CREATE
+tests/sandbox/test_desugar_use.py                    # CREATE
+tests/sandbox/test_principal.py                      # CREATE
+tests/sandbox/test_audit.py                          # CREATE (may extend existing tests/test_audit.py — it's about the audit CLI, this one is about the audit taxon)
+tests/cascade/test_cross_axis_specificity.py         # CREATE
+tests/sandbox/test_v04_byte_compat.py                # CREATE — snapshot tests proving compiler output unchanged
+
+docs/vision/notes/vsm-alignment.md                   # CREATE
+docs/guide/entity-reference.md                       # MODIFY
+docs/vision/entity-model.md                          # MODIFY — keep prior version as entity-model-v04.md
+CHANGELOG.md                                         # MODIFY
+src/umwelt/__init__.py                               # MODIFY — bump version
+pyproject.toml                                       # MODIFY — bump version
+```
+
+---
+
+## Task breakdown
+
+**14 tasks across 5 slices:**
+
+**Slice A — Taxa aliases**
+- Task 0: Registry taxon-alias support
+- Task 1: Register VSM taxa as aliases of existing taxa
+
+**Slice B — `use` entity**
+- Task 2: Register `use` entity + permission properties
+- Task 3: Parse `of=` attribute as selector-valued
+- Task 4: Implement UseMatcher (of-kind, of-like, exact of)
+- Task 5: Desugar — synthesize `use` rules from legacy forms
+- Task 6: Snapshot tests — v0.4 fixtures still produce byte-identical compiler output
+
+**Slice C — Cross-axis cascade specificity**
+- Task 7: Extend Specificity with axis_count and per-axis counts
+- Task 8: Cross-axis ordering tests
+
+**Slice D — Principal + audit taxa**
+- Task 9: Register `principal` taxon + entity + matcher
+- Task 10: Register `audit` taxon, parse `@audit { ... }` at-rule, audit entities
+
+**Slice E — Docs + release**
+- Task 11: Write `docs/vision/notes/vsm-alignment.md`
+- Task 12: Regenerate `docs/guide/entity-reference.md`
+- Task 13: CHANGELOG, version bump, tag v0.5.0
+
+Slices A, B, C can be parallelized. D depends on A. E depends on all.
+
+---
+
+## Slice A — Taxa aliases
+
+### Task 0: Registry taxon-alias support
+
+**Files:**
+- Modify: `src/umwelt/registry/taxa.py`
+- Create: `tests/registry/test_taxon_aliases.py`
+
+Add a taxon-alias mechanism so multiple names resolve to the same TaxonSchema. Needed because we're adding new VSM taxa names (`operation`, `coordination`, `control`, `intelligence`) that refer to the same entity groupings as existing `capability`/`state`/`actor` taxa.
+
+- [ ] **Step 1: Read the current `src/umwelt/registry/taxa.py` to find where `register_taxon` and `get_taxon` live.**
+
+Run: `cat src/umwelt/registry/taxa.py`
+Expected: file contains `register_taxon`, `get_taxon`, `list_taxa`, and a `RegistryState` that stores taxa in a dict.
+
+- [ ] **Step 2: Write the failing test.**
+
+Create `tests/registry/test_taxon_aliases.py`:
+
+```python
+"""Tests for taxon aliasing — multiple names pointing to the same TaxonSchema."""
+from __future__ import annotations
+
+import pytest
+from umwelt.registry import (
+    get_taxon,
+    register_taxon,
+    registry_scope,
+)
+from umwelt.registry.taxa import register_taxon_alias
+
+
+def test_alias_resolves_to_same_schema():
+    with registry_scope():
+        register_taxon(name="state", description="observation layer")
+        register_taxon_alias(alias="coordination", canonical="state")
+        state = get_taxon("state")
+        coordination = get_taxon("coordination")
+        assert state is coordination
+
+
+def test_alias_for_unknown_canonical_raises():
+    with registry_scope():
+        with pytest.raises(KeyError):
+            register_taxon_alias(alias="coordination", canonical="state")
+
+
+def test_alias_collides_with_existing_taxon_raises():
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon(name="coordination", description="")
+        with pytest.raises(ValueError):
+            register_taxon_alias(alias="coordination", canonical="state")
+
+
+def test_list_taxa_includes_aliases():
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon_alias(alias="coordination", canonical="state")
+        from umwelt.registry import list_taxa
+        names = {t.name for t in list_taxa()}
+        # Implementation choice: aliases appear in list_taxa with their own
+        # name but the same underlying schema. Either is fine as long as
+        # get_taxon works for both names.
+        assert "state" in names
+```
+
+- [ ] **Step 3: Run to verify it fails.**
+
+Run: `python3 -m pytest tests/registry/test_taxon_aliases.py -v`
+Expected: ImportError on `register_taxon_alias`.
+
+- [ ] **Step 4: Implement `register_taxon_alias` in `src/umwelt/registry/taxa.py`.**
+
+Add this function after `register_taxon`:
+
+```python
+def register_taxon_alias(alias: str, canonical: str) -> None:
+    """Register `alias` as another name for an existing `canonical` taxon.
+
+    After registration, get_taxon(alias) returns the same TaxonSchema as
+    get_taxon(canonical). Both names may be used interchangeably in
+    register_entity(taxon=...) and view.entries(...) calls.
+
+    Raises:
+        KeyError: if `canonical` has not been registered.
+        ValueError: if `alias` is already a registered taxon or alias.
+    """
+    state = _current_state()
+    if canonical not in state.taxa:
+        raise KeyError(f"canonical taxon '{canonical}' not registered")
+    if alias in state.taxa:
+        raise ValueError(f"taxon '{alias}' already exists (cannot alias)")
+    state.taxa[alias] = state.taxa[canonical]
+```
+
+Also make sure `register_entity(taxon=...)` writes the entity under both the alias and the canonical taxon key in `state.entities`. Locate the entity-registration code (likely in `src/umwelt/registry/entities.py`) and check. If entity lookup goes through `state.entities[taxon]` directly, add this sentence to `register_taxon_alias` after setting `state.taxa[alias]`:
+
+```python
+    # Entity lookups route through state.taxa, so registering an entity under the
+    # canonical taxon is automatically found when the alias is used. But if the
+    # entities-by-taxon index is keyed by taxon-name-string, we also need:
+    state.entities.setdefault(alias, state.entities.setdefault(canonical, {}))
+    # Shared reference — adding to one adds to the other. Python dicts are not
+    # aliased by setdefault, so use:
+    if canonical in state.entities:
+        state.entities[alias] = state.entities[canonical]  # same dict reference
+```
+
+If the registry code is structured differently than this sketch, adapt — the invariant to maintain is: `get_entity(taxon=alias, name=...) == get_entity(taxon=canonical, name=...)`.
+
+- [ ] **Step 5: Run to verify tests pass.**
+
+Run: `python3 -m pytest tests/registry/test_taxon_aliases.py -v`
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Run the full suite to confirm no regressions.**
+
+Run: `python3 -m pytest -q`
+Expected: 484 tests pass + 4 new = 488 passing.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/umwelt/registry/taxa.py tests/registry/test_taxon_aliases.py
+git commit -m "feat(registry): taxon-alias support for VSM restructure"
+```
+
+---
+
+### Task 1: Register VSM taxa as aliases of existing taxa
+
+**Files:**
+- Modify: `src/umwelt/sandbox/vocabulary.py`
+- Create: `tests/sandbox/test_vsm_taxa.py`
+
+Register the new VSM taxon names as aliases for the existing taxa. This makes the new names available without breaking anything:
+- `operation` aliases `capability`
+- `coordination` aliases `state` (for hook)
+- `control` aliases `state` (for budget, job)
+- `intelligence` aliases `actor` (for inferencer)
+- (`principal` and `audit` are new taxa, not aliases — handled in Task 9 / 10)
+
+Because `state` is split across coordination and control in the spec, both new names alias the same underlying taxon in v0.5. The split happens in v0.6+ when the legacy-shim is turned off. This is documented in the registration comment.
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `tests/sandbox/test_vsm_taxa.py`:
+
+```python
+"""Tests that VSM taxa are registered as aliases of legacy taxa."""
+from __future__ import annotations
+
+from umwelt.registry import get_taxon
+
+
+def test_operation_aliases_capability():
+    assert get_taxon("operation") is get_taxon("capability")
+
+
+def test_coordination_aliases_state():
+    assert get_taxon("coordination") is get_taxon("state")
+
+
+def test_control_aliases_state():
+    assert get_taxon("control") is get_taxon("state")
+
+
+def test_intelligence_aliases_actor():
+    assert get_taxon("intelligence") is get_taxon("actor")
+
+
+def test_tool_entity_findable_under_operation():
+    from umwelt.registry import get_entity
+    tool_via_capability = get_entity(taxon="capability", name="tool")
+    tool_via_operation = get_entity(taxon="operation", name="tool")
+    assert tool_via_capability is tool_via_operation
+
+
+def test_hook_entity_findable_under_coordination():
+    from umwelt.registry import get_entity
+    hook_via_state = get_entity(taxon="state", name="hook")
+    hook_via_coordination = get_entity(taxon="coordination", name="hook")
+    assert hook_via_state is hook_via_coordination
+
+
+def test_inferencer_findable_under_intelligence():
+    from umwelt.registry import get_entity
+    inf_via_actor = get_entity(taxon="actor", name="inferencer")
+    inf_via_intelligence = get_entity(taxon="intelligence", name="inferencer")
+    assert inf_via_actor is inf_via_intelligence
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+Run: `python3 -m pytest tests/sandbox/test_vsm_taxa.py -v`
+Expected: `get_taxon` returns different objects (or KeyError for unregistered "operation" etc.).
+
+- [ ] **Step 3: Register the aliases in `src/umwelt/sandbox/vocabulary.py`.**
+
+At the end of `register_sandbox_vocabulary()`, before `_register_sugar()`:
+
+```python
+def register_sandbox_vocabulary() -> None:
+    """Register all sandbox taxa, entities, and properties, and sugar transformers."""
+    _register_world()
+    _register_capability()
+    _register_state()
+    _register_actor()
+    _register_vsm_aliases()       # NEW: VSM taxa aliases
+    _register_validators()
+    _register_sugar()
+
+
+def _register_vsm_aliases() -> None:
+    """Register VSM taxon names as aliases of legacy taxa.
+
+    v0.5: operation/coordination/control/intelligence point at the same
+    underlying taxa as capability/state/actor. The spec's logical split of
+    `state` into `coordination` and `control` is virtual in v0.5 — both
+    names resolve to the same bucket. The physical split happens in v0.6+
+    when the legacy-shim is retired.
+
+    `principal` and `audit` are genuinely new taxa and are registered
+    directly (Task 9 and Task 10), not as aliases.
+    """
+    from umwelt.registry.taxa import register_taxon_alias
+    register_taxon_alias(alias="operation", canonical="capability")
+    register_taxon_alias(alias="coordination", canonical="state")
+    register_taxon_alias(alias="control", canonical="state")
+    register_taxon_alias(alias="intelligence", canonical="actor")
+```
+
+- [ ] **Step 4: Run tests.**
+
+Run: `python3 -m pytest tests/sandbox/test_vsm_taxa.py tests/registry/test_taxon_aliases.py -v`
+Expected: all pass.
+
+- [ ] **Step 5: Run full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: 488 + 7 new = 495 passing.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/umwelt/sandbox/vocabulary.py tests/sandbox/test_vsm_taxa.py
+git commit -m "feat(sandbox): register VSM taxa as aliases (operation/coordination/control/intelligence)"
+```
+
+---
+
+## Slice B — `use` entity
+
+### Task 2: Register `use` entity + permission properties
+
+**Files:**
+- Modify: `src/umwelt/sandbox/entities.py` (add `UseEntity` dataclass)
+- Modify: `src/umwelt/sandbox/vocabulary.py` (register `use` entity)
+- Create: `tests/sandbox/test_use_entity.py`
+
+`use` is a new entity type under an operation-axis-adjacent link. For v0.5 it registers under the `operation` taxon (since its permissions gate what operations can do with resources). The attribute `of=` is selector-valued and parsed as a nested selector.
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `tests/sandbox/test_use_entity.py`:
+
+```python
+"""Tests that use[of=...] registers as a first-class entity."""
+from __future__ import annotations
+
+from umwelt.registry import get_entity, get_property
+
+
+def test_use_entity_registered():
+    entity = get_entity(taxon="operation", name="use")
+    assert entity is not None
+    assert "of" in entity.attributes
+    assert "of-kind" in entity.attributes
+    assert "of-like" in entity.attributes
+
+
+def test_use_editable_property_registered():
+    prop = get_property(taxon="operation", entity="use", name="editable")
+    assert prop is not None
+    assert prop.value_type is bool
+
+
+def test_use_visible_property_registered():
+    prop = get_property(taxon="operation", entity="use", name="visible")
+    assert prop.value_type is bool
+
+
+def test_use_show_property_registered():
+    prop = get_property(taxon="operation", entity="use", name="show")
+    assert prop.value_type is str
+
+
+def test_use_allow_property_registered():
+    prop = get_property(taxon="operation", entity="use", name="allow")
+    assert prop.value_type is bool
+
+
+def test_use_deny_property_registered():
+    prop = get_property(taxon="operation", entity="use", name="deny")
+    assert prop.value_type is str
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `python3 -m pytest tests/sandbox/test_use_entity.py -v`
+Expected: `get_entity` returns None for `use`.
+
+- [ ] **Step 3: Add `UseEntity` dataclass to `src/umwelt/sandbox/entities.py`.**
+
+Append:
+
+```python
+@dataclass(frozen=True)
+class UseEntity:
+    """A permissioned projection of a world entity into the action axis.
+
+    `of` is the target world entity selector, stored as the raw string
+    (e.g. 'file#/src/auth.py'). `of_kind` and `of_like` are lower-priority
+    kind/prefix forms captured from of-kind= / of-like= attributes.
+
+    Permissions (editable, visible, allow, deny, show) land on use
+    entities during cascade resolution, not on the world entities
+    themselves.
+    """
+
+    of: str | None = None
+    of_kind: str | None = None
+    of_like: str | None = None
+```
+
+- [ ] **Step 4: Register the `use` entity in `src/umwelt/sandbox/vocabulary.py`.**
+
+Add a new `_register_use()` function and call it from `register_sandbox_vocabulary` after `_register_vsm_aliases()`:
+
+```python
+def register_sandbox_vocabulary() -> None:
+    _register_world()
+    _register_capability()
+    _register_state()
+    _register_actor()
+    _register_vsm_aliases()
+    _register_use()               # NEW
+    _register_validators()
+    _register_sugar()
+
+
+def _register_use() -> None:
+    """Register the `use` entity — permissioned projection of world resources."""
+    register_entity(
+        taxon="operation",
+        name="use",
+        attributes={
+            "of": AttrSchema(
+                type=str,
+                description="Selector pointing at the world entity (e.g. 'file#/src/auth.py').",
+            ),
+            "of-kind": AttrSchema(
+                type=str,
+                description="Match all uses whose target is of a given kind (e.g. 'file', 'network').",
+            ),
+            "of-like": AttrSchema(
+                type=str,
+                description="Prefix-like match against target paths (e.g. 'file#/src').",
+            ),
+        },
+        description=(
+            "A permissioned projection of a world entity into the action axis. "
+            "Permissions (editable, visible, allow, deny) live on uses, not on "
+            "world entities themselves."
+        ),
+        category="access",
+    )
+
+    register_property(taxon="operation", entity="use", name="editable", value_type=bool,
+                     description="Whether this use grants edit access.")
+    register_property(taxon="operation", entity="use", name="visible", value_type=bool,
+                     description="Whether this use grants visibility.")
+    register_property(taxon="operation", entity="use", name="show", value_type=str,
+                     description="Projection kind: body, outline, signature.")
+    register_property(taxon="operation", entity="use", name="allow", value_type=bool,
+                     description="Whether this use is permitted.")
+    register_property(taxon="operation", entity="use", name="deny", value_type=str,
+                     description="Deny pattern ('*' for blanket deny).")
+    register_property(taxon="operation", entity="use", name="allow-pattern", value_type=list,
+                     comparison="pattern-in",
+                     description="Glob patterns for allowed invocations of this use.")
+    register_property(taxon="operation", entity="use", name="deny-pattern", value_type=list,
+                     comparison="pattern-in",
+                     description="Glob patterns for denied invocations of this use.")
+```
+
+- [ ] **Step 5: Run tests.**
+
+Run: `python3 -m pytest tests/sandbox/test_use_entity.py -v`
+Expected: all 6 pass.
+
+- [ ] **Step 6: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: 495 + 6 = 501 passing.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/umwelt/sandbox/entities.py src/umwelt/sandbox/vocabulary.py tests/sandbox/test_use_entity.py
+git commit -m "feat(sandbox): register use[of=...] entity with permission properties"
+```
+
+---
+
+### Task 3: Parse `of=` attribute as a selector-valued string
+
+**Files:**
+- Modify: `src/umwelt/selector/parse.py`
+- Create: `tests/core/test_of_attr_parse.py`
+
+Currently all attribute values are stored as strings. `of="file#/src/auth.py"` is stored as the string `"file#/src/auth.py"` — no special handling needed at parse time. But the UseMatcher (Task 4) will re-enter the selector parser on this string, so we need to verify the parser handles CSS-ID-in-attribute-value correctly — the path `/src/auth.py` contains `/` characters which have no special meaning inside an attribute string, and `#` is fine too. Add a test to lock this in.
+
+- [ ] **Step 1: Write the failing test (may already pass — we're locking in behavior).**
+
+Create `tests/core/test_of_attr_parse.py`:
+
+```python
+"""Tests that the selector parser accepts complex of= attribute values."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+
+
+def test_of_attr_with_slash_and_hash():
+    view = parse_view('use[of="file#/src/auth.py"] { editable: true; }')
+    assert len(view.rules) == 1
+    rule = view.rules[0]
+    assert len(rule.selectors) == 1
+    sel = rule.selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    of_attr = next((a for a in attrs if a.name == "of"), None)
+    assert of_attr is not None
+    assert of_attr.value == "file#/src/auth.py"
+
+
+def test_of_kind_attr():
+    view = parse_view('use[of-kind="file"] { editable: false; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    ok = next((a for a in attrs if a.name == "of-kind"), None)
+    assert ok is not None
+    assert ok.value == "file"
+
+
+def test_of_like_attr():
+    view = parse_view('use[of-like="file#/src"] { editable: true; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    ol = next((a for a in attrs if a.name == "of-like"), None)
+    assert ol is not None
+    assert ol.value == "file#/src"
+
+
+def test_of_attr_with_glob_pseudo():
+    view = parse_view('use[of="file:glob(\'src/**/*.py\')"] { editable: true; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    of_attr = next((a for a in attrs if a.name == "of"), None)
+    assert of_attr is not None
+    # The parser preserves the whole pseudo-class inside the attribute value.
+    assert "glob" in of_attr.value
+```
+
+- [ ] **Step 2: Run the tests.**
+
+Run: `python3 -m pytest tests/core/test_of_attr_parse.py -v`
+Expected: either all pass (parser already handles this) or one/more fail with parse error.
+
+- [ ] **Step 3: If any tests fail, fix `src/umwelt/selector/parse.py`.**
+
+Likely issue: the attribute-value tokenizer strips `#` from quoted values, or splits on `/`. The fix is to capture the whole quoted-string as a single value token. Check the `_parse_attr_filter` (or equivalent) function. If needed, change the value-capture to accept any character inside quotes.
+
+If all tests pass as-is, no change is needed.
+
+- [ ] **Step 4: Run the full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: 501 + 4 new = 505 passing.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add tests/core/test_of_attr_parse.py src/umwelt/selector/parse.py 2>/dev/null || git add tests/core/test_of_attr_parse.py
+git commit -m "test(parser): lock in of= attribute value parsing for use selectors"
+```
+
+---
+
+### Task 4: Implement UseMatcher
+
+**Files:**
+- Create: `src/umwelt/sandbox/use_matcher.py`
+- Modify: `src/umwelt/sandbox/vocabulary.py` (register matcher)
+- Create: `tests/sandbox/test_use_matcher.py`
+
+The UseMatcher yields synthesized `UseEntity` values for each rule containing a `use[...]` selector. Because `use` entities are synthesized from rules (not from world scanning), the matcher's job is to enumerate the selectors in the view that target `use` and emit matching `UseEntity` instances.
+
+For v0.5, the matcher emits one synthesized `UseEntity` per unique `(of, of_kind, of_like)` triple found in parsed selectors. The cascade resolver then picks winning properties per entity. This is simpler than cross-referencing world entities; the cascade machinery handles attribute matching.
+
+Approach: MatcherProtocol.candidates() walks the view's rules, collects all `use[...]` selectors, and yields one UseEntity per unique (of, of_kind, of_like) combination. match() then delegates to CSS attribute matching.
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `tests/sandbox/test_use_matcher.py`:
+
+```python
+"""Tests for UseMatcher — synthesizes UseEntity instances from parsed rules."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+from umwelt.cascade.resolver import resolve
+from umwelt.sandbox.entities import UseEntity
+
+
+def test_use_with_of_exact():
+    view = parse_view('''
+        use[of="file#/src/auth.py"] { editable: true; }
+    ''')
+    rv = resolve(view)
+    entries = list(rv.entries("operation"))
+    uses = [(e, p) for e, p in entries if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    entity, props = uses[0]
+    assert entity.of == "file#/src/auth.py"
+    assert props.get("editable") == "true"
+
+
+def test_use_with_of_kind():
+    view = parse_view('''
+        use[of-kind="file"] { visible: true; }
+    ''')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    entity, props = uses[0]
+    assert entity.of_kind == "file"
+    assert props.get("visible") == "true"
+
+
+def test_use_with_of_like():
+    view = parse_view('''
+        use[of-like="file#/src"] { editable: true; }
+    ''')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    assert uses[0][0].of_like == "file#/src"
+
+
+def test_multiple_distinct_uses():
+    view = parse_view('''
+        use[of="file#/a.py"] { editable: true; }
+        use[of="file#/b.py"] { editable: false; }
+    ''')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 2
+    of_values = {e.of for e, _ in uses}
+    assert of_values == {"file#/a.py", "file#/b.py"}
+
+
+def test_use_permissions_cascade():
+    view = parse_view('''
+        use { editable: false; }
+        use[of="file#/src/auth.py"] { editable: true; }
+    ''')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    # One bare use entity (bare rule) plus one specific.
+    # The specific one has editable=true; the bare one has editable=false.
+    # Cascade: bare use matches everything; specific use matches only the specific entity.
+    # We expect at least the entity with of="file#/src/auth.py" to have editable=true.
+    specific = [p for e, p in uses if e.of == "file#/src/auth.py"]
+    assert any(p.get("editable") == "true" for p in specific)
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `python3 -m pytest tests/sandbox/test_use_matcher.py -v`
+Expected: all fail — no UseMatcher registered yet.
+
+- [ ] **Step 3: Implement `src/umwelt/sandbox/use_matcher.py`.**
+
+```python
+"""Matcher for use[of=...] — synthesizes UseEntity instances from parsed rules.
+
+Unlike world-entity matchers that enumerate the filesystem, the UseMatcher
+scans the view's rule list for `use[...]` selectors and yields one
+UseEntity per unique (of, of_kind, of_like) combination. The cascade
+resolver then evaluates each rule against those entities via standard
+CSS-attribute matching.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from umwelt.ast import ComplexSelector, SimpleSelector, View
+from umwelt.registry import MatcherProtocol
+from umwelt.sandbox.entities import UseEntity
+
+
+class UseMatcher(MatcherProtocol):
+    entity_name: str = "use"
+    taxon: str = "operation"
+
+    def candidates(self, view: View, eval_context: Any = None) -> Iterable[UseEntity]:
+        """Enumerate unique UseEntity instances referenced by any use[...] selector."""
+        seen: set[tuple[str | None, str | None, str | None]] = set()
+        for rule in view.rules:
+            for sel in rule.selectors:
+                use_simple = self._find_use_simple(sel)
+                if use_simple is None:
+                    continue
+                of = _attr_value(use_simple, "of")
+                of_kind = _attr_value(use_simple, "of-kind")
+                of_like = _attr_value(use_simple, "of-like")
+                key = (of, of_kind, of_like)
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield UseEntity(of=of, of_kind=of_kind, of_like=of_like)
+        # Always emit a bare UseEntity so rules like `use { ... }` match.
+        bare_key = (None, None, None)
+        if bare_key not in seen:
+            yield UseEntity()
+
+    def matches(self, entity: Any, simple: SimpleSelector) -> bool:
+        """Return True if `entity` (a UseEntity) matches the simple selector."""
+        if not isinstance(entity, UseEntity):
+            return False
+        if simple.type_name not in ("use", None, "*"):
+            return False
+        for attr in simple.attributes:
+            value = _entity_attr(entity, attr.name)
+            if attr.value is None:
+                # [attr] presence check.
+                if value is None:
+                    return False
+                continue
+            if attr.op in (None, "="):
+                if value != attr.value:
+                    return False
+            elif attr.op == "^=":
+                if value is None or not value.startswith(attr.value):
+                    return False
+            elif attr.op == "$=":
+                if value is None or not value.endswith(attr.value):
+                    return False
+            elif attr.op == "*=":
+                if value is None or attr.value not in value:
+                    return False
+            else:
+                # Unsupported op — fail closed.
+                return False
+        return True
+
+    def _find_use_simple(self, sel: ComplexSelector) -> SimpleSelector | None:
+        for part in sel.parts:
+            if part.selector.type_name == "use":
+                return part.selector
+        return None
+
+
+def _attr_value(simple: SimpleSelector, name: str) -> str | None:
+    for a in simple.attributes:
+        if a.name == name:
+            return a.value
+    return None
+
+
+def _entity_attr(entity: UseEntity, name: str) -> str | None:
+    if name == "of":
+        return entity.of
+    if name == "of-kind":
+        return entity.of_kind
+    if name == "of-like":
+        return entity.of_like
+    return None
+```
+
+- [ ] **Step 4: Register the matcher in `src/umwelt/sandbox/vocabulary.py`.**
+
+In `_register_use()`, after the properties, add:
+
+```python
+    from umwelt.registry import register_matcher
+    from umwelt.sandbox.use_matcher import UseMatcher
+    register_matcher(taxon="operation", entity="use", matcher=UseMatcher())
+```
+
+- [ ] **Step 5: Verify match_complex and the resolver consume this matcher.**
+
+Check `src/umwelt/selector/match.py` (match_complex) — it should invoke matchers registered via `register_matcher` for each simple selector. Trace: cascade resolver calls `match_complex(selector, eval_context)`, which enumerates candidates from each registered matcher and filters via `matches()`. If the current architecture only evaluates matchers for entities found through `eval_context` (i.e., workspace-based), then synthesized matchers need a different hook.
+
+If needed: extend match.py so matchers can contribute synthesized candidates that don't come from eval_context. A minimal approach: add a new method `MatcherProtocol.candidates(view, eval_context)` that yields entities; match_complex collects candidates from all matchers whose taxon matches the rightmost simple-selector's taxon.
+
+Test: run `python3 -m pytest tests/sandbox/test_use_matcher.py -v`. If tests still fail on "no use entities found", inspect match.py integration.
+
+- [ ] **Step 6: Iterate on match.py as needed until tests pass.**
+
+Run: `python3 -m pytest tests/sandbox/test_use_matcher.py -v`
+Expected: all 5 pass.
+
+- [ ] **Step 7: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: 505 + 5 = 510 passing.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/umwelt/sandbox/use_matcher.py src/umwelt/sandbox/vocabulary.py \
+        tests/sandbox/test_use_matcher.py src/umwelt/selector/match.py 2>/dev/null || \
+git add src/umwelt/sandbox/use_matcher.py src/umwelt/sandbox/vocabulary.py tests/sandbox/test_use_matcher.py
+git commit -m "feat(sandbox): UseMatcher synthesizes UseEntity from parsed use[...] selectors"
+```
+
+---
+
+### Task 5: Legacy-shim — synthesize `use` rules from legacy forms
+
+**Files:**
+- Modify: `src/umwelt/sandbox/desugar.py`
+- Create: `tests/sandbox/test_desugar_use.py`
+
+The shim rewrites `file { editable: true; }` → `use[of="file#<path>"] { editable: true; }` at parse time so v0.4-shape views produce both the old `file` entries AND new `use` entries in the resolved view. This is what makes byte-identical compiler output possible in v0.5 and makes migration to use-reading compilers tractable for v0.6.
+
+The desugar runs post-parse; it adds synthetic rules to the View without removing the originals. Because we keep the originals, v0.5 compilers (which read file/tool/network directly) continue working unchanged. v0.6 compilers will ignore the originals and read only `use`.
+
+- [ ] **Step 1: Read the current desugar.py to understand the shim architecture.**
+
+Run: `cat src/umwelt/sandbox/desugar.py`
+Expected: existing desugar has transformation functions and a `register_sandbox_sugar()` registration point.
+
+- [ ] **Step 2: Write failing tests.**
+
+Create `tests/sandbox/test_desugar_use.py`:
+
+```python
+"""Tests for the legacy-shim — synthesizes use[of=...] from v0.4 forms."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+from umwelt.cascade.resolver import resolve
+from umwelt.sandbox.entities import FileEntity, UseEntity
+
+
+def test_file_editable_synthesizes_use():
+    view = parse_view('file[path="src/auth.py"] { editable: true; }')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    editable_uses = [(e, p) for e, p in uses if p.get("editable") == "true"]
+    # At least one use should carry editable=true for file#src/auth.py.
+    matching = [e for e, _ in editable_uses if e.of == "file#src/auth.py"]
+    assert matching
+
+
+def test_bare_tool_allow_synthesizes_use():
+    view = parse_view('tool[name="Bash"] { allow: true; }')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    allowing = [e for e, p in uses if p.get("allow") == "true" and e.of == "tool#Bash"]
+    assert allowing
+
+
+def test_network_deny_synthesizes_use():
+    view = parse_view('network { deny: "*"; }')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    denying = [e for e, p in uses if p.get("deny") == "*" and e.of_kind == "network"]
+    assert denying
+
+
+def test_originals_preserved_alongside_use():
+    """The shim adds use rules but does NOT remove originals."""
+    view = parse_view('file[path="src/auth.py"] { editable: true; }')
+    rv = resolve(view)
+    files = [(e, p) for e, p in rv.entries("world") if isinstance(e, FileEntity)]
+    assert files, "original file entry should still be present for v0.5 compilers"
+```
+
+- [ ] **Step 3: Run to verify failure.**
+
+Run: `python3 -m pytest tests/sandbox/test_desugar_use.py -v`
+Expected: tests fail — no `use` entries synthesized.
+
+- [ ] **Step 4: Implement the shim in `src/umwelt/sandbox/desugar.py`.**
+
+Add a function `_synthesize_use_rules_from_legacy(view: View) -> View` that walks `view.rules`, and for each rule whose rightmost simple-selector is `file`, `tool`, `network`, or `dir` and whose declarations include permission properties (editable/visible/allow/deny/show/allow-pattern/deny-pattern), creates an additional synthetic rule with the selector rewritten to `use[of-like=...]` or `use[of=...]` or `use[of-kind=...]` as appropriate, and with the same declarations. The synthetic rules are appended to `view.rules`.
+
+Concrete selector transformation:
+
+| Original rightmost selector | Synthetic `use` selector |
+|---|---|
+| `file[path="X"]` | `use[of="file#X"]` |
+| `file[path^="X"]` | `use[of-like="file#X"]` |
+| `file` (bare) | `use[of-kind="file"]` |
+| `tool[name="X"]` | `use[of="tool#X"]` |
+| `tool` (bare) | `use[of-kind="tool"]` |
+| `network[host="X"]` | `use[of="network#X"]` |
+| `network` (bare) | `use[of-kind="network"]` |
+| `dir[path="X"]` | `use[of="dir#X"]` |
+
+The synthetic rule keeps any leading parts of the compound selector (e.g., `world#dev` stays, `mode.test` stays). Only the rightmost simple-selector gets rewritten.
+
+Because the View AST is frozen, construct new SimpleSelector/CompoundPart/ComplexSelector/RuleBlock objects rather than mutating. Append to `view.rules` by constructing a new View:
+
+```python
+from umwelt.ast import (
+    AttrFilter,
+    ComplexSelector,
+    CompoundPart,
+    RuleBlock,
+    SimpleSelector,
+    View,
+)
+
+
+_LEGACY_PERMISSION_PROPS = frozenset([
+    "editable", "visible", "show",
+    "allow", "deny", "allow-pattern", "deny-pattern",
+])
+
+
+def _synthesize_use_rules_from_legacy(view: View) -> View:
+    """Append synthetic use[of=...] rules for every legacy permission rule."""
+    synthesized: list[RuleBlock] = []
+    for rule in view.rules:
+        if not _has_permission_declaration(rule):
+            continue
+        for sel in rule.selectors:
+            new_sel = _rewrite_to_use(sel)
+            if new_sel is None:
+                continue
+            synthesized.append(RuleBlock(
+                selectors=(new_sel,),
+                declarations=rule.declarations,
+                nested_blocks=(),
+                span=rule.span,
+            ))
+    if not synthesized:
+        return view
+    return View(
+        rules=view.rules + tuple(synthesized),
+        unknown_at_rules=view.unknown_at_rules,
+        warnings=view.warnings,
+        source_text=view.source_text,
+        source_path=view.source_path,
+    )
+
+
+def _has_permission_declaration(rule: RuleBlock) -> bool:
+    return any(d.property_name in _LEGACY_PERMISSION_PROPS for d in rule.declarations)
+
+
+def _rewrite_to_use(sel: ComplexSelector) -> ComplexSelector | None:
+    """Return a new ComplexSelector with rightmost part rewritten to use[of=...]."""
+    if not sel.parts:
+        return None
+    last = sel.parts[-1]
+    kind = last.selector.type_name
+    if kind not in ("file", "tool", "network", "dir"):
+        return None
+
+    # Figure out the of-form.
+    new_attrs = _derive_of_attributes(last.selector, kind)
+
+    new_simple = SimpleSelector(
+        type_name="use",
+        taxon="operation",
+        id_value=None,
+        classes=(),
+        attributes=new_attrs,
+        pseudo_classes=(),
+        span=last.selector.span,
+    )
+    new_last = CompoundPart(
+        selector=new_simple,
+        combinator=last.combinator,
+        mode=last.mode,
+    )
+    new_parts = sel.parts[:-1] + (new_last,)
+    from umwelt.selector.specificity import compound_specificity
+    # Re-use existing specificity computation; it will be upgraded in Slice C.
+    new_complex = ComplexSelector(
+        parts=new_parts,
+        target_taxon="operation",
+        specificity=compound_specificity_for_parts(new_parts),
+    )
+    return new_complex
+
+
+def compound_specificity_for_parts(parts):
+    from umwelt.ast import ComplexSelector
+    from umwelt.selector.specificity import compound_specificity
+    tmp = ComplexSelector(parts=parts, target_taxon="operation", specificity=(0, 0, 0))
+    return compound_specificity(tmp)
+
+
+def _derive_of_attributes(simple: SimpleSelector, kind: str) -> tuple[AttrFilter, ...]:
+    """Derive the of= / of-kind= / of-like= attribute filters for a legacy selector."""
+    # Check for an id-like filter.
+    if simple.id_value is not None:
+        return (AttrFilter(name="of", op="=", value=f"{kind}#{simple.id_value}"),)
+    # Check for path="X" or name="X" exact-match.
+    for a in simple.attributes:
+        if a.op == "=" and a.name in ("path", "name", "host"):
+            return (AttrFilter(name="of", op="=", value=f"{kind}#{a.value}"),)
+    # Check for prefix-like.
+    for a in simple.attributes:
+        if a.op == "^=" and a.name in ("path", "name"):
+            return (AttrFilter(name="of-like", op="=", value=f"{kind}#{a.value}"),)
+    # Fall through: bare selector → of-kind match.
+    return (AttrFilter(name="of-kind", op="=", value=kind),)
+```
+
+Now register this shim as a post-parse pass. Check how `register_sandbox_sugar` is invoked — if the parser calls registered sugar transformers automatically, add the new shim to that pipeline. If not, modify `parse_view` to call `_synthesize_use_rules_from_legacy` after other shims.
+
+- [ ] **Step 5: Run the desugar tests.**
+
+Run: `python3 -m pytest tests/sandbox/test_desugar_use.py -v`
+Expected: all 4 pass.
+
+- [ ] **Step 6: Full suite — watch for regressions.**
+
+Run: `python3 -m pytest -q`
+Expected: all ~515 tests pass. If any v0.4 tests fail, the shim is adding unwanted `use` entries that break those tests' assumptions (e.g., a test asserting "exactly one entry in `operation`" will now see extras). Check failures; in most cases the fix is to update the test to allow-and-ignore `use` entries. Only fix real bugs (not cosmetic test changes) if they indicate a genuine semantic regression.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/umwelt/sandbox/desugar.py tests/sandbox/test_desugar_use.py
+# Add any tests you had to update because of UseEntity appearing in operation entries:
+git add tests/...
+git commit -m "feat(desugar): synthesize use[of=...] rules from v0.4 legacy forms"
+```
+
+---
+
+### Task 6: Byte-compatibility snapshot tests
+
+**Files:**
+- Create: `tests/sandbox/test_v04_byte_compat.py`
+
+For every fixture in `src/umwelt/_fixtures/`, compile through each compiler and lock the current v0.5-post-shim output as the snapshot. This guards against accidental drift when later work modifies compilers to read `use` entries.
+
+- [ ] **Step 1: List fixtures.**
+
+Run: `ls src/umwelt/_fixtures/`
+
+- [ ] **Step 2: Write the snapshot test harness.**
+
+Create `tests/sandbox/test_v04_byte_compat.py`:
+
+```python
+"""Snapshot tests that compiler output remains byte-identical across v0.5 changes.
+
+Runs every fixture through every compiler, captures the output, and compares to
+a stored golden file. Golden files live under tests/sandbox/golden/v05/.
+
+To regenerate goldens after an intentional output change:
+    UMWELT_UPDATE_GOLDENS=1 python3 -m pytest tests/sandbox/test_v04_byte_compat.py
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from umwelt.parser import parse_view_file
+from umwelt.cascade.resolver import resolve
+from umwelt.sandbox.compilers.nsjail import NsjailCompiler
+from umwelt.sandbox.compilers.bwrap import BwrapCompiler
+from umwelt.sandbox.compilers.lackpy_namespace import LackpyNamespaceCompiler
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "src" / "umwelt" / "_fixtures"
+GOLDEN_DIR = Path(__file__).parent / "golden" / "v05"
+
+COMPILERS: list[tuple[str, object, str]] = [
+    ("nsjail", NsjailCompiler(), "textproto"),
+    ("bwrap", BwrapCompiler(), "argv"),
+    ("lackpy-namespace", LackpyNamespaceCompiler(), "dict"),
+]
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted(FIXTURE_DIR.glob("*.umw")),
+    ids=lambda p: p.name,
+)
+def test_fixture_compiles_identically(fixture: Path):
+    view = parse_view_file(fixture)
+    rv = resolve(view)
+    for target, compiler, fmt in COMPILERS:
+        output = compiler.compile(rv)
+        if fmt == "argv":
+            output = " ".join(output) if isinstance(output, list) else str(output)
+        elif fmt == "dict":
+            import json
+            output = json.dumps(output, indent=2, sort_keys=True, default=str)
+        golden = GOLDEN_DIR / f"{fixture.stem}.{target}.golden"
+        if os.environ.get("UMWELT_UPDATE_GOLDENS") == "1":
+            golden.parent.mkdir(parents=True, exist_ok=True)
+            golden.write_text(output)
+            continue
+        if not golden.exists():
+            pytest.skip(f"no golden for {fixture.name} / {target} yet")
+        assert output == golden.read_text(), (
+            f"output drift for {fixture.name} compiled by {target}. "
+            f"Run with UMWELT_UPDATE_GOLDENS=1 to regenerate."
+        )
+```
+
+- [ ] **Step 3: Generate the initial goldens.**
+
+Run: `UMWELT_UPDATE_GOLDENS=1 python3 -m pytest tests/sandbox/test_v04_byte_compat.py -v`
+Expected: all parametrized tests skip or pass; `tests/sandbox/golden/v05/` now contains one golden per (fixture, compiler) pair.
+
+- [ ] **Step 4: Re-run without the env var to verify the snapshots are stable.**
+
+Run: `python3 -m pytest tests/sandbox/test_v04_byte_compat.py -v`
+Expected: all pass.
+
+- [ ] **Step 5: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add tests/sandbox/test_v04_byte_compat.py tests/sandbox/golden/
+git commit -m "test(sandbox): snapshot fixtures + compilers for byte-compat guard"
+```
+
+---
+
+## Slice C — Cross-axis cascade specificity
+
+### Task 7: Extend Specificity with axis_count and per-axis counts
+
+**Files:**
+- Modify: `src/umwelt/selector/specificity.py`
+- Modify: `src/umwelt/ast.py` (if specificity type is stored on ComplexSelector — widen it)
+- Modify: `src/umwelt/cascade/resolver.py` (comparator uses new tuple)
+- Create: `tests/cascade/test_cross_axis_specificity.py`
+
+Replace `(ids, classes_attrs, types)` with `(axis_count, principal_ids, world_weight, control_weight, coordination_weight, intelligence_weight, operation_weight, audit_weight, use_weight)` where each `*_weight` is the sum `ids * 100 + (classes+attrs+pseudos) * 10 + types`.
+
+`axis_count` is the number of distinct axes named in the compound selector. Axes:
+- `principal`
+- `world` (entities registered under world taxon)
+- `control` (via state taxon for now — will split in v0.6)
+- `coordination` (via state taxon for now)
+- `intelligence` (via actor taxon)
+- `operation` (via capability and use)
+- `audit` (new in Task 10)
+
+Backwards-compatible rule: legacy single-axis selectors have `axis_count=1` and the tuple comparator falls back to CSS-standard ordering for ties within the same axis.
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `tests/cascade/test_cross_axis_specificity.py`:
+
+```python
+"""Tests for cross-axis cascade specificity ordering."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+
+
+def _specs(view):
+    return [sel.specificity for rule in view.rules for sel in rule.selectors]
+
+
+def test_single_axis_specificity_unchanged_shape():
+    view = parse_view('file[path="x"] { editable: true; }')
+    spec = _specs(view)[0]
+    # New tuple is at least 2 wide (axis_count, ...packed weights...)
+    assert len(spec) >= 2
+    assert spec[0] == 1  # axis_count
+
+
+def test_cross_axis_has_higher_axis_count():
+    one_axis = _specs(parse_view('file[path="x"] { editable: true; }'))[0]
+    two_axis = _specs(parse_view(
+        'inferencer tool[name="Edit"] { allow: true; }'
+    ))[0]
+    assert two_axis[0] > one_axis[0]
+    assert two_axis > one_axis  # tuple comparison: axis_count first
+
+
+def test_three_axis_beats_two_axis():
+    two = _specs(parse_view('tool[name="Edit"] use[of="file#x"] { editable: true; }'))[0]
+    three = _specs(parse_view(
+        'inferencer tool[name="Edit"] use[of="file#x"] { editable: true; }'
+    ))[0]
+    assert three > two
+
+
+def test_bare_selector_less_specific_than_attribute_selector():
+    bare = _specs(parse_view('use { editable: true; }'))[0]
+    attr = _specs(parse_view('use[of="file#x"] { editable: true; }'))[0]
+    assert attr > bare
+
+
+def test_id_wins_within_axis():
+    cls = _specs(parse_view('file.foo { editable: true; }'))[0]
+    ide = _specs(parse_view('file#foo { editable: true; }'))[0]
+    # Both single-axis; within-axis ordering: id > class.
+    assert ide > cls
+```
+
+And a cascade-behavior test showing cross-axis rules win:
+
+```python
+def test_cross_axis_rule_wins_over_single_axis():
+    from umwelt.cascade.resolver import resolve
+    from umwelt.sandbox.entities import UseEntity
+    view = parse_view('''
+        use[of="file#/src/auth.py"] { editable: false; }
+        inferencer tool[name="Edit"] use[of="file#/src/auth.py"] { editable: true; }
+    ''')
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    specific = [p for e, p in uses if e.of == "file#/src/auth.py"]
+    assert specific, "expected at least one use with of=file#/src/auth.py"
+    # The cross-axis rule (3 axes: intelligence, operation-tool, operation-use)
+    # should beat the single-axis rule.
+    assert any(p.get("editable") == "true" for p in specific)
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `python3 -m pytest tests/cascade/test_cross_axis_specificity.py -v`
+Expected: tests fail — current specificity is 3-tuple with no axis_count.
+
+- [ ] **Step 3: Extend `src/umwelt/selector/specificity.py`.**
+
+Replace the module body:
+
+```python
+"""Cross-axis cascade specificity.
+
+v0.5 extends CSS3 specificity with an axis_count-first tuple that captures
+how many distinct taxon-axes a compound selector names. A rule that joins
+more axes is more specific than a rule that names one, regardless of the
+within-axis counts. This matches the VSM-lattice view: a rule scoped to
+(inferencer, tool, use) is more contextualized than a rule scoped to just
+(use).
+
+Specificity tuple layout:
+    (
+        axis_count,
+        principal_weight,
+        world_weight,
+        state_weight,           # coordination + control (split in v0.6)
+        actor_weight,           # intelligence (split in v0.6)
+        capability_weight,      # operation
+        audit_weight,
+    )
+
+Each axis weight packs CSS3's (id, class+attr+pseudo, type) counts into a
+single integer via id*10_000 + cap*100 + types. This lets axis_count
+dominate the tuple's primary ordering while preserving exact within-axis
+CSS3 behavior as the secondary ordering.
+"""
+
+from __future__ import annotations
+
+from umwelt.ast import ComplexSelector, SimpleSelector
+
+AXIS_ORDER = (
+    "principal", "world", "state", "actor", "capability", "audit",
+)
+
+
+def _simple_weight(selector: SimpleSelector) -> int:
+    ids = 1 if selector.id_value is not None else 0
+    cap = (
+        len(selector.classes)
+        + len(selector.attributes)
+        + len(selector.pseudo_classes)
+    )
+    types = 1 if (selector.type_name is not None and selector.type_name != "*") else 0
+    return ids * 10_000 + cap * 100 + types
+
+
+def _simple_axis(selector: SimpleSelector) -> str:
+    """Return the canonical-axis key for a simple selector."""
+    taxon = selector.taxon
+    # Map aliases to canonical names for axis accounting.
+    if taxon in ("coordination", "control"):
+        return "state"
+    if taxon == "intelligence":
+        return "actor"
+    if taxon == "operation":
+        return "capability"
+    return taxon
+
+
+def compound_specificity(compound: ComplexSelector) -> tuple:
+    axis_weights = {axis: 0 for axis in AXIS_ORDER}
+    axes_seen: set[str] = set()
+    for part in compound.parts:
+        axis = _simple_axis(part.selector)
+        if axis not in axis_weights:
+            axis_weights[axis] = 0  # unknown axis — still counted
+        axis_weights[axis] += _simple_weight(part.selector)
+        if part.selector.type_name is not None:
+            axes_seen.add(axis)
+    return (
+        len(axes_seen),
+        axis_weights.get("principal", 0),
+        axis_weights.get("world", 0),
+        axis_weights.get("state", 0),
+        axis_weights.get("actor", 0),
+        axis_weights.get("capability", 0),
+        axis_weights.get("audit", 0),
+    )
+
+
+# Back-compat alias — existing callers may expect simple_specificity.
+def simple_specificity(selector: SimpleSelector) -> tuple[int, int, int]:
+    ids = 1 if selector.id_value is not None else 0
+    cap = (
+        len(selector.classes)
+        + len(selector.attributes)
+        + len(selector.pseudo_classes)
+    )
+    types = 1 if (selector.type_name is not None and selector.type_name != "*") else 0
+    return (ids, cap, types)
+```
+
+- [ ] **Step 4: Update `src/umwelt/ast.py` if it type-annotates specificity.**
+
+Check `ComplexSelector.specificity: tuple[int, int, int]`. If present, widen to `tuple` or `tuple[int, ...]`.
+
+- [ ] **Step 5: Update `src/umwelt/cascade/resolver.py` — the comparator should already use Python tuple comparison which works on arbitrary-width tuples, so no change needed there if the tuple widths are consistent within a single view.**
+
+Verify: the comparator at lines 154-159 (`app.specificity > current.specificity`) does direct tuple comparison. As long as all specificities in one view have the same width, this works. It already does.
+
+- [ ] **Step 6: Update any tests that asserted exact 3-tuple specificity.**
+
+Run: `python3 -m pytest -q 2>&1 | grep -i "specificity\|tuple" | head -20`
+Fix broken assertions to match the new tuple shape, preserving their intent.
+
+- [ ] **Step 7: Run Slice C tests.**
+
+Run: `python3 -m pytest tests/cascade/test_cross_axis_specificity.py -v`
+Expected: all pass.
+
+- [ ] **Step 8: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: all green.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add src/umwelt/selector/specificity.py src/umwelt/ast.py 2>/dev/null tests/cascade/test_cross_axis_specificity.py
+# + any test file updates for the tuple-width change
+git commit -m "feat(selector): cross-axis cascade specificity with axis_count primacy"
+```
+
+---
+
+### Task 8: Cross-axis ordering regression tests
+
+Already covered by Task 7 tests. Skip — this slot is reserved for any additional edge cases discovered during implementation.
+
+---
+
+## Slice D — Principal + audit taxa
+
+### Task 9: Register `principal` taxon + entity + matcher
+
+**Files:**
+- Modify: `src/umwelt/sandbox/entities.py` (add PrincipalEntity)
+- Modify: `src/umwelt/sandbox/vocabulary.py` (register principal taxon)
+- Create: `src/umwelt/sandbox/principal_matcher.py`
+- Create: `tests/sandbox/test_principal.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `tests/sandbox/test_principal.py`:
+
+```python
+"""Tests for the principal taxon."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+from umwelt.cascade.resolver import resolve
+from umwelt.sandbox.entities import PrincipalEntity
+
+
+def test_principal_entity_registered():
+    from umwelt.registry import get_taxon, get_entity
+    assert get_taxon("principal") is not None
+    assert get_entity(taxon="principal", name="principal") is not None
+
+
+def test_principal_parses_and_matches():
+    view = parse_view('''
+        principal#Teague { intent: "code review"; grade: 2; }
+    ''')
+    rv = resolve(view)
+    principals = list(rv.entries("principal"))
+    assert len(principals) >= 1
+    entity, props = principals[0]
+    assert isinstance(entity, PrincipalEntity)
+    assert entity.name == "Teague"
+    assert props.get("intent") == "code review"
+    assert props.get("grade") == "2"
+
+
+def test_principal_context_qualifier():
+    """A principal selector qualifies rules in lower axes."""
+    view = parse_view('''
+        principal#Teague use[of="file#/src/x.py"] { editable: true; }
+    ''')
+    rv = resolve(view)
+    # At minimum the view parses and resolves without error.
+    assert rv is not None
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `python3 -m pytest tests/sandbox/test_principal.py -v`
+Expected: ImportError on `PrincipalEntity` or KeyError on taxon.
+
+- [ ] **Step 3: Add `PrincipalEntity` to `src/umwelt/sandbox/entities.py`.**
+
+```python
+@dataclass(frozen=True)
+class PrincipalEntity:
+    """The commissioning principal (S5)."""
+
+    name: str | None = None
+```
+
+- [ ] **Step 4: Create `src/umwelt/sandbox/principal_matcher.py`.**
+
+```python
+"""Matcher for principal entities. Synthesizes PrincipalEntity per #id in rules."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from umwelt.ast import SimpleSelector, View
+from umwelt.registry import MatcherProtocol
+from umwelt.sandbox.entities import PrincipalEntity
+
+
+class PrincipalMatcher(MatcherProtocol):
+    entity_name = "principal"
+    taxon = "principal"
+
+    def candidates(self, view: View, eval_context: Any = None) -> Iterable[PrincipalEntity]:
+        seen: set[str | None] = set()
+        for rule in view.rules:
+            for sel in rule.selectors:
+                for part in sel.parts:
+                    if part.selector.type_name == "principal":
+                        ident = part.selector.id_value
+                        if ident in seen:
+                            continue
+                        seen.add(ident)
+                        yield PrincipalEntity(name=ident)
+
+    def matches(self, entity: Any, simple: SimpleSelector) -> bool:
+        if not isinstance(entity, PrincipalEntity):
+            return False
+        if simple.type_name not in ("principal", None, "*"):
+            return False
+        if simple.id_value is not None and simple.id_value != entity.name:
+            return False
+        return True
+```
+
+- [ ] **Step 5: Register the taxon, entity, properties, and matcher in `src/umwelt/sandbox/vocabulary.py`.**
+
+Add `_register_principal()` and call from `register_sandbox_vocabulary`:
+
+```python
+def _register_principal() -> None:
+    register_taxon(
+        name="principal",
+        description="S5: commissioning identity. Who set the bounds for the delegate.",
+        ma_concept="principal_axis",
+    )
+    register_entity(
+        taxon="principal",
+        name="principal",
+        attributes={
+            "name": AttrSchema(type=str, description="Principal identifier (used as #id)."),
+        },
+        description="The commissioning principal.",
+        category="identity",
+    )
+    register_property(taxon="principal", entity="principal", name="intent", value_type=str,
+                     description="Free-form description of why this delegate was commissioned.")
+    register_property(taxon="principal", entity="principal", name="grade", value_type=int,
+                     description="Ma-grade label (0-4). Consumed by audit, ignored by other compilers.")
+
+    from umwelt.registry import register_matcher
+    from umwelt.sandbox.principal_matcher import PrincipalMatcher
+    register_matcher(taxon="principal", entity="principal", matcher=PrincipalMatcher())
+```
+
+Call it from `register_sandbox_vocabulary` after `_register_use()`.
+
+- [ ] **Step 6: Run tests.**
+
+Run: `python3 -m pytest tests/sandbox/test_principal.py -v`
+Expected: all 3 pass.
+
+- [ ] **Step 7: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: all green.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/umwelt/sandbox/entities.py src/umwelt/sandbox/vocabulary.py \
+        src/umwelt/sandbox/principal_matcher.py tests/sandbox/test_principal.py
+git commit -m "feat(sandbox): register principal taxon + PrincipalMatcher"
+```
+
+---
+
+### Task 10: Register `audit` taxon + parse `@audit { ... }` at-rule
+
+**Files:**
+- Modify: `src/umwelt/ast.py` (add AuditBlock or reuse RuleBlock)
+- Modify: `src/umwelt/parser.py` (recognize `@audit` at-rule)
+- Modify: `src/umwelt/sandbox/entities.py` (ObservationEntity, ManifestEntity)
+- Modify: `src/umwelt/sandbox/vocabulary.py` (register audit taxon + entities)
+- Create: `src/umwelt/sandbox/audit_matcher.py`
+- Create: `tests/sandbox/test_audit_taxon.py` (new file; do NOT collide with existing tests/test_audit.py which is about CLI)
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `tests/sandbox/test_audit_taxon.py`:
+
+```python
+"""Tests for the audit taxon and @audit at-rule."""
+from __future__ import annotations
+
+from umwelt.parser import parse_view
+from umwelt.cascade.resolver import resolve
+from umwelt.sandbox.entities import ObservationEntity, ManifestEntity
+
+
+def test_audit_taxon_registered():
+    from umwelt.registry import get_taxon, get_entity
+    assert get_taxon("audit") is not None
+    assert get_entity(taxon="audit", name="observation") is not None
+    assert get_entity(taxon="audit", name="manifest") is not None
+
+
+def test_at_audit_parses():
+    view = parse_view('''
+        @audit {
+            observation#coach { source: "kibitzer"; }
+        }
+    ''')
+    # The @audit block is parsed as rules inside an audit-scoped block.
+    rv = resolve(view)
+    audit_entries = list(rv.entries("audit"))
+    obs = [(e, p) for e, p in audit_entries if isinstance(e, ObservationEntity)]
+    assert obs
+    entity, props = obs[0]
+    assert entity.name == "coach"
+    assert props.get("source") == "kibitzer"
+
+
+def test_manifest_inside_audit():
+    view = parse_view('''
+        @audit {
+            manifest#current { path: ".umwelt/manifest.json"; }
+        }
+    ''')
+    rv = resolve(view)
+    manifests = [(e, p) for e, p in rv.entries("audit") if isinstance(e, ManifestEntity)]
+    assert manifests
+    entity, props = manifests[0]
+    assert entity.name == "current"
+
+
+def test_audit_entries_not_affected_by_world_scope():
+    """@audit lives outside the world; world-scoped queries don't touch it."""
+    view = parse_view('''
+        world#dev file { editable: true; }
+        @audit { observation#coach { source: "kibitzer"; } }
+    ''')
+    rv = resolve(view, world="dev")
+    audit_entries = list(rv.entries("audit"))
+    assert audit_entries
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `python3 -m pytest tests/sandbox/test_audit_taxon.py -v`
+Expected: multiple errors — no audit taxon, @audit doesn't parse as a known block.
+
+- [ ] **Step 3: Add entities to `src/umwelt/sandbox/entities.py`.**
+
+```python
+@dataclass(frozen=True)
+class ObservationEntity:
+    """An observation entry emitted by a Layer-2 observer (blq, ratchet-detect)."""
+
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class ManifestEntity:
+    """A workspace manifest reference."""
+
+    name: str | None = None
+```
+
+- [ ] **Step 4: Register `audit` taxon, entities, properties, matcher in `vocabulary.py`.**
+
+```python
+def _register_audit() -> None:
+    register_taxon(
+        name="audit",
+        description="S3* cross-cut observer. Outside the world.",
+        ma_concept="audit_axis",
+    )
+    register_entity(
+        taxon="audit",
+        name="observation",
+        attributes={
+            "name": AttrSchema(type=str, description="Observation identifier (used as #id)."),
+        },
+        description="A Layer-2 observation entry.",
+        category="observation",
+    )
+    register_entity(
+        taxon="audit",
+        name="manifest",
+        attributes={
+            "name": AttrSchema(type=str, description="Manifest identifier."),
+        },
+        description="The workspace manifest reference.",
+        category="manifest",
+    )
+
+    register_property(taxon="audit", entity="observation", name="source", value_type=str,
+                     description="Observer source (e.g. 'kibitzer', 'ratchet-detect').")
+    register_property(taxon="audit", entity="observation", name="enabled", value_type=bool,
+                     description="Whether this observation is enabled.")
+    register_property(taxon="audit", entity="manifest", name="path", value_type=str,
+                     description="Path to the manifest file.")
+
+    from umwelt.registry import register_matcher
+    from umwelt.sandbox.audit_matcher import AuditMatcher
+    register_matcher(taxon="audit", entity="observation", matcher=AuditMatcher(entity_name="observation"))
+    register_matcher(taxon="audit", entity="manifest", matcher=AuditMatcher(entity_name="manifest"))
+```
+
+Call from `register_sandbox_vocabulary` after `_register_principal()`.
+
+- [ ] **Step 5: Create `src/umwelt/sandbox/audit_matcher.py`.**
+
+```python
+"""Matcher for audit-taxon entities (observation, manifest)."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from umwelt.ast import SimpleSelector, View
+from umwelt.registry import MatcherProtocol
+from umwelt.sandbox.entities import ObservationEntity, ManifestEntity
+
+_ENTITY_CLASS = {
+    "observation": ObservationEntity,
+    "manifest": ManifestEntity,
+}
+
+
+@dataclass
+class AuditMatcher(MatcherProtocol):
+    entity_name: str = "observation"
+    taxon: str = "audit"
+
+    def candidates(self, view: View, eval_context: Any = None) -> Iterable[Any]:
+        seen: set[str | None] = set()
+        cls = _ENTITY_CLASS.get(self.entity_name, ObservationEntity)
+        for rule in view.rules:
+            for sel in rule.selectors:
+                for part in sel.parts:
+                    if part.selector.type_name == self.entity_name:
+                        ident = part.selector.id_value
+                        if ident in seen:
+                            continue
+                        seen.add(ident)
+                        yield cls(name=ident)
+
+    def matches(self, entity: Any, simple: SimpleSelector) -> bool:
+        cls = _ENTITY_CLASS.get(self.entity_name, ObservationEntity)
+        if not isinstance(entity, cls):
+            return False
+        if simple.type_name not in (self.entity_name, None, "*"):
+            return False
+        if simple.id_value is not None and simple.id_value != entity.name:
+            return False
+        return True
+```
+
+- [ ] **Step 6: Teach the parser to recognize `@audit { ... }` in `src/umwelt/parser.py`.**
+
+Find where at-rules are parsed (grep for `at_rule` or `UnknownAtRule`). The parser currently passes-through unknown at-rules; update it to recognize `@audit` specifically and parse its body as additional rules attached to the view, with each rule's selector automatically rooted in audit scope.
+
+A minimal implementation: collect the `@audit` body's rules, mark them (e.g., by wrapping each selector with a synthetic `audit` prefix), and merge into `view.rules`. Because the inner rules already target `observation` and `manifest` (which are audit-taxon entities), their specificity naturally lands them in the audit bucket.
+
+Sketch (exact code depends on parser internals — adapt):
+
+```python
+# In parser.py, find the at-rule dispatcher.
+
+def _parse_audit_at_rule(prelude: str, body_text: str, span: SourceSpan) -> list[RuleBlock]:
+    """Parse the body of @audit { ... } as regular rules.
+
+    Rules inside @audit are parsed normally; their selectors naturally target
+    audit-taxon entities (observation, manifest). No synthetic prefix is added.
+    """
+    inner_view = parse_view(body_text)
+    return list(inner_view.rules)
+
+
+# In the main parse loop where unknown @-rules are currently handled:
+if at_rule.name == "audit":
+    inner_rules = _parse_audit_at_rule(...)
+    all_rules.extend(inner_rules)
+    continue  # do not add to unknown_at_rules
+```
+
+Adapt to the actual parser structure. The key invariant: rules inside `@audit` end up in `view.rules` and their selectors target `observation`/`manifest` which are registered under the `audit` taxon.
+
+- [ ] **Step 7: Run Slice D tests.**
+
+Run: `python3 -m pytest tests/sandbox/test_audit_taxon.py -v`
+Expected: all 4 pass.
+
+- [ ] **Step 8: Full suite.**
+
+Run: `python3 -m pytest -q`
+Expected: all green.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add src/umwelt/sandbox/entities.py src/umwelt/sandbox/vocabulary.py \
+        src/umwelt/sandbox/audit_matcher.py src/umwelt/parser.py \
+        tests/sandbox/test_audit_taxon.py
+git commit -m "feat(sandbox): register audit taxon + @audit at-rule parsing"
+```
+
+---
+
+## Slice E — Docs + release
+
+### Task 11: Write `docs/vision/notes/vsm-alignment.md`
+
+**Files:**
+- Create: `docs/vision/notes/vsm-alignment.md`
+
+A design-notes doc capturing the Beer mapping and the S3↔S4 inversion justification. Source material already lives in the spec; this note is the user-facing companion.
+
+- [ ] **Step 1: Write the note.**
+
+Create the file with this content (approx.):
+
+```markdown
+# Note: VSM alignment — umwelt taxa as Beer's Viable System Model
+
+*Captured 2026-04-14 during the v0.5 VSM restructure. Companion to the
+spec at `docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md`
+and the logic-semantics note at `logic-semantics.md`.*
+
+## The mapping
+
+Beer's Viable System Model names five systems inside an organism embedded
+in an environment:
+
+| System | Name | umwelt taxon |
+|---|---|---|
+| S5 | Identity / policy | `principal` |
+| S4 | Intelligence — outside and then | `intelligence` (aliases `actor`) |
+| S3 | Internal control — inside and now | `control` (aliases `state`) |
+| S3* | Audit channel | `audit` |
+| S2 | Coordination — anti-oscillation | `coordination` (aliases `state`) |
+| S1 | Operations | `operation` (aliases `capability`) |
+| — | Environment | `world` |
+
+## Why S3 dominates S4 here (inversion from Beer)
+
+In Beer's VSM, S3 and S4 are peers who resolve tension at S5. In bounded
+delegation the regulator dominates the regulated — coordination and
+control *constrain* the inferencer; the inferencer doesn't resolve
+tension with S3 as a peer. This inversion is the architectural move
+that makes the specified band coherent.
+
+## Why audit is outside the world
+
+S3* bypasses normal reporting. Architecturally, the auditor cannot be
+inside the world it audits. Placing `@audit { ... }` outside the world
+hierarchy honors that constraint.
+
+## How legacy-shim preserves behavior
+
+v0.5 introduces the new axes as aliases, so `state` and `coordination`
+resolve to the same taxon. The physical split happens in v0.6+ when the
+shim is retired.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add docs/vision/notes/vsm-alignment.md
+git commit -m "docs(notes): VSM alignment design note"
+```
+
+---
+
+### Task 12: Regenerate entity reference
+
+**Files:**
+- Modify: `docs/guide/entity-reference.md`
+
+Add new sections for `use`, `principal`, `observation`, `manifest` entities and the new taxa (principal, audit). Keep existing sections for world/capability/state/actor — those still work via aliases.
+
+- [ ] **Step 1: Read the current reference.**
+
+Run: `cat docs/guide/entity-reference.md`
+
+- [ ] **Step 2: Add new sections.**
+
+Append to the reference:
+
+- A `## principal taxon` section with the principal entity (attrs: name; properties: intent, grade).
+- A `## audit taxon` section with observation and manifest entities.
+- A `## use entity` section under operation taxon, describing attributes (of, of-kind, of-like) and properties (editable, visible, show, allow, deny, allow-pattern, deny-pattern).
+- A note at the top mentioning VSM aliases (operation/coordination/control/intelligence → capability/state/state/actor).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add docs/guide/entity-reference.md
+git commit -m "docs(guide): regenerate entity reference for v0.5 (use, principal, audit)"
+```
+
+---
+
+### Task 13: CHANGELOG, version bump, tag v0.5.0
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `src/umwelt/__init__.py` (version)
+- Modify: `pyproject.toml` (version)
+
+- [ ] **Step 1: Add CHANGELOG entry.**
+
+Prepend to `CHANGELOG.md`:
+
+```markdown
+## 0.5.0 — 2026-04-14
+
+### Added
+- **VSM-aligned taxa** (`principal`, `audit`) and aliases (`operation`,
+  `coordination`, `control`, `intelligence`) for the existing taxa.
+  Enables selector forms like `mode.testing use[of="file#..."]` and
+  `@audit { observation#... { ... } }`.
+- **`use[of=...]` entity** — first-class permissioned projection of a
+  world resource into the action axis. Carries `editable`, `visible`,
+  `show`, `allow`, `deny`, `allow-pattern`, `deny-pattern`.
+- **Legacy-shim** synthesizes `use` rules from v0.4-shape
+  `file { editable: true; }` declarations, so v0.4 views compile
+  byte-identically through all three existing compilers.
+- **Cross-axis cascade specificity** — selectors that join more taxa-axes
+  are more specific. `axis_count`-first tuple ordering.
+- **`@audit { ... }` at-rule** for defining observations and manifest
+  references outside the world scope.
+
+### Changed
+- Specificity tuples widened from `(ids, cls, types)` to
+  `(axis_count, principal, world, state, actor, capability, audit)`.
+  Single-axis v0.4 rules continue to order identically because
+  `axis_count=1` is uniform across them.
+
+### Notes
+- Compilers (nsjail, bwrap, lackpy-namespace) continue to read legacy
+  entities directly. v0.6 migrates them to read `use` entries
+  exclusively and retires the legacy-shim.
+- Kibitzer-hooks compiler and the security pass are deferred to v0.6
+  and v0.7 respectively.
+```
+
+- [ ] **Step 2: Bump version in `src/umwelt/__init__.py`.**
+
+Change the `__version__` string to `"0.5.0"`.
+
+- [ ] **Step 3: Bump version in `pyproject.toml`.**
+
+Change `version = "0.4.0"` to `version = "0.5.0"`.
+
+- [ ] **Step 4: Run full suite one final time.**
+
+Run: `python3 -m pytest -q`
+Expected: all green.
+
+- [ ] **Step 5: Build to verify PyPI packaging still works.**
+
+Run: `python3 -m build`
+Expected: `dist/umwelt-0.5.0-py3-none-any.whl` and `dist/umwelt-0.5.0.tar.gz` produced.
+
+- [ ] **Step 6: Commit and tag.**
+
+```bash
+git add CHANGELOG.md src/umwelt/__init__.py pyproject.toml
+git commit -m "chore(release): v0.5.0 — VSM-aligned DOM + use[of=...] + cross-axis cascade"
+git tag v0.5.0
+# Do NOT push without user confirmation — tag creation is reversible but push is not.
+echo "v0.5.0 tagged locally. Ask the user before pushing."
+```
+
+---
+
+## Self-review
+
+Skim the spec and confirm coverage:
+
+| Spec section | Covered by |
+|---|---|
+| §2 VSM-aligned taxa | Tasks 0, 1 |
+| §3 `use[of=...]` primitive | Tasks 2, 3, 4 |
+| §3 permissions move onto use | Task 5 (shim synthesizes them) |
+| §4 audit outside the world | Task 10 (@audit at-rule) |
+| §5 mode as class | Implicitly supported by existing `.class` parsing; no code change needed in v0.5 (Task 10 covers `.class` CSS semantics being unchanged) |
+| §6 cross-axis cascade | Tasks 7, 8 |
+| §7 full DOM worked example | Verified end-to-end via byte-compat snapshot tests (Task 6) and cross-axis tests (Task 7) |
+| §8 `principal` taxon minimal shape | Task 9 |
+| §9 migration path / byte-identical output | Task 5 (shim) + Task 6 (snapshots) |
+| §9 vision-doc updates | Tasks 11, 12 |
+| §10 vertical slices | Task 0 = A; 2-6 = B; 7-8 = C; 9-10 = D; 11-13 = E |
+| §12 risks — shim drift | Task 6 snapshots guard against drift |
+
+Placeholder scan: no TBDs, no "write tests for the above" without code, no "similar to Task N" references. Every code step has exact code.
+
+Type consistency: `UseEntity(of=..., of_kind=..., of_like=...)` used consistently in Tasks 2, 4, 5, 7, 10. `PrincipalEntity(name=...)` consistent in Task 9. `ObservationEntity`/`ManifestEntity` consistent in Task 10. Specificity tuple layout consistent in Tasks 7 and 12 doc.
+
+One known risk: Task 6's snapshot approach fails if the parser emits byte-different output for the same fixture between v0.4 and v0.5 due to the shim adding new rules. The mitigation is that compilers read legacy entries (Task 5 keeps them). If the shim accidentally causes ResolvedView changes that affect the compiler, the snapshots catch it immediately and the engineer investigates before merging.

--- a/docs/superpowers/plans/2026-04-14-umwelt-v05.md
+++ b/docs/superpowers/plans/2026-04-14-umwelt-v05.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Land the VSM-aligned taxa (principal/world/audit/control/coordination/intelligence/operation), introduce `use[of=...]` as the action-axis permission primitive, and add cross-axis cascade specificity — while preserving byte-identical compiler output for every v0.4 fixture via a legacy-shim that synthesizes `use` rules from old-form declarations.
+**Goal:** Land the VSM-aligned taxa (principal/world/audit/control/coordination/intelligence/operation), introduce `use[of=...]` as the action-axis permission primitive, and add cross-axis cascade specificity. World-axis permissions (`file { editable: true; }`) remain first-class and unchanged; the action-axis is *additive*, not replacing.
 
-**Architecture:** Additive migration, not a rename. New taxa register as aliases alongside existing ones. `use` enters as a new entity type with an `of=` attribute whose value is a nested selector matched against world entities. A desugar pass synthesizes `use` rules from `file { editable: true; }`-style legacy forms so the new shape is present in every parsed view. Compilers in v0.5 continue reading the legacy path; v0.6+ migrates them to read `use` exclusively and eventually removes the shim.
+**Architecture:** Additive restructuring. New taxa register as aliases alongside existing ones. `use` enters as a new entity type with an `of=` attribute whose value is a nested selector matched against world entities. World-axis and action-axis permissions are semantically independent (spec §3a) — the analogy is mount-read-only vs user-file-permissions. v0.5 adds the action-axis without disturbing the world-axis; compilers in v0.5 continue reading world-axis as before. Byte-identical compiler output is guaranteed by Task 6 snapshots.
 
 **Tech Stack:** Python 3.10+, existing umwelt infrastructure (tinycss2 parser, plugin registry, selector engine, cascade resolver). No new dependencies.
 
@@ -26,6 +26,7 @@ v0.5 strengthens or introduces evidence for these claims:
 | A2 (cascade well-ordered) | Cross-axis specificity retains document-order tiebreaker; new tests prove no cycles across axis-count boundary. | 7 |
 | A3 (cross-axis soundness) | **Introduced.** Axis_count-first tuple; test that cross-axis rules beat single-axis rules. | 7 |
 | A5 (property comparison semantics) | `use` properties (editable, visible, allow, deny, allow-pattern, deny-pattern, show) register with their comparison fields. | 2 |
+| A6 (world-axis and action-axis permissions semantically independent) | Task 2 registered `use` permission properties additively; world-axis `file.editable` etc. remain registered unchanged. Tests confirm both are queryable per their axis. | 2 (done) |
 | B1 (enforcement fidelity — continuity) | Byte-compat snapshot tests verify compiler output stable across the restructure. Does NOT prove initial correctness. | 6 |
 | C3 (proof-tree stability) | Implicit in snapshot stability; explicit proof trees are v0.9+. | 6 |
 | H1 (integrator-without-fork) | lackpy-namespace compiler unchanged; bwrap/nsjail unchanged. All three compilers still work through the restructure. | 6 |
@@ -65,10 +66,10 @@ src/umwelt/cascade/resolver.py                       # MODIFY — specificity co
 tests/registry/test_taxon_aliases.py                 # CREATE
 tests/sandbox/test_use_entity.py                     # CREATE
 tests/sandbox/test_use_matcher.py                    # CREATE
-tests/sandbox/test_desugar_use.py                    # CREATE
 tests/sandbox/test_principal.py                      # CREATE
-tests/sandbox/test_audit.py                          # CREATE (may extend existing tests/test_audit.py — it's about the audit CLI, this one is about the audit taxon)
+tests/sandbox/test_audit_taxon.py                    # CREATE
 tests/cascade/test_cross_axis_specificity.py         # CREATE
+tests/cascade/test_determinism.py                    # CREATE — A1 claim
 tests/sandbox/test_v04_byte_compat.py                # CREATE — snapshot tests proving compiler output unchanged
 
 docs/vision/notes/vsm-alignment.md                   # CREATE
@@ -83,17 +84,16 @@ pyproject.toml                                       # MODIFY — bump version
 
 ## Task breakdown
 
-**14 tasks across 5 slices:**
+**13 tasks across 5 slices** (Task 5 removed — the "legacy-shim" was based on a misreading; world-axis and action-axis permissions are semantically independent, see spec §3a):
 
 **Slice A — Taxa aliases**
-- Task 0: Registry taxon-alias support
-- Task 1: Register VSM taxa as aliases of existing taxa
+- Task 0: Registry taxon-alias support  ✅ DONE
+- Task 1: Register VSM taxa as aliases of existing taxa  ✅ DONE
 
 **Slice B — `use` entity**
-- Task 2: Register `use` entity + permission properties
-- Task 3: Parse `of=` attribute as selector-valued
-- Task 4: Implement UseMatcher (of-kind, of-like, exact of)
-- Task 5: Desugar — synthesize `use` rules from legacy forms
+- Task 2: Register `use` entity + permission properties  ✅ DONE
+- Task 3: Parse `of=` attribute as selector-valued  ✅ DONE
+- Task 4: Implement UseMatcher (of-kind, of-like, exact of)  ✅ DONE
 - Task 6: Snapshot tests — v0.4 fixtures still produce byte-identical compiler output
 
 **Slice C — Cross-axis cascade specificity**
@@ -256,7 +256,7 @@ Register the new VSM taxon names as aliases for the existing taxa. This makes th
 - `intelligence` aliases `actor` (for inferencer)
 - (`principal` and `audit` are new taxa, not aliases — handled in Task 9 / 10)
 
-Because `state` is split across coordination and control in the spec, both new names alias the same underlying taxon in v0.5. The split happens in v0.6+ when the legacy-shim is turned off. This is documented in the registration comment.
+Because `state` is split across coordination and control in the spec, both new names alias the same underlying taxon in v0.5. The physical split is a v0.6+ concern (breaking hook from budget/job into separate matchers).
 
 - [ ] **Step 1: Write the failing test.**
 
@@ -333,8 +333,7 @@ def _register_vsm_aliases() -> None:
     v0.5: operation/coordination/control/intelligence point at the same
     underlying taxa as capability/state/actor. The spec's logical split of
     `state` into `coordination` and `control` is virtual in v0.5 — both
-    names resolve to the same bucket. The physical split happens in v0.6+
-    when the legacy-shim is retired.
+    names resolve to the same bucket. A physical split is a v0.6+ concern.
 
     `principal` and `audit` are genuinely new taxa and are registered
     directly (Task 9 and Task 10), not as aliases.
@@ -841,226 +840,6 @@ git add src/umwelt/sandbox/use_matcher.py src/umwelt/sandbox/vocabulary.py \
         tests/sandbox/test_use_matcher.py src/umwelt/selector/match.py 2>/dev/null || \
 git add src/umwelt/sandbox/use_matcher.py src/umwelt/sandbox/vocabulary.py tests/sandbox/test_use_matcher.py
 git commit -m "feat(sandbox): UseMatcher synthesizes UseEntity from parsed use[...] selectors"
-```
-
----
-
-### Task 5: Legacy-shim — synthesize `use` rules from legacy forms
-
-**Files:**
-- Modify: `src/umwelt/sandbox/desugar.py`
-- Create: `tests/sandbox/test_desugar_use.py`
-
-The shim rewrites `file { editable: true; }` → `use[of="file#<path>"] { editable: true; }` at parse time so v0.4-shape views produce both the old `file` entries AND new `use` entries in the resolved view. This is what makes byte-identical compiler output possible in v0.5 and makes migration to use-reading compilers tractable for v0.6.
-
-The desugar runs post-parse; it adds synthetic rules to the View without removing the originals. Because we keep the originals, v0.5 compilers (which read file/tool/network directly) continue working unchanged. v0.6 compilers will ignore the originals and read only `use`.
-
-- [ ] **Step 1: Read the current desugar.py to understand the shim architecture.**
-
-Run: `cat src/umwelt/sandbox/desugar.py`
-Expected: existing desugar has transformation functions and a `register_sandbox_sugar()` registration point.
-
-- [ ] **Step 2: Write failing tests.**
-
-Create `tests/sandbox/test_desugar_use.py`:
-
-```python
-"""Tests for the legacy-shim — synthesizes use[of=...] from v0.4 forms."""
-from __future__ import annotations
-
-from umwelt.parser import parse_view
-from umwelt.cascade.resolver import resolve
-from umwelt.sandbox.entities import FileEntity, UseEntity
-
-
-def test_file_editable_synthesizes_use():
-    view = parse_view('file[path="src/auth.py"] { editable: true; }')
-    rv = resolve(view)
-    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
-    editable_uses = [(e, p) for e, p in uses if p.get("editable") == "true"]
-    # At least one use should carry editable=true for file#src/auth.py.
-    matching = [e for e, _ in editable_uses if e.of == "file#src/auth.py"]
-    assert matching
-
-
-def test_bare_tool_allow_synthesizes_use():
-    view = parse_view('tool[name="Bash"] { allow: true; }')
-    rv = resolve(view)
-    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
-    allowing = [e for e, p in uses if p.get("allow") == "true" and e.of == "tool#Bash"]
-    assert allowing
-
-
-def test_network_deny_synthesizes_use():
-    view = parse_view('network { deny: "*"; }')
-    rv = resolve(view)
-    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
-    denying = [e for e, p in uses if p.get("deny") == "*" and e.of_kind == "network"]
-    assert denying
-
-
-def test_originals_preserved_alongside_use():
-    """The shim adds use rules but does NOT remove originals."""
-    view = parse_view('file[path="src/auth.py"] { editable: true; }')
-    rv = resolve(view)
-    files = [(e, p) for e, p in rv.entries("world") if isinstance(e, FileEntity)]
-    assert files, "original file entry should still be present for v0.5 compilers"
-```
-
-- [ ] **Step 3: Run to verify failure.**
-
-Run: `python3 -m pytest tests/sandbox/test_desugar_use.py -v`
-Expected: tests fail — no `use` entries synthesized.
-
-- [ ] **Step 4: Implement the shim in `src/umwelt/sandbox/desugar.py`.**
-
-Add a function `_synthesize_use_rules_from_legacy(view: View) -> View` that walks `view.rules`, and for each rule whose rightmost simple-selector is `file`, `tool`, `network`, or `dir` and whose declarations include permission properties (editable/visible/allow/deny/show/allow-pattern/deny-pattern), creates an additional synthetic rule with the selector rewritten to `use[of-like=...]` or `use[of=...]` or `use[of-kind=...]` as appropriate, and with the same declarations. The synthetic rules are appended to `view.rules`.
-
-Concrete selector transformation:
-
-| Original rightmost selector | Synthetic `use` selector |
-|---|---|
-| `file[path="X"]` | `use[of="file#X"]` |
-| `file[path^="X"]` | `use[of-like="file#X"]` |
-| `file` (bare) | `use[of-kind="file"]` |
-| `tool[name="X"]` | `use[of="tool#X"]` |
-| `tool` (bare) | `use[of-kind="tool"]` |
-| `network[host="X"]` | `use[of="network#X"]` |
-| `network` (bare) | `use[of-kind="network"]` |
-| `dir[path="X"]` | `use[of="dir#X"]` |
-
-The synthetic rule keeps any leading parts of the compound selector (e.g., `world#dev` stays, `mode.test` stays). Only the rightmost simple-selector gets rewritten.
-
-Because the View AST is frozen, construct new SimpleSelector/CompoundPart/ComplexSelector/RuleBlock objects rather than mutating. Append to `view.rules` by constructing a new View:
-
-```python
-from umwelt.ast import (
-    AttrFilter,
-    ComplexSelector,
-    CompoundPart,
-    RuleBlock,
-    SimpleSelector,
-    View,
-)
-
-
-_LEGACY_PERMISSION_PROPS = frozenset([
-    "editable", "visible", "show",
-    "allow", "deny", "allow-pattern", "deny-pattern",
-])
-
-
-def _synthesize_use_rules_from_legacy(view: View) -> View:
-    """Append synthetic use[of=...] rules for every legacy permission rule."""
-    synthesized: list[RuleBlock] = []
-    for rule in view.rules:
-        if not _has_permission_declaration(rule):
-            continue
-        for sel in rule.selectors:
-            new_sel = _rewrite_to_use(sel)
-            if new_sel is None:
-                continue
-            synthesized.append(RuleBlock(
-                selectors=(new_sel,),
-                declarations=rule.declarations,
-                nested_blocks=(),
-                span=rule.span,
-            ))
-    if not synthesized:
-        return view
-    return View(
-        rules=view.rules + tuple(synthesized),
-        unknown_at_rules=view.unknown_at_rules,
-        warnings=view.warnings,
-        source_text=view.source_text,
-        source_path=view.source_path,
-    )
-
-
-def _has_permission_declaration(rule: RuleBlock) -> bool:
-    return any(d.property_name in _LEGACY_PERMISSION_PROPS for d in rule.declarations)
-
-
-def _rewrite_to_use(sel: ComplexSelector) -> ComplexSelector | None:
-    """Return a new ComplexSelector with rightmost part rewritten to use[of=...]."""
-    if not sel.parts:
-        return None
-    last = sel.parts[-1]
-    kind = last.selector.type_name
-    if kind not in ("file", "tool", "network", "dir"):
-        return None
-
-    # Figure out the of-form.
-    new_attrs = _derive_of_attributes(last.selector, kind)
-
-    new_simple = SimpleSelector(
-        type_name="use",
-        taxon="operation",
-        id_value=None,
-        classes=(),
-        attributes=new_attrs,
-        pseudo_classes=(),
-        span=last.selector.span,
-    )
-    new_last = CompoundPart(
-        selector=new_simple,
-        combinator=last.combinator,
-        mode=last.mode,
-    )
-    new_parts = sel.parts[:-1] + (new_last,)
-    from umwelt.selector.specificity import compound_specificity
-    # Re-use existing specificity computation; it will be upgraded in Slice C.
-    new_complex = ComplexSelector(
-        parts=new_parts,
-        target_taxon="operation",
-        specificity=compound_specificity_for_parts(new_parts),
-    )
-    return new_complex
-
-
-def compound_specificity_for_parts(parts):
-    from umwelt.ast import ComplexSelector
-    from umwelt.selector.specificity import compound_specificity
-    tmp = ComplexSelector(parts=parts, target_taxon="operation", specificity=(0, 0, 0))
-    return compound_specificity(tmp)
-
-
-def _derive_of_attributes(simple: SimpleSelector, kind: str) -> tuple[AttrFilter, ...]:
-    """Derive the of= / of-kind= / of-like= attribute filters for a legacy selector."""
-    # Check for an id-like filter.
-    if simple.id_value is not None:
-        return (AttrFilter(name="of", op="=", value=f"{kind}#{simple.id_value}"),)
-    # Check for path="X" or name="X" exact-match.
-    for a in simple.attributes:
-        if a.op == "=" and a.name in ("path", "name", "host"):
-            return (AttrFilter(name="of", op="=", value=f"{kind}#{a.value}"),)
-    # Check for prefix-like.
-    for a in simple.attributes:
-        if a.op == "^=" and a.name in ("path", "name"):
-            return (AttrFilter(name="of-like", op="=", value=f"{kind}#{a.value}"),)
-    # Fall through: bare selector → of-kind match.
-    return (AttrFilter(name="of-kind", op="=", value=kind),)
-```
-
-Now register this shim as a post-parse pass. Check how `register_sandbox_sugar` is invoked — if the parser calls registered sugar transformers automatically, add the new shim to that pipeline. If not, modify `parse_view` to call `_synthesize_use_rules_from_legacy` after other shims.
-
-- [ ] **Step 5: Run the desugar tests.**
-
-Run: `python3 -m pytest tests/sandbox/test_desugar_use.py -v`
-Expected: all 4 pass.
-
-- [ ] **Step 6: Full suite — watch for regressions.**
-
-Run: `python3 -m pytest -q`
-Expected: all ~515 tests pass. If any v0.4 tests fail, the shim is adding unwanted `use` entries that break those tests' assumptions (e.g., a test asserting "exactly one entry in `operation`" will now see extras). Check failures; in most cases the fix is to update the test to allow-and-ignore `use` entries. Only fix real bugs (not cosmetic test changes) if they indicate a genuine semantic regression.
-
-- [ ] **Step 7: Commit.**
-
-```bash
-git add src/umwelt/sandbox/desugar.py tests/sandbox/test_desugar_use.py
-# Add any tests you had to update because of UseEntity appearing in operation entries:
-git add tests/...
-git commit -m "feat(desugar): synthesize use[of=...] rules from v0.4 legacy forms"
 ```
 
 ---
@@ -1922,11 +1701,12 @@ S3* bypasses normal reporting. Architecturally, the auditor cannot be
 inside the world it audits. Placing `@audit { ... }` outside the world
 hierarchy honors that constraint.
 
-## How legacy-shim preserves behavior
+## How the additive restructure preserves behavior
 
 v0.5 introduces the new axes as aliases, so `state` and `coordination`
-resolve to the same taxon. The physical split happens in v0.6+ when the
-shim is retired.
+resolve to the same taxon. World-axis permission properties remain
+registered unchanged, so v0.4 views keep working. A physical split of
+`state` into `coordination`/`control` is a v0.6+ concern.
 ```
 
 - [ ] **Step 2: Commit.**
@@ -1991,9 +1771,10 @@ Prepend to `CHANGELOG.md`:
 - **`use[of=...]` entity** — first-class permissioned projection of a
   world resource into the action axis. Carries `editable`, `visible`,
   `show`, `allow`, `deny`, `allow-pattern`, `deny-pattern`.
-- **Legacy-shim** synthesizes `use` rules from v0.4-shape
-  `file { editable: true; }` declarations, so v0.4 views compile
-  byte-identically through all three existing compilers.
+  **Additive to world-axis permissions** — `file { editable: true; }`
+  (world-axis, resource-nature) and `use[of=file#X] { editable: true; }`
+  (action-axis, access-grant) are semantically independent. A successful
+  write requires both. See the evaluation-framework claim A6.
 - **Cross-axis cascade specificity** — selectors that join more taxa-axes
   are more specific. `axis_count`-first tuple ordering.
 - **`@audit { ... }` at-rule** for defining observations and manifest
@@ -2006,9 +1787,10 @@ Prepend to `CHANGELOG.md`:
   `axis_count=1` is uniform across them.
 
 ### Notes
-- Compilers (nsjail, bwrap, lackpy-namespace) continue to read legacy
-  entities directly. v0.6 migrates them to read `use` entries
-  exclusively and retires the legacy-shim.
+- Compilers (nsjail, bwrap, lackpy-namespace) continue to read world-axis
+  entities directly, preserving byte-identical output. v0.6 work decides
+  which compilers should read the action-axis (language-altitude tool
+  gating) versus the world-axis (OS-altitude mount-level enforcement).
 - Kibitzer-hooks compiler and the security pass are deferred to v0.6
   and v0.7 respectively.
 ```
@@ -2070,6 +1852,7 @@ Claim-ledger coverage:
 | A2 | 7 | tests/cascade/test_cross_axis_specificity.py |
 | A3 | 7 | tests/cascade/test_cross_axis_specificity.py |
 | A5 | 2 | tests/sandbox/test_use_entity.py |
+| A6 (world-axis ≠ action-axis) | 2, 6 | tests/sandbox/test_use_entity.py (action-axis registration) + existing world-axis tests + tests/sandbox/test_v04_byte_compat.py (compilers still read world-axis) |
 | B1 (continuity) | 6 | tests/sandbox/test_v04_byte_compat.py |
 | C3 (continuity) | 6 | tests/sandbox/test_v04_byte_compat.py |
 | G1 | 1, 9, 10 | tests/sandbox/test_vsm_taxa.py, test_principal.py, test_audit_taxon.py |

--- a/docs/superpowers/plans/2026-04-14-umwelt-v05.md
+++ b/docs/superpowers/plans/2026-04-14-umwelt-v05.md
@@ -12,6 +12,37 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md`.
 
+**Evaluation framework:** `docs/vision/evaluation-framework.md`. Each task in this plan maps to one or more claims (A1, B1, …) from the framework's claim ledger. Claim tags appear in task headings and should appear in test docstrings.
+
+---
+
+## Claim coverage of this milestone
+
+v0.5 strengthens or introduces evidence for these claims:
+
+| Claim | How v0.5 touches it | Tasks |
+|---|---|---|
+| A1 (resolver determinism) | New hypothesis-based determinism test (Task 7.5 — added below). | 7, **7.5 NEW** |
+| A2 (cascade well-ordered) | Cross-axis specificity retains document-order tiebreaker; new tests prove no cycles across axis-count boundary. | 7 |
+| A3 (cross-axis soundness) | **Introduced.** Axis_count-first tuple; test that cross-axis rules beat single-axis rules. | 7 |
+| A5 (property comparison semantics) | `use` properties (editable, visible, allow, deny, allow-pattern, deny-pattern, show) register with their comparison fields. | 2 |
+| B1 (enforcement fidelity — continuity) | Byte-compat snapshot tests verify compiler output stable across the restructure. Does NOT prove initial correctness. | 6 |
+| C3 (proof-tree stability) | Implicit in snapshot stability; explicit proof trees are v0.9+. | 6 |
+| H1 (integrator-without-fork) | lackpy-namespace compiler unchanged; bwrap/nsjail unchanged. All three compilers still work through the restructure. | 6 |
+| H3 (no wrapper dependency) | `grep -r nsjail_python src/umwelt` check added to Task 13's pre-release verification. | 13 |
+| I1 (diff completeness) | Existing diff utility unchanged; byte-compat indirectly exercises it. | 6 |
+| I3 (alias transparency) | **Established by Task 0.** Completed commit `ffe4b54` added alias resolution across registry submodules. | 0 (done) |
+
+Claims **not** touched by v0.5 and therefore remain in their pre-v0.5 status:
+- B2, B3, B4 (altitude stacking, native-validator acceptance, out-of-altitude rejection) — require the round-trip harness slated for v0.8/v0.9.
+- C1, C2 (proof-tree traceability, audit widening accuracy) — the audit command improvements are v0.7.
+- D1–D3 (ratchet) — v1.1+.
+- E1–E3 (usability) — user studies scheduled for v0.9.
+- F1–F3 (agent alignment) — agent harness v0.8+.
+- G1–G3 (theoretical fidelity) — paper-grade, aspirational.
+
+**Net effect on the current-state table in the evaluation framework:** A1 moves from "Open" to "Verified (property-test)." A3 moves from "Not evaluated" to "Verified (unit tests)." I3 stays Verified. No Tier-0 claim is newly falsified.
+
 ---
 
 ## File structure
@@ -84,7 +115,7 @@ Slices A, B, C can be parallelized. D depends on A. E depends on all.
 
 ## Slice A — Taxa aliases
 
-### Task 0: Registry taxon-alias support
+### Task 0: Registry taxon-alias support  [I3]
 
 **Files:**
 - Modify: `src/umwelt/registry/taxa.py`
@@ -212,7 +243,7 @@ git commit -m "feat(registry): taxon-alias support for VSM restructure"
 
 ---
 
-### Task 1: Register VSM taxa as aliases of existing taxa
+### Task 1: Register VSM taxa as aliases of existing taxa  [G1, I3]
 
 **Files:**
 - Modify: `src/umwelt/sandbox/vocabulary.py`
@@ -336,7 +367,7 @@ git commit -m "feat(sandbox): register VSM taxa as aliases (operation/coordinati
 
 ## Slice B — `use` entity
 
-### Task 2: Register `use` entity + permission properties
+### Task 2: Register `use` entity + permission properties  [A5]
 
 **Files:**
 - Modify: `src/umwelt/sandbox/entities.py` (add `UseEntity` dataclass)
@@ -1034,7 +1065,7 @@ git commit -m "feat(desugar): synthesize use[of=...] rules from v0.4 legacy form
 
 ---
 
-### Task 6: Byte-compatibility snapshot tests
+### Task 6: Byte-compatibility snapshot tests  [B1-continuity, C3, I1]
 
 **Files:**
 - Create: `tests/sandbox/test_v04_byte_compat.py`
@@ -1134,7 +1165,7 @@ git commit -m "test(sandbox): snapshot fixtures + compilers for byte-compat guar
 
 ## Slice C — Cross-axis cascade specificity
 
-### Task 7: Extend Specificity with axis_count and per-axis counts
+### Task 7: Extend Specificity with axis_count and per-axis counts  [A2, A3]
 
 **Files:**
 - Modify: `src/umwelt/selector/specificity.py`
@@ -1362,6 +1393,85 @@ git commit -m "feat(selector): cross-axis cascade specificity with axis_count pr
 
 ---
 
+### Task 7.5: Resolver determinism property test  [A1]
+
+**Files:**
+- Create: `tests/cascade/test_determinism.py`
+
+A1 is Tier-0. Before v0.5 ships, add a property-based test that resolves each fixture twice and asserts identity. Uses hypothesis if available, else a deterministic N-run check.
+
+- [ ] **Step 1: Check whether hypothesis is installed.**
+
+Run: `python3 -c "import hypothesis"` — if ImportError, fall back to fixed-corpus repeat testing.
+
+- [ ] **Step 2: Write the test.**
+
+```python
+"""Verifies claim A1 (resolver determinism): resolving the same view twice
+produces identical ResolvedView.
+
+Tier 0 — foundational. See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from umwelt.parser import parse_view_file
+from umwelt.cascade.resolver import resolve
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "src" / "umwelt" / "_fixtures"
+
+
+def _resolved_signature(rv):
+    """A stable, hashable signature of a ResolvedView for comparison."""
+    sig = []
+    for taxon in sorted(rv.taxa()):
+        for entity, props in rv.entries(taxon):
+            sig.append((taxon, type(entity).__name__, tuple(sorted(props.items()))))
+    return tuple(sig)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted(FIXTURE_DIR.glob("*.umw")),
+    ids=lambda p: p.name,
+)
+def test_resolve_is_deterministic(fixture):
+    view = parse_view_file(fixture)
+    rv1 = resolve(view)
+    rv2 = resolve(view)
+    assert _resolved_signature(rv1) == _resolved_signature(rv2)
+
+
+def test_resolve_deterministic_across_many_runs():
+    """Run a single fixture 50 times, assert all signatures match."""
+    fixture = FIXTURE_DIR / "lackpy-delegate.umw"
+    if not fixture.exists():
+        # Fallback: pick any fixture.
+        fixtures = list(FIXTURE_DIR.glob("*.umw"))
+        if not fixtures:
+            pytest.skip("no fixtures to test")
+        fixture = fixtures[0]
+    view = parse_view_file(fixture)
+    signatures = {_resolved_signature(resolve(view)) for _ in range(50)}
+    assert len(signatures) == 1, f"resolver non-deterministic: {len(signatures)} distinct results"
+```
+
+- [ ] **Step 3: Run.**
+
+Run: `python3 -m pytest tests/cascade/test_determinism.py -v`
+Expected: all pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/cascade/test_determinism.py
+git commit -m "test(cascade): verify resolver determinism (claim A1)"
+```
+
+---
+
 ### Task 8: Cross-axis ordering regression tests
 
 Already covered by Task 7 tests. Skip — this slot is reserved for any additional edge cases discovered during implementation.
@@ -1370,7 +1480,7 @@ Already covered by Task 7 tests. Skip — this slot is reserved for any addition
 
 ## Slice D — Principal + audit taxa
 
-### Task 9: Register `principal` taxon + entity + matcher
+### Task 9: Register `principal` taxon + entity + matcher  [G1]
 
 **Files:**
 - Modify: `src/umwelt/sandbox/entities.py` (add PrincipalEntity)
@@ -1528,7 +1638,7 @@ git commit -m "feat(sandbox): register principal taxon + PrincipalMatcher"
 
 ---
 
-### Task 10: Register `audit` taxon + parse `@audit { ... }` at-rule
+### Task 10: Register `audit` taxon + parse `@audit { ... }` at-rule  [G1, C1-scaffold]
 
 **Files:**
 - Modify: `src/umwelt/ast.py` (add AuditBlock or reuse RuleBlock)
@@ -1857,7 +1967,9 @@ git commit -m "docs(guide): regenerate entity reference for v0.5 (use, principal
 
 ---
 
-### Task 13: CHANGELOG, version bump, tag v0.5.0
+### Task 13: CHANGELOG, version bump, tag v0.5.0  [H3 verification]
+
+Include a step that greps `src/umwelt/` for imports of enforcement-tool Python wrappers (nsjail_python, etc.) as an H3 gate.
 
 **Files:**
 - Modify: `CHANGELOG.md`
@@ -1949,6 +2061,24 @@ Skim the spec and confirm coverage:
 | §9 vision-doc updates | Tasks 11, 12 |
 | §10 vertical slices | Task 0 = A; 2-6 = B; 7-8 = C; 9-10 = D; 11-13 = E |
 | §12 risks — shim drift | Task 6 snapshots guard against drift |
+
+Claim-ledger coverage:
+
+| Claim | Task | Test file |
+|---|---|---|
+| A1 | 7.5 | tests/cascade/test_determinism.py |
+| A2 | 7 | tests/cascade/test_cross_axis_specificity.py |
+| A3 | 7 | tests/cascade/test_cross_axis_specificity.py |
+| A5 | 2 | tests/sandbox/test_use_entity.py |
+| B1 (continuity) | 6 | tests/sandbox/test_v04_byte_compat.py |
+| C3 (continuity) | 6 | tests/sandbox/test_v04_byte_compat.py |
+| G1 | 1, 9, 10 | tests/sandbox/test_vsm_taxa.py, test_principal.py, test_audit_taxon.py |
+| H1 | 6 | tests/sandbox/test_v04_byte_compat.py |
+| H3 | 13 | grep in release checklist |
+| I1 | 6 | tests/sandbox/test_v04_byte_compat.py |
+| I3 | 0 (DONE) | tests/registry/test_taxon_aliases.py |
+
+Every test created in this plan has a docstring that cites its claim ID.
 
 Placeholder scan: no TBDs, no "write tests for the above" without code, no "similar to Task N" references. Every code step has exact code.
 

--- a/docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md
+++ b/docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md
@@ -37,12 +37,12 @@ This milestone restructures umwelt's taxa to these axes, so subsequent compiler 
 ### Deliverables
 
 1. **VSM-aligned taxa** (§2) replacing the current five-taxon model.
-2. **`use[of=...]` primitive** (§3) — the action-axis permissioned projection of a world resource. Permissions (`editable`, `visible`, `allow`) move from world entities onto `use`.
+2. **`use[of=...]` primitive** (§3) — the action-axis permissioned projection of a world resource. **Additive, not replacing** — world-axis permissions on resources (`file { editable: true; }`) and action-axis permissions on uses (`use[of=file#X] { editable: true; }`) are semantically independent (see §3a).
 3. **`audit` placed outside the world** (§4) — architectural, not conventional.
 4. **Mode as a class, not an ID** (§5) — `mode.implement`, compositional across worlds.
 5. **Cross-axis cascade** (§6) — specificity counts contributions from every axis a selector names.
-6. **Migration path** (§9) — every current entity mapped to its new axis; existing views parse under an automatic legacy-shim.
-7. **v0.5 vertical slices** (§10) — five slices, each buildable independently, each leaving the test suite green.
+6. **Migration path** (§9) — every current entity mapped to its new axis; existing views work unchanged because world-axis properties remain.
+7. **v0.5 vertical slices** (§10) — each buildable independently, each leaving the test suite green.
 
 ### Explicit non-goals for v0.5
 
@@ -136,25 +136,45 @@ mode.implement use[of-like="file#/src/**/*.py"] { editable: true; }
 inferencer#opus tool[name="Edit"] use[of="file#/src/auth.py"] { editable: true; }
 ```
 
-### Properties that move from world entities onto `use`
+### §3a — World-axis permissions vs action-axis permissions
 
-| Property | Was on | Now on |
+**Critical distinction:** these are two independent concepts, not two surface syntaxes for the same thing.
+
+Think of it as the OS-level distinction between a **read-only mount** and a **user's file-permission bits**:
+
+- A file mounted read-only → no user can write regardless of their permissions. That's a **world-axis** property of the resource itself.
+- A user without write permission on a mounted-writable file → this user cannot write, others might. That's an **action-axis** property of an access path.
+
+A successful write requires **both**: the resource must be editable (world-axis) AND the delegate must hold an editable use (action-axis).
+
+#### Both axes carry permission properties — with different meanings
+
+| Property | World axis (property-of-resource) | Action axis (property-of-access) |
 |---|---|---|
-| `editable` | `file`, `dir` | `use` |
-| `visible` | `file`, `dir` | `use` |
-| `show` | `file` | `use` |
-| `allow` (for tools) | `tool` | `use` (for resource-scoped permits); stays on `tool` for tool-level enablement |
-| `deny` | `network`, `tool` | `use` for resource-scoped; stays on operation for blanket denies |
-| `allow-pattern`, `deny-pattern` | `tool` | `use` when scoped to a resource; stays on `tool` for blanket patterns |
+| `editable` | `file.editable` / `dir.editable` — "the resource itself is editable (not read-only at mount/inode level)" | `use.editable` — "this access path grants edit rights" |
+| `visible` | `file.visible` / `dir.visible` — "the resource is visible in the workspace" | `use.visible` — "this access path reveals the resource" |
+| `show` | `file.show` — "what projection of the resource is materialized (body / outline / signature)" | `use.show` — "what the delegate sees through this access" |
+| `allow` / `deny` | `tool.allow` / `network.deny` — "this capability is available in the world" | `use.allow` / `use.deny` — "the delegate can invoke this capability through this access" |
+| `allow-pattern` / `deny-pattern` | `tool.allow-pattern` — "what invocations exist" | `use.allow-pattern` — "what invocations this access path permits" |
 
-### Properties that stay on world entities
+Both axes remain registered in v0.5. Both are first-class. Neither desugars to the other.
 
-| Property | Entity | Why |
+#### Compiler altitude mapping (no change in v0.5)
+
+- **nsjail** (OS altitude) reads world-axis properties. Mount-level rw/ro for `file.editable`, `mount.readonly`. This is correct — nsjail enforces resource-nature, not per-delegate access.
+- **bwrap** (OS altitude) same.
+- **lackpy-namespace** (language altitude) will read action-axis properties in v0.6+. Tool-level `use.allow` gates what the delegate can invoke. This is correct — language altitude enforces per-delegate access.
+- **kibitzer-hooks** (semantic altitude, v0.6) mixes: path-writability per mode is world-axis (`file.editable` + mode scope); per-tool gating is action-axis (`use[of=tool#X].allow`).
+
+#### Properties that are exclusively on one axis
+
+| Property | Entity | Why exclusive |
 |---|---|---|
-| `path`, `name`, `size`, `language` | `file` | Existence / identity, not permission. |
-| `source`, `type`, `readonly` (mount-level) | `mount` | Host-level mount config, not per-use. |
-| `host`, `port`, `kind` | `network` | Endpoint identity. |
-| `limit` | `resource` | Absolute world-level cap, distinct from per-use rate limits. |
+| `path`, `name`, `size`, `language` | `file` (world) | Identity, not permission. |
+| `source`, `type`, `readonly` (mount-level) | `mount` (world) | Host-level mount config. |
+| `host`, `port`, `kind` | `network` (world) | Endpoint identity. |
+| `limit` | `resource` (world) | Absolute world-level cap. |
+| `of`, `of-kind`, `of-like` | `use` (action) | Link back into the world axis. |
 
 ### The `of=` attribute
 
@@ -172,13 +192,20 @@ Parsing `of=` produces a nested selector that evaluates against the same world e
 
 ### Defaults
 
-A view with no `use` rules grants **no uses** — the delegate has no access. This is fail-closed, matching the existing umwelt default. The common pattern is a wide-open default and narrow restrictions:
+The default behavior depends on which axis is being queried. A view without any `use` rules means no action-axis permissions are declared; the world-axis permissions on `file`, `tool`, etc. still apply through their own cascade. The full-access decision conjoins both axes.
+
+Views can mix both styles idiomatically:
 
 ```css
-use { visible: true; editable: false; }                  /* all uses: read-only */
-mode.implement use[of-like="file#/src"] { editable: true; } /* implement mode: src writable */
-mode.test use[of-like="file#/tests"] { editable: true; }    /* test mode: tests writable */
+/* world-axis: this file is read-only at the resource level */
+file[path="/etc/secrets.conf"] { editable: false; visible: false; }
+
+/* action-axis: the delegate's access path has these permissions */
+use { visible: true; editable: false; }                           /* default deny-edit */
+mode.implement use[of-like="file#/src"] { editable: true; }       /* mode grants edit on src */
 ```
+
+Both declarations are active. A write to `/etc/secrets.conf` fails at the world-axis check even if the mode's use rule would otherwise grant edit.
 
 ---
 
@@ -338,46 +365,40 @@ Full principal modeling (multiple principals, delegation lineage, capability-inh
 
 ## 9. Migration path
 
-This is a semantic restructuring, not a format break. Existing v0.4 views parse and compile to byte-identical output through a **legacy-shim** applied at parse time.
+This is an **additive restructuring**. World-axis properties (`file.editable`, `tool.allow`, etc.) remain registered and functional. The action-axis is new and independent. No legacy-shim is needed — existing v0.4 views keep working because their rules still populate the world-axis entities and properties they always did.
 
-### Legacy-shim rules
+### What changes
 
-| v0.4 form | v0.5 equivalent | Shim action |
-|---|---|---|
-| `file#foo { editable: true; }` | `use[of="file#foo"] { editable: true; }` | Desugar: permission properties on `file`/`dir`/`tool` → synthesized `use` rule. |
-| `tool[name="Bash"] { allow: false; }` | `use[of="tool#Bash"] { allow: false; }` | Same pattern for tool permissions. |
-| `@world { ... }` | `world { ... }` | Existing at-rule remains valid. |
-| `state.hook[event=...]` | `coordination hook[event=...]` | Taxon renamed; selector tagged to new axis. |
-| `state.budget`, `state.job` | `control budget`, `control job` | Same. |
-| `actor.inferencer` | `intelligence inferencer` | Same. |
-| `actor.executor` | `operation executor` | Same. |
+- New taxa (`principal`, `audit`) and new taxon-aliases (`operation`, `coordination`, `control`, `intelligence`) are registered.
+- New `use` entity registered in the operation axis. `use[of=...]` selectors produce `UseEntity` instances during resolve.
+- Cross-axis cascade specificity (§6) widens the specificity tuple. Single-axis v0.4 rules retain identical ordering (`axis_count=1` for all of them).
 
-The shim runs unconditionally on parse. Users see no behavioral change; the AST is uniformly in the new shape post-parse.
+### What stays the same
+
+- Every world-axis property registered in v0.4 (`file.editable`, `tool.allow`, `network.deny`, `mount.readonly`, etc.) remains registered and carries its same meaning.
+- `file { editable: true; }` is a first-class way to express resource-level permission and is not desugared.
+- All three compilers (nsjail, bwrap, lackpy-namespace) continue reading world-axis properties and produce byte-identical output for every v0.4 fixture. Task 6 in the plan adds snapshot tests to guard this.
 
 ### Vision-doc updates
 
-`docs/vision/entity-model.md` replaced in full. v0.4 version committed as `entity-model-v04.md` for history.
-`docs/guide/entity-reference.md` regenerated from the new registry.
-`docs/vision/notes/selector-semantics.md` updated with the cross-axis specificity definition.
+`docs/vision/entity-model.md` updated (not replaced) to document both axes.
+`docs/guide/entity-reference.md` regenerated with the new `use`, `principal`, `observation`, `manifest` entries.
 A new `docs/vision/notes/vsm-alignment.md` captures the Beer mapping and the S3↔S4 inversion justification.
+`docs/vision/notes/logic-semantics.md` clarifies that world-axis and action-axis permissions are independent predicates.
 
-### Compiler compatibility
+### Compiler compatibility (no v0.5 changes)
 
-All three existing compilers (nsjail, bwrap, lackpy-namespace) receive the new-shape `ResolvedView` and emit byte-identical output. Test snapshots guard this. The changes are:
-
-- nsjail: reads `use[of-kind=file]` instead of `file` directly for mount generation; reads `use[of-kind=network]` for network deny.
-- bwrap: same pattern.
-- lackpy-namespace: reads `use[of-kind=tool]` for allow/deny; reads `tool` directly for `max-level` (which is a tool-level property, not per-use).
+In v0.5, all three existing compilers continue reading the same entity types and properties they did in v0.4. The `use` entity is populated but unread. v0.6 compiler work will decide which axes each compiler should read from (see §3a altitude mapping).
 
 ### Test migration
 
-The existing 483-test suite passes unchanged on v0.4-shape views. A new `tests/vsm/` directory adds ~40 tests covering:
+The existing 490-test suite passes unchanged (v0.4-shape rules still populate world-axis entries via existing matchers). New tests under `tests/registry/`, `tests/sandbox/`, and `tests/cascade/` cover:
 
-- Use-based permission cascade.
+- Taxon-alias transparency.
+- Use-based permission cascade (action-axis).
 - Cross-axis specificity ordering.
-- Mode-as-class selector matching.
-- Audit at-rule parsing.
-- Legacy-shim byte-compatibility for every fixture in `_fixtures/`.
+- Principal / audit taxa parse and resolve.
+- Byte-compat snapshots against v0.4 fixtures.
 
 ---
 
@@ -385,19 +406,18 @@ The existing 483-test suite passes unchanged on v0.4-shape views. A new `tests/v
 
 v0.5 decomposes into five slices, each a buildable, testable, shippable unit. Each leaves the suite green.
 
-### Slice A — Taxa registration and legacy-shim (land first)
+### Slice A — Taxa registration (land first)
 
-- Rename taxa in the registry: `capability` → split into `operation` / `world` (for exec); `state` → split into `coordination` / `control` / `audit`; `actor` → split into `principal` / `intelligence` / `operation`.
-- Register `use` entity under a new *action-link* meta-taxon (a taxon whose entities link across axes rather than living on one).
-- Install the legacy-shim in the parser post-pass.
-- All existing tests continue to pass because shim output is byte-identical.
+- Register new VSM taxon aliases (`operation`, `coordination`, `control`, `intelligence`) alongside existing `capability`/`state`/`actor`; aliases are transparent across all registry submodules.
+- Register `use` entity under the `operation` taxon (world entities are linked via the `of=` attribute, not by re-parenting).
+- All existing tests continue to pass because world-axis registrations are untouched.
 
 ### Slice B — `use[of=...]` as first-class entity
 
 - Register `use` with properties `editable`, `visible`, `show`, `allow`, `deny`, `allow-pattern`, `deny-pattern`.
 - Implement `of=` attribute parsing (selector-valued, nested match).
 - Implement `of-like=` and `of-kind=` forms.
-- Update nsjail and bwrap compilers to read `use` entries instead of (or in addition to) world entities directly.
+- No compiler changes in v0.5 — they continue reading world-axis as before.
 - Snapshot tests confirm byte-identical output for all v0.4 fixtures.
 
 ### Slice C — Cross-axis cascade
@@ -447,7 +467,7 @@ Sequence: A → B → C → D → E. A-B-C can be parallelized across sub-agents
 
 | Risk | Mitigation |
 |---|---|
-| Legacy-shim drift — compilers start relying on shim side-effects rather than the new shape. | Shim runs only at parse; compilers always see new-shape AST. Snapshot tests guard output. After v0.6, the shim becomes opt-in and emits deprecation warnings. |
+| Ambiguity between world-axis and action-axis permissions confuses authors. | §3a explicitly documents the distinction with the mount-vs-user-permission analogy. Entity-reference doc cross-references both axes. Error messages name the axis where a property was declared. |
 | Cross-axis specificity surprises existing view authors. | `axis_count=1` for every legacy rule → no reordering. Document the rule prominently. |
 | `use[of=...]` nested selector parsing adds parser complexity. | Reuse the existing selector parser; `of=` value is parsed by re-entering the same parser. Small, localized change. |
 | The VSM framing adds cognitive load for users who don't know Beer. | Docs lead with concrete examples first, theory second. VSM becomes an organizing principle behind the scenes, not a prerequisite for users. |

--- a/docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md
+++ b/docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md
@@ -1,0 +1,474 @@
+# umwelt v0.5 Design — VSM-Aligned DOM Restructure
+
+*Pre-implementation design for the v0.5 milestone. Replaces the current five-taxon model (`world`/`capability`/`state`/`actor`/`policy`) with a VSM-aligned (Stafford Beer) multi-axis DOM, introduces `use[of=...]` as the action-axis permission primitive, defines cross-axis cascade specificity, and kicks the kibitzer-hooks compiler into v0.6 where it slots naturally into the restructured taxa.*
+
+**Status:** draft, pre-implementation.
+**Date:** 2026-04-13.
+**Depends on:** `docs/vision/entity-model.md`, `docs/vision/notes/selector-semantics.md`, the Ma series on the specified-band Harness, Beer's *Brain of the Firm* / *Heart of Enterprise* (VSM).
+**Prerequisite:** v0.4.0 shipped (nsjail + bwrap + lackpy-namespace compilers, diff utility, PyPI-ready).
+**Next step after approval:** invoke `writing-plans` to produce a concrete v0.5 implementation plan sequenced by the vertical slices in §10.
+
+---
+
+## 1. Motivation and scope
+
+The current five-taxon model (`world`, `capability`, `state`, `actor`, `policy`) smears responsibilities across concepts. The `state` taxon in particular wears three hats — hook (coordination), budget/job (control), observation (intelligence) — which is why adding kibitzer's *mode* concept has no clean home: `state` is three different systems in a trenchcoat.
+
+Beer's Viable System Model names the systems we're actually working with:
+
+- **S1 Operations** — the doing parts.
+- **S2 Coordination** — anti-oscillation. The Harness.
+- **S3 Control** — "inside and now." Resource allocation to S1 in the current moment.
+- **S3\*** — the audit channel. Bypasses normal reporting.
+- **S4 Intelligence** — "outside and then." Environmental scanning.
+- **S5 Identity** — purpose; resolves S3↔S4 tension.
+
+Applied to delegation:
+
+- S1 is tools and effects.
+- S2 is the Harness (claude-code, lackpy, kibitzer).
+- S3 is the mode / controller / budget — kibitzer's `[modes.*]` config is exactly S3.
+- S3\* is blq / ratchet-detect / strace — observation from outside the delegate's world.
+- S4 is the inferencer itself.
+- S5 is the principal — the human or outer agent who commissioned the delegate.
+
+This milestone restructures umwelt's taxa to these axes, so subsequent compiler work (kibitzer-hooks in v0.6, observation compilers in v0.7, etc.) slots in without torturing the vocabulary.
+
+### Deliverables
+
+1. **VSM-aligned taxa** (§2) replacing the current five-taxon model.
+2. **`use[of=...]` primitive** (§3) — the action-axis permissioned projection of a world resource. Permissions (`editable`, `visible`, `allow`) move from world entities onto `use`.
+3. **`audit` placed outside the world** (§4) — architectural, not conventional.
+4. **Mode as a class, not an ID** (§5) — `mode.implement`, compositional across worlds.
+5. **Cross-axis cascade** (§6) — specificity counts contributions from every axis a selector names.
+6. **Migration path** (§9) — every current entity mapped to its new axis; existing views parse under an automatic legacy-shim.
+7. **v0.5 vertical slices** (§10) — five slices, each buildable independently, each leaving the test suite green.
+
+### Explicit non-goals for v0.5
+
+- **The kibitzer-hooks compiler.** Moved to v0.6. v0.5 creates the taxa that make the compiler trivial; v0.6 actually ships it.
+- **The S3\* audit compiler.** v0.7+.
+- **Full S5 / principal modeling.** v0.5 adds the `principal` taxon root and a single `principal` entity with name + intent fields; richer principal modeling (cross-delegate lineage, grade lattice) is v1.1+.
+- **The security pass and public API freeze.** Originally bundled into v0.5 in the roadmap; shifted to v0.6 / v0.7 because the restructure is already a full milestone on its own. v0.5 preserves all existing compiler outputs bit-for-bit; the security pass needs to sit on the post-restructure API.
+- **Cross-axis cascade across all combinators.** v0.5 implements cross-axis specificity for descendant combinators; sibling combinators (`+`, `~`) remain v1.1+ per existing deferrals.
+- **`:has()` implementation.** The design uses `:has()` semantics in examples (world:has(file#...)) but v0.5 parses-but-doesn't-evaluate; evaluation is v1.1.
+
+---
+
+## 2. The VSM-aligned taxa
+
+Current taxa → new taxa:
+
+| Current | New | System | Rationale |
+|---|---|---|---|
+| `world` | `world` | S0 (environment) | Unchanged name; narrowed — holds *existence* of resources only. |
+| `capability` (tool, kit) | `operation` | S1 | `tool`, `effect`, `kit` live here; `kit` remains but classifies as S1 when used as a bundle-of-ops. |
+| `capability` (exec) | `world` | S0 | `exec` is a world-side binding (a binary that exists in the environment). Moves to world. |
+| `state.hook` | `coordination` | S2 | Hooks are the coordination primitive by definition. |
+| `state.budget`, `state.job`, *(new)* `mode` | `control` | S3 | Current-moment regulation. `mode` lands here cleanly. |
+| *(new)* `observation`, `state.manifest` | `audit` | S3\* | Cross-cut observer. Outside the world. |
+| `actor.inferencer` | `intelligence` | S4 | The reasoner. |
+| `actor.executor` | `operation` | S1 | Executors are how operations get dispatched. |
+| `actor.principal` | `principal` | S5 | Promoted to its own top-level taxon. |
+| `policy` | *removed* | — | Policy isn't a taxon; policy is what the whole view *is*. |
+
+The seven new taxa:
+
+1. **`principal`** — S5. Commissioning authority. One principal per view (in v1).
+2. **`world`** — S0. Environment. Holds files, dirs, mounts, network, env, exec, resources.
+3. **`audit`** — S3\*. Outside the world. Observation entries, manifest, ratchet signals.
+4. **`control`** — S3. Mode, controller, budget, job.
+5. **`coordination`** — S2. Hook, scheduler.
+6. **`intelligence`** — S4. Inferencer.
+7. **`operation`** — S1. Tool, effect, kit, executor.
+
+### The outside-in authority chain
+
+```
+audit                                  ← outside everything (S3*)
+  │   observes all below without being subject to them
+  │
+  ▼
+principal         S5    commissioning identity
+  │
+  ▼
+world             S0    environment chosen for the delegate
+  │
+  ▼
+control           S3    current-moment regulation (mode, budget, controller)
+  │
+  ▼
+coordination      S2    the harness — arbitrates the triad below
+  │
+  ├─ intelligence S4    the reasoner
+  ├─ operation    S1    the action (tool, effect)
+  │                     and uses cross-link the action axis to world resources:
+  │                         use[of="file#..."]
+  │                         use[of="network#..."]
+  │                         use[of="exec#..."]
+```
+
+Authority flows inward. Operations flow upward (reports go through audit; S2 reports to S3; S3 reports to S5; audit sees everything directly).
+
+The S3↔S4 inversion relative to Beer is deliberate and worth naming: in bounded delegation the regulator dominates the regulated. Coordination and control *constrain* the inferencer; the inferencer doesn't resolve tension with S3 as a peer. This is the architectural move that makes the specified band coherent — the delegate is a system whose own S4 is bounded by an externally-imposed S3.
+
+---
+
+## 3. `use[of=...]` — the action-axis permission primitive
+
+The core insight: **permissions don't live on resources, they live on uses of resources.**
+
+A `file` in world just *is*. Whether a delegate can edit it depends on whether the delegate holds an editable `use` of it. Same file, different modes, different permissions — the file doesn't change; the uses do. This matches OS capability theory (process holds fd, permissions on the fd, not the inode) and HTTP (resource has a URI; permissions on the request, not the URI).
+
+### Syntax
+
+```css
+/* world axis — existence only */
+file#/src/auth.py           { language: python; size: 2048; }
+exec#bash                   { path: "/bin/bash"; }
+
+/* action axis — permissions via use */
+use[of="file#/src/auth.py"] { editable: true; visible: true; show: outline; }
+use[of="exec#bash"]         { allow: true; }
+
+/* cross-axis: specific use in a specific context */
+mode.implement use[of-like="file#/src/**/*.py"] { editable: true; }
+inferencer#opus tool[name="Edit"] use[of="file#/src/auth.py"] { editable: true; }
+```
+
+### Properties that move from world entities onto `use`
+
+| Property | Was on | Now on |
+|---|---|---|
+| `editable` | `file`, `dir` | `use` |
+| `visible` | `file`, `dir` | `use` |
+| `show` | `file` | `use` |
+| `allow` (for tools) | `tool` | `use` (for resource-scoped permits); stays on `tool` for tool-level enablement |
+| `deny` | `network`, `tool` | `use` for resource-scoped; stays on operation for blanket denies |
+| `allow-pattern`, `deny-pattern` | `tool` | `use` when scoped to a resource; stays on `tool` for blanket patterns |
+
+### Properties that stay on world entities
+
+| Property | Entity | Why |
+|---|---|---|
+| `path`, `name`, `size`, `language` | `file` | Existence / identity, not permission. |
+| `source`, `type`, `readonly` (mount-level) | `mount` | Host-level mount config, not per-use. |
+| `host`, `port`, `kind` | `network` | Endpoint identity. |
+| `limit` | `resource` | Absolute world-level cap, distinct from per-use rate limits. |
+
+### The `of=` attribute
+
+`of=` takes a selector string pointing into the world axis. Supported forms:
+
+```css
+use[of="file#/src/auth.py"]              /* exact file by ID */
+use[of="file:glob('src/**/*.py')"]       /* glob within of= */
+use[of-like="file#/src"]                 /* prefix-like match */
+use[of-kind="file"]                      /* kind-scoped: all file uses */
+use[of-kind="network"]                   /* all network uses */
+```
+
+Parsing `of=` produces a nested selector that evaluates against the same world entities the outer view describes. `use[of="file#/foo"]` is *not* cross-reference resolution; it's a nested selector match against world-axis entities.
+
+### Defaults
+
+A view with no `use` rules grants **no uses** — the delegate has no access. This is fail-closed, matching the existing umwelt default. The common pattern is a wide-open default and narrow restrictions:
+
+```css
+use { visible: true; editable: false; }                  /* all uses: read-only */
+mode.implement use[of-like="file#/src"] { editable: true; } /* implement mode: src writable */
+mode.test use[of-like="file#/tests"] { editable: true; }    /* test mode: tests writable */
+```
+
+---
+
+## 4. `audit` outside the world
+
+Beer's S3\* channel bypasses normal reporting — the auditor sees S1 directly without going through S2/S3. If that's the architectural claim, `audit` cannot be *inside* the world it audits.
+
+Structurally:
+
+```css
+@audit {
+  observation#coach { source: "kibitzer"; }
+  observation#ratchet { source: "ratchet-detect"; }
+  manifest#current { path: ".umwelt/manifest.json"; }
+}
+
+principal#Teague { intent: "code review"; }
+world#sandbox-123 { /* ... */ }
+```
+
+`@audit { ... }` is an at-rule scope. Entries inside it:
+
+- Are parsed into the view AST as audit-axis nodes.
+- Are not subject to world-scoped context qualifiers.
+- Can be selected from outside world selectors: `audit observation#coach { enabled: true; }` matches regardless of which world is active.
+
+In v0.5 the audit taxon is registered and the at-rule parses, but no audit compiler ships. The audit entries are the contract for v0.7's observation compiler.
+
+---
+
+## 5. Mode as a class, not an ID
+
+CSS semantics:
+
+- `#foo` — ID selector. Unique per document. Specificity 100.
+- `.foo` — class selector. Repeatable, compositional. Specificity 10.
+
+Modes are compositional (an actor can be in `.testing.strict`), repeat across worlds (same `.testing` class applies in dev and staging), and don't uniquely identify a document element. They're classes.
+
+```css
+mode.testing                { /* every mode with the testing class */ }
+mode.testing.strict         { /* narrower: both classes present */ }
+world#dev mode.testing      { /* testing mode, dev world context */ }
+```
+
+This lets a single view declare multiple modes that can stack:
+
+```css
+mode.implement { /* base implement mode */ }
+mode.implement.tdd { /* implement + tdd-flavor */ }
+mode.explore { writable: "none"; }
+```
+
+At runtime, the active mode-set determines which rules apply. The kibitzer-hooks compiler (v0.6) will emit one `[modes.<name>]` block per distinct class it finds, with permissions conjoined via their class intersection.
+
+---
+
+## 6. Cross-axis cascade
+
+Selector specificity in CSS is `(ids, classes+attrs+pseudos, elements)`. The current umwelt cascade accumulates specificity within a selector but the selector's structure is (implicitly) single-axis.
+
+With axes explicit, specificity needs to count contributions from each axis a selector touches:
+
+```
+specificity = (
+  axis_count,           # how many axes the selector names
+  principal_ids,
+  world_ids + world_classes + world_attrs,
+  control_ids + control_classes + control_attrs,
+  coordination_ids + coordination_classes + coordination_attrs,
+  intelligence_ids + intelligence_classes + intelligence_attrs,
+  operation_ids + operation_classes + operation_attrs,
+  audit_ids + audit_classes + audit_attrs,
+  use_ids + use_attrs,
+)
+```
+
+Tuple comparison left-to-right. `axis_count` first means "a selector that touches more axes is more specific" — a rule that conjoins (inferencer, tool, use) beats a rule that names just one axis.
+
+Example ordering (highest to lowest specificity):
+
+1. `inferencer#opus tool[name=Edit] use[of="file#/src/auth.py"] { editable: true }` — 3 axes, ID on each.
+2. `mode.implement use[of-like="file#/src/**/*.py"] { editable: true }` — 2 axes, class + attr.
+3. `use[of="file#/src/auth.py"] { editable: true }` — 1 axis, ID.
+4. `use { editable: true }` — 1 axis, bare element.
+
+### Why axis_count first
+
+Without `axis_count` primacy, a single-axis rule with many attribute filters could outrank a cross-axis rule with few filters. That's wrong for our semantics — cross-axis rules are *more contextualized* and should win. A rule that says "in implement mode, for Bash tool, use this file is editable" is specifically about that triple; a rule that says "this file is editable" is a blanket statement. The triple must win.
+
+### Compatibility
+
+Existing single-axis views produce the same cascade order as v0.4 because `axis_count=1` for every rule — the new field is uniform across legacy views and doesn't reorder them. Only views that *introduce* cross-axis selectors benefit from the new ordering.
+
+---
+
+## 7. The full DOM — worked example
+
+The user's end-to-end example, annotated:
+
+```css
+principal#Teague
+  world#sandbox-123:has(file#/foo.txt)
+  mode.testing
+  harness#claude-code
+  inferencer#opus-46
+  tool#Bash
+  exec#sed
+  use[of="file#/foo.txt"]
+  { editable: true; }
+```
+
+Reading left-to-right, axis by axis:
+
+| Selector | Axis | System | Reading |
+|---|---|---|---|
+| `principal#Teague` | principal | S5 | "commissioned by Teague" |
+| `world#sandbox-123:has(file#/foo.txt)` | world | S0 | "in a sandbox that contains /foo.txt" |
+| `mode.testing` | control | S3 | "with testing mode active" |
+| `harness#claude-code` | coordination | S2 | "under claude-code harness" |
+| `inferencer#opus-46` | intelligence | S4 | "using Opus 4.6" |
+| `tool#Bash` | operation | S1 | "via the Bash tool" |
+| `exec#sed` | world | S0 | "dispatching to sed" |
+| `use[of="file#/foo.txt"]` | action-link | — | "the use of /foo.txt" |
+| `{ editable: true; }` | — | — | declaration |
+
+Eight axis-crossings. The combinator is one descendant-combinator throughout; the *meaning* of each crossing is emergent from which axes it joins. `principal→world` reads "running in"; `tool→exec` reads "dispatches to"; `exec→use` reads "operates on." One syntax, many readings, no new combinators.
+
+This is the same overload CSS already accepts: `.sidebar a` means either "a link that happens to be inside sidebar" or "a link styled by sidebar context," depending on which the stylesheet author cares about. The DOM doesn't encode the reading; the reader resolves it from which axes are being crossed.
+
+---
+
+## 8. The `principal` taxon in v0.5 — minimal shape
+
+Adding S5 to the DOM doesn't require full principal modeling. v0.5 ships:
+
+```css
+principal[name="..."]?     /* attribute */
+principal#<id>              /* ID selector */
+
+principal#Teague {
+  intent: "code review";
+  grade: 2;                 /* optional, per Ma grade lattice */
+}
+```
+
+With two properties:
+
+- `intent: str` — free-form description of why this delegate was commissioned. Consumed by audit and by human review. Compilers in v0.5 ignore it.
+- `grade: int` — optional Ma-grade label (0–4). Compilers ignore it in v0.5; the audit compiler (v0.7) will consume it.
+
+The principal appears in selectors as the outermost qualifier. If no `principal` appears, rules apply across all principals (legacy behavior).
+
+Full principal modeling (multiple principals, delegation lineage, capability-inheritance rules) is v1.1+.
+
+---
+
+## 9. Migration path
+
+This is a semantic restructuring, not a format break. Existing v0.4 views parse and compile to byte-identical output through a **legacy-shim** applied at parse time.
+
+### Legacy-shim rules
+
+| v0.4 form | v0.5 equivalent | Shim action |
+|---|---|---|
+| `file#foo { editable: true; }` | `use[of="file#foo"] { editable: true; }` | Desugar: permission properties on `file`/`dir`/`tool` → synthesized `use` rule. |
+| `tool[name="Bash"] { allow: false; }` | `use[of="tool#Bash"] { allow: false; }` | Same pattern for tool permissions. |
+| `@world { ... }` | `world { ... }` | Existing at-rule remains valid. |
+| `state.hook[event=...]` | `coordination hook[event=...]` | Taxon renamed; selector tagged to new axis. |
+| `state.budget`, `state.job` | `control budget`, `control job` | Same. |
+| `actor.inferencer` | `intelligence inferencer` | Same. |
+| `actor.executor` | `operation executor` | Same. |
+
+The shim runs unconditionally on parse. Users see no behavioral change; the AST is uniformly in the new shape post-parse.
+
+### Vision-doc updates
+
+`docs/vision/entity-model.md` replaced in full. v0.4 version committed as `entity-model-v04.md` for history.
+`docs/guide/entity-reference.md` regenerated from the new registry.
+`docs/vision/notes/selector-semantics.md` updated with the cross-axis specificity definition.
+A new `docs/vision/notes/vsm-alignment.md` captures the Beer mapping and the S3↔S4 inversion justification.
+
+### Compiler compatibility
+
+All three existing compilers (nsjail, bwrap, lackpy-namespace) receive the new-shape `ResolvedView` and emit byte-identical output. Test snapshots guard this. The changes are:
+
+- nsjail: reads `use[of-kind=file]` instead of `file` directly for mount generation; reads `use[of-kind=network]` for network deny.
+- bwrap: same pattern.
+- lackpy-namespace: reads `use[of-kind=tool]` for allow/deny; reads `tool` directly for `max-level` (which is a tool-level property, not per-use).
+
+### Test migration
+
+The existing 483-test suite passes unchanged on v0.4-shape views. A new `tests/vsm/` directory adds ~40 tests covering:
+
+- Use-based permission cascade.
+- Cross-axis specificity ordering.
+- Mode-as-class selector matching.
+- Audit at-rule parsing.
+- Legacy-shim byte-compatibility for every fixture in `_fixtures/`.
+
+---
+
+## 10. Vertical slices
+
+v0.5 decomposes into five slices, each a buildable, testable, shippable unit. Each leaves the suite green.
+
+### Slice A — Taxa registration and legacy-shim (land first)
+
+- Rename taxa in the registry: `capability` → split into `operation` / `world` (for exec); `state` → split into `coordination` / `control` / `audit`; `actor` → split into `principal` / `intelligence` / `operation`.
+- Register `use` entity under a new *action-link* meta-taxon (a taxon whose entities link across axes rather than living on one).
+- Install the legacy-shim in the parser post-pass.
+- All existing tests continue to pass because shim output is byte-identical.
+
+### Slice B — `use[of=...]` as first-class entity
+
+- Register `use` with properties `editable`, `visible`, `show`, `allow`, `deny`, `allow-pattern`, `deny-pattern`.
+- Implement `of=` attribute parsing (selector-valued, nested match).
+- Implement `of-like=` and `of-kind=` forms.
+- Update nsjail and bwrap compilers to read `use` entries instead of (or in addition to) world entities directly.
+- Snapshot tests confirm byte-identical output for all v0.4 fixtures.
+
+### Slice C — Cross-axis cascade
+
+- Extend `Specificity` to carry per-axis counts.
+- Rewrite `cmp_specificity` to do the axis_count-first tuple comparison.
+- Add ~15 tests covering cross-axis ordering, tie-breaks within an axis, and `axis_count` primacy.
+
+### Slice D — Audit and principal taxa
+
+- Register `principal` with `name`, `intent`, `grade`.
+- Register `audit` with `observation`, `manifest` entities.
+- Parse `@audit { ... }` at-rule into audit-axis nodes.
+- No compiler changes (audit compiler is v0.7).
+- Tests: parse + cascade over principal and audit; verify compilers ignore them without error.
+
+### Slice E — Documentation + release
+
+- Regenerate `docs/guide/entity-reference.md` from the new registry.
+- Replace `docs/vision/entity-model.md`; preserve v0.4 as historical.
+- Add `docs/vision/notes/vsm-alignment.md`.
+- Update CHANGELOG.
+- Tag `v0.5.0`.
+
+Sequence: A → B → C → D → E. A-B-C can be parallelized across sub-agents if desired; D depends on A; E depends on all.
+
+---
+
+## 11. Open questions resolved
+
+| Question | Resolution |
+|---|---|
+| Where does `mode` live? | S3 control. Class selector, not ID. |
+| Is audit inside or outside the world? | Outside. Architectural S3\* bypass. |
+| Do resources live in world or under coordination? | World. `use` projects them into the action axis. |
+| What name for the action-link entity? | `use` (with `of=` attribute). Considered `handle`, `ref`; `use` wins because permissions are on *usage*, and SVG precedent exists. |
+| Do modes compose? | Yes — `mode.implement.tdd` is legal; kibitzer compiler derives distinct mode blocks from class sets. |
+| Does audit_count primacy break existing cascades? | No — every legacy rule has `axis_count=1`, uniform comparison. |
+| Is the kibitzer-hooks compiler in v0.5? | No — moved to v0.6 so v0.5 can land the restructure cleanly. The v0.6 compiler is ~1 slice of work once v0.5 lands. |
+| Are the `security pass` and `public API freeze` in v0.5? | No — deferred to v0.6 / v0.7. v0.5 is the restructure milestone. |
+| Do exec entities move with world? | Yes — exec is S0, a world-side binding (a binary that exists in the environment). `tool` stays S1 (the verb), but dispatches via `exec` which lives in world. |
+| Does `policy` remain a taxon? | No — removed. A view *is* policy; policy isn't one of its parts. |
+
+---
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Legacy-shim drift — compilers start relying on shim side-effects rather than the new shape. | Shim runs only at parse; compilers always see new-shape AST. Snapshot tests guard output. After v0.6, the shim becomes opt-in and emits deprecation warnings. |
+| Cross-axis specificity surprises existing view authors. | `axis_count=1` for every legacy rule → no reordering. Document the rule prominently. |
+| `use[of=...]` nested selector parsing adds parser complexity. | Reuse the existing selector parser; `of=` value is parsed by re-entering the same parser. Small, localized change. |
+| The VSM framing adds cognitive load for users who don't know Beer. | Docs lead with concrete examples first, theory second. VSM becomes an organizing principle behind the scenes, not a prerequisite for users. |
+| v0.5 is too large as a single milestone. | Decomposed into five slices. Each slice is independently testable and shippable — we can tag and release at any intermediate point. |
+
+---
+
+## 13. What comes after v0.5
+
+The roadmap clarifies with v0.5 as foundation:
+
+- **v0.6 — kibitzer-hooks compiler + S3\* audit compiler hints.** Now a small, clean compiler because S3 modes and S2 hooks live in dedicated taxa.
+- **v0.7 — observation consumer + full audit compiler.** blq and ratchet-detect output consumed as audit entries.
+- **v0.8 — security pass.** Parser hardening, fuzz tests, threat model. Rests on the post-restructure API.
+- **v0.9 — public API freeze.** `__all__` explicit, deprecation policy, API-stability commitments.
+- **v1.0 — PyPI publish.**
+
+Each now slots onto a DOM that already has the right shape for it.
+
+---
+
+## 14. Approval gate
+
+After approval, `writing-plans` produces `docs/superpowers/plans/2026-04-13-umwelt-v05.md` sequenced by the five slices in §10. The plan contains task-by-task test specifications, file-by-file change lists, and CHANGELOG entries.

--- a/docs/vision/evaluation-framework.md
+++ b/docs/vision/evaluation-framework.md
@@ -1,0 +1,275 @@
+# Evaluating umwelt — A Rigorous Framework
+
+*Captured 2026-04-14. The framework by which umwelt is tested at every milestone. Treat as a living document — update the claim ledger when claims are added, strengthened, refuted, or retired.*
+
+---
+
+## Why this document exists
+
+"Does umwelt work?" is not a useful question. umwelt makes several distinct claims, operating at different levels (formal, empirical, ergonomic, theoretical), aimed at different audiences (view authors, delegates, auditors, formal reviewers). A rigorous evaluation treats each claim as a **falsifiable proposition** and defines methodology, success threshold, and falsification test per claim.
+
+The evaluation is useful only if it could, in principle, find umwelt wanting. A framework that can't fail a bad design isn't rigor — it's marketing.
+
+Every test in `tests/` should map to a claim in the ledger below. Every claim should have at least one test or documented verification plan. When those lines go out of sync, the framework is no longer being run.
+
+---
+
+## Part 1 — The claim ledger
+
+Every design decision umwelt has committed to is a claim. Writing them down explicitly is the first rigor move.
+
+Each claim has an ID (category letter + number), a falsifier (what would make the claim false), and a tier (0 = foundational, 3 = aspirational).
+
+### Category A — Semantic claims (what the language means)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| A1 | Every umwelt view has a unique, deterministic cascade-resolved fact-set given fixed runtime inputs. | Two resolver runs over identical view + input produce differing ResolvedViews. | 0 |
+| A2 | Cascade specificity is a well-ordered preference over rules (no cycles, no ties after tiebreaking). | Construct a view where two rules have indistinguishable specificity and conflicting declarations without a document-order tiebreaker. | 0 |
+| A3 | Cross-axis specificity is sound: rules that join more axes *are* more contextualized than rules that join fewer. | Construct a natural example where a cross-axis rule should be less specific than a single-axis rule with heavy attribute filtering. | 1 |
+| A4 | The CSS-shaped concrete syntax is equivalent in expressive power to non-recursive Datalog with stratified negation. | Find a Datalog program of that class with no umwelt-view equivalent. | 3 |
+| A5 | Every property declaration has a semantics specified by its `comparison` field (`exact`, `<=`, `>=`, `in`, `overlap`, `pattern-in`). | Find a property whose observed behavior differs from its declared comparison. | 1 |
+
+### Category B — Enforcement claims (does the view bind the delegate)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| B1 | Compiler output faithfully implements the ResolvedView's semantics at its altitude. | Execute the compiled config; observe that the delegate can do something the view forbids, or is blocked from something the view allows. | 0 |
+| B2 | Altitude stacking is additive — enforcement at a higher altitude cannot loosen constraints imposed at a lower altitude. | Find a lower-altitude compiler output that passes, but gets relaxed by the upper-altitude config. | 1 |
+| B3 | Every compiler produces output accepted by its target tool's native validator (nsjail, bwrap, lackpy). | Produce a view whose compiled output is rejected by the target tool. | 1 |
+| B4 | Every altitude's compiler faithfully rejects (at compile time) views it cannot express. | Compile a view whose semantics exceed the altitude, without error — then observe enforcement gap at runtime. | 1 |
+
+### Category C — Audit claims (can you trace what happened)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| C1 | Every enforcement decision maps to a specific rule in the view (proof-tree traceability). | An enforcement event with no rule-level attribution. | 1 |
+| C2 | `umwelt audit` detects genuine cascade widenings — places where a rule lets the delegate do more than an earlier rule did. | Audit misses a real widening (false negative) or flags a non-widening (false positive) at a measurable rate. | 2 |
+| C3 | Proof trees for a decision are reproducible — running audit on the same view+inputs twice yields identical proofs. | Observed non-determinism. | 1 |
+
+### Category D — Specifiability claims (can failures become rules)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| D1 | Observed delegate failures can be crystallized into rules the view accepts. | An observed failure that has no rule-level representation. | 1 |
+| D2 | The ratchet is monotone: adding a ratcheted rule never loosens bounds, only tightens. | A ratchet proposal that widens the view. | 2 |
+| D3 | Ratchet proposals are specified — no learned or opaque component in the proposal path. | A proposal whose derivation requires data outside the observation log + existing view. | 2 |
+
+### Category E — Usability claims (can humans write and reason about views)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| E1 | CSS-literate authors can read a view and predict its behavior without prior umwelt training. | User study: median target user with CSS background fails to predict cascade outcome >30% of the time. | 2 |
+| E2 | Errors in views surface at parse or resolve time with line-accurate messages. | A broken view compiles with silent fallback. | 2 |
+| E3 | `umwelt diff` makes rule-level changes between view versions obvious. | Reviewer fails to notice a regression in a diffed view. | 2 |
+
+### Category F — Agent-alignment claims (does the view bound an LLM)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| F1 | A delegate operating under a compiled view is constrained to the view's specified band regardless of prompting. | Find prompt that induces out-of-band behavior under a correctly-compiled view. | 0 |
+| F2 | When a delegate hits a bound, it receives actionable feedback (what was denied, why, and what alternative modes exist). | Bound-hit produces silent failure or non-actionable error. | 1 |
+| F3 | Modes (S3) can be switched dynamically by the delegate via the mode-switch tool, and switches are auditable. | Mode switch occurs without audit entry, or mode-switch does not change effective permissions. | 1 |
+
+### Category G — Theoretical-fidelity claims (does umwelt instantiate the Ma framework)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| G1 | umwelt's taxa instantiate Beer's VSM systems with the S3↔S4 inversion documented. | Audit the taxa; find a system that maps ambiguously or a VSM concept unrepresented. | 3 |
+| G2 | umwelt provides the specified band: the decision surface is transparent regardless of world coupling. | Find a decision whose derivation cannot be reproduced from the view + observed inputs. | 1 |
+| G3 | umwelt is a policy-layer instantiation of the Layer 3 regulator in the three-layer strategy (constraint + observation + policy). | Show the layer's outputs do not suffice to drive Layer 1 enforcement. | 3 |
+
+### Category H — Ecosystem claims (does umwelt integrate)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| H1 | umwelt is consumable by every target integrator (lackpy, kibitzer, blq, claude-plugins) without forking. | An integrator cannot use umwelt without a private fork. | 1 |
+| H2 | umwelt's output formats are equivalent to or strictly more expressive than the native formats of each integrator. | Find a native-format policy the umwelt compiler cannot produce. | 2 |
+| H3 | umwelt has no runtime dependency on any enforcement tool's Python wrapper. | Find an import of `nsjail_python` or similar in the umwelt runtime path. | 1 |
+
+### Category I — Compositional claims (do views combine cleanly)
+
+| # | Claim | Falsifier | Tier |
+|---|---|---|---|
+| I1 | `umwelt diff a.umw b.umw` reports every rule-level change between views (no silent drops, no spurious changes). | Find a diff that misses or fabricates changes. | 2 |
+| I2 | Multiple views loaded into one resolve run produce the union of their rules, cascaded as if authored together. | Combine two views and observe a rule whose effect differs from its effect in isolation plus specificity logic. | 2 |
+| I3 | Taxon aliases are transparent: an entity/property/matcher registered under canonical is indistinguishable from one registered under alias. | Code review found a gap; fix commit `ffe4b54`. Still open: cross-consumer conflict if two consumers register different matchers under equivalent aliases. | 1 |
+
+---
+
+## Part 2 — Evaluation methodology per category
+
+For each category, a distinct methodology. The rigor comes from *matching* method to claim kind.
+
+### Semantic claims → formal verification + test generation
+
+- **Formal**: mechanize the resolver semantics in Lean or Coq. Prove A1 (determinism) and A2 (well-ordering) as theorems. This is the Cedar playbook.
+- **Property-based testing**: `hypothesis` + `pytest-benchmark`. Generate random views, run resolve twice, assert identity. Catches A1 in the limit.
+- **Differential testing**: against a Datalog reference implementation (Soufflé). Compile view → Datalog IR, run both, compare fact-sets. Catches A4.
+
+### Enforcement claims → round-trip empirical testing
+
+- **Corpus**: hand-curated views that exercise each altitude's full vocabulary.
+- **Method**: parse → resolve → compile → execute in the real sandbox → probe from inside with a test harness that attempts forbidden and permitted operations.
+- **Metric**: false-allow rate (forbidden operations that succeed) and false-deny rate (permitted operations that fail).
+- **B2 specifically**: run each pair of altitudes in combination; assert constraints compose.
+
+### Audit claims → proof-tree coverage
+
+- **Corpus**: every execution in the enforcement-round-trip test.
+- **Method**: for every enforcement event, emit proof tree; verify each step references a source line in the view.
+- **Metric**: proof-tree coverage (fraction of events with complete attribution) and proof-tree stability (same view+input → same tree, byte-identical).
+
+### Specifiability claims → ratchet-loop measurement
+
+- **Corpus**: observation logs from real delegate runs (internal dogfood, then partner installs).
+- **Method**: Run ratchet over logs; compare proposed rules to rules a human operator would have written (ground truth from incident retros).
+- **Metric**: precision (fraction of proposals accepted) and recall (fraction of human-written rules that ratchet would have proposed).
+- **D2 specifically**: for every proposed rule, assert the resulting view is a strictly-tighter refinement (automate this check as an invariant of the ratchet).
+
+### Usability claims → mixed-methods user study
+
+- **Protocol**: recruit N=15–30 CSS-literate engineers; give them a view; ask them to predict the outcome of a query without running umwelt.
+- **Metric**: prediction accuracy. E1's threshold (30%) is deliberately conservative; lower = better.
+- **Supplement**: think-aloud sessions to identify confusion points. Qualitative output feeds docs and error-message work.
+- **E2 specifically**: corpus of deliberately-broken views; assert every one produces line-accurate errors.
+
+### Agent-alignment claims → adversarial agent runs
+
+- **Protocol**: give the delegate a task; compile a view that forbids the straightforward path; observe whether the delegate breaches the bound, requests mode-switch, or fails gracefully.
+- **Metric**: out-of-band rate (breach frequency per N runs) and alignment responsiveness (fraction of runs where the delegate correctly identifies the bound and adapts).
+- **F1 specifically**: adversarial prompts designed to induce escape. Red-team setup.
+
+### Theoretical-fidelity claims → peer review
+
+- **Protocol**: write a paper-grade mapping from umwelt taxa to VSM; submit for external review (academic or Ma-series audience).
+- **Metric**: specific objections raised and resolved. Not a single number; a living document.
+- **G2 specifically**: produce a trace-example where a decision is reconstructed purely from view + observed inputs, with no hidden state.
+
+### Ecosystem claims → integrator dogfooding
+
+- **Protocol**: pick one integrator per milestone (lackpy in v0.6, kibitzer in v0.7, etc.), require it consume umwelt in production before milestone is shipped.
+- **Metric**: did the integration land without forking umwelt?
+- **H2 specifically**: audit each native format's expressive power; produce a capability-coverage table.
+
+### Compositional claims → diff and merge testing
+
+- **Corpus**: pairs of views that exercise add/remove/change in each taxon.
+- **Method**: `diff` output compared against a manually-produced reference diff.
+- **I2 specifically**: load combinations of two real-world views (sandbox + lackpy, sandbox + kibitzer) and verify cascade predictions by hand on a sample.
+
+---
+
+## Part 3 — The evaluation protocol
+
+A one-time evaluation yields a snapshot. Rigorous evaluation is a *protocol* — a repeatable process.
+
+### Per-milestone evaluation (v0.5, v0.6, …)
+
+1. **Claim ledger review** — for each claim in categories A–I, confirm whether this milestone strengthens, weakens, or leaves unchanged the evidence for/against it.
+2. **Test-suite gatekeeping** — every test file maps to one or more claims. No new claim without a test; no test without a claim. Tag tests with claim IDs in docstrings (e.g., `"""Verifies claim A1 (determinism)."""`).
+3. **Regression panel** — the byte-compat snapshots are the B1 continuity kit. Run on every PR.
+4. **User-study cadence** — a small user study per major milestone. 5 users is enough to catch egregious usability regressions.
+5. **Incident retros** — every delegate failure in dogfood gets a retro. Each retro produces: (a) a view edit that closes the gap, (b) a test that catches the class of failure, (c) a claim-ledger entry if it reveals a new gap.
+
+### Quarterly deep-eval
+
+- Full formal-verification pass (Lean proofs regenerated; counterexamples recorded).
+- Full round-trip test against a fresh enforcement stack.
+- User study N ≥ 15 with new recruits (don't reuse familiar users).
+- Public audit report: one paragraph per claim; what's verified, what's open.
+
+---
+
+## Part 4 — Prioritization
+
+Not all claims are equally load-bearing. Some are foundational (if false, the project is wrong); some are ergonomic (if false, the project is annoying).
+
+### Tier 0 — foundational (falsify these and the project is broken)
+
+- A1 (determinism), A2 (cascade well-ordered), B1 (enforcement fidelity), F1 (delegate is actually bound).
+
+### Tier 1 — load-bearing (falsify these and the value prop collapses)
+
+- A3 (cross-axis soundness), A5 (property comparison semantics), B2–B4 (altitude stacking, native-validator acceptance, out-of-altitude rejection), C1/C3 (proof-tree traceability and stability), D1 (failures can become rules), F2/F3 (actionable feedback, mode switching), G2 (specified band holds), H1/H3 (integrator adoption without fork, no wrapper dependency), I3 (alias transparency).
+
+### Tier 2 — quality (falsify these and the project works but is worse)
+
+- C2 (audit widening accuracy), D2/D3 (ratchet monotone and specified), E1–E3 (usability), H2 (expressive superset of native formats), I1/I2 (diff completeness, view composition).
+
+### Tier 3 — aspirational (falsify these and the project is less ambitious than claimed)
+
+- A4 (Datalog equivalence), G1 (VSM fidelity), G3 (three-layer instantiation).
+
+**First rigor investment: Tier 0.** Everything else can wait.
+
+---
+
+## Part 5 — Red flags / stopping rules
+
+Rigor includes knowing when to stop. Conditions under which umwelt should pivot or be abandoned:
+
+- **False-allow rate > 1%** in round-trip testing after Slice B lands. Enforcement is the foundation; if it leaks, the theoretical sophistication is window-dressing.
+- **Usability study prediction-accuracy < 50%** with CSS-literate users. The CSS-syntax bet has failed; reconsider the surface syntax.
+- **Integrator-without-fork requirement fails for two of four integrators.** The common-language-of-the-specified-band claim is falsified; umwelt is just another policy language.
+- **A partner integration takes > 2 weeks from zero-to-production.** The library is too heavyweight; strip it.
+- **Ratchet proposals have < 30% human-acceptance rate after N > 50 proposals.** The specified-ILP story needs work or the ratchet needs a neural assist (which itself would require framework change).
+
+---
+
+## Part 6 — Gaps deliberately unaddressed in v1
+
+Honest rigor includes naming the gaps.
+
+- **Long-run stability**: views evolve over years. Does a view written in v0.5 still compile in v2.0? No story yet.
+- **Multi-principal composition**: two principals with overlapping views. Not specified. Needed before v1.1.
+- **Federated enforcement**: a view that composes across multiple sandboxes (different teams, different machines). Out of scope for v1.
+- **Performance under adversarial input**: parser hardening / fuzz testing. Deferred to v0.7.
+- **Cost accounting**: the budget axis is declared but compile-time verification of budget sufficiency isn't formalized. Interesting paper-grade problem.
+
+These gaps define the roadmap beyond v1.0.
+
+---
+
+## Part 7 — The one-sentence test
+
+If a stakeholder asks "is umwelt working?", the honest answer has the shape:
+
+> "Claims {A1, A2, B1, F1} are verified with {method}; claim {X} is open pending {measurement}; no Tier-0 claims are falsified; the next evaluation is scheduled for {date}."
+
+If you can't produce that sentence, the evaluation framework isn't being run. The deliverable of this framework is that sentence, on demand, at every milestone.
+
+---
+
+## Current state (as of 2026-04-14, post-v0.4, pre-v0.5)
+
+| Claim | Evidence | Status |
+|---|---|---|
+| A1 | Resolver determinism: not property-tested; no formal proof. Each test implicitly assumes it. | **Open — Tier 0**. Add hypothesis-based determinism test in v0.5 Slice C. |
+| A2 | Cascade uses document order as tiebreaker (resolver.py L151-159). | **Verified** by construction for single-axis; extended by v0.5 Slice C for cross-axis. |
+| A3 | Introduced in v0.5 Slice C. | **Open pending v0.5 implementation**. |
+| A5 | Each registered property declares its comparison. Tested per-property in sandbox tests. | **Verified** by existing tests. |
+| B1 | Compilers have snapshot tests for output stability (Task 6 of v0.5 plan), but no runtime round-trip in the actual sandbox. | **Partial** — continuity verified, correctness unverified. Open for v0.8/v0.9. |
+| B3 | No native-validator round-trip harness. | **Open — Tier 1**. Candidate for v0.7. |
+| C1 | `umwelt audit` reports per-rule source attribution. No formal proof tree. | **Partial**. Full proof trees v0.9+. |
+| D1–D3 | Ratchet utility is v1.1+. | **Not applicable yet**. |
+| E1–E3 | No user studies. | **Not evaluated**. Schedule for v0.9. |
+| F1–F3 | No agent-alignment runs. | **Not evaluated**. Needs agent harness (v0.8+). |
+| G2 | Specified band is claimed; not instrumented. | **Partial** — every decision is declarative, but no proof-tree extraction yet. |
+| H1 | lackpy-namespace compiler ships; lackpy integration is hypothetical. | **Partial**. |
+| H3 | Grep confirms no nsjail_python imports in src/umwelt. | **Verified**. |
+| I1 | `umwelt diff` has tests for added/removed/changed rules. | **Verified** at unit level. |
+| I3 | Task 0 + `ffe4b54` fix cover alias transparency for registry lookups. | **Verified** for current registry submodules. |
+
+**No Tier-0 claim is currently falsified.** Tier-0 claims A1 and B1 are partially verified; the v0.5 plan does not strengthen them directly — that work (hypothesis-based determinism test, round-trip enforcement harness) is a gap to close in subsequent milestones.
+
+---
+
+## How to update this document
+
+- Adding a claim: pick a category letter and the next available number. Provide falsifier and tier. Add to current-state table.
+- Strengthening a claim: add a link to the test or proof that establishes it. Update current-state status.
+- Refuting a claim: record the falsifying observation in git history. Either fix the design, drop the claim, or move it to a "retired claims" section with explanation.
+- New category: appropriate for major capabilities (e.g., Category J for performance, K for security) when they become first-class. Propose in a note first, then merge.
+
+The document is a contract between the project and its users that umwelt's claims are testable, tested, or deliberately deferred. Drift between this document and reality is a project defect.

--- a/docs/vision/evaluation-framework.md
+++ b/docs/vision/evaluation-framework.md
@@ -29,6 +29,7 @@ Each claim has an ID (category letter + number), a falsifier (what would make th
 | A3 | Cross-axis specificity is sound: rules that join more axes *are* more contextualized than rules that join fewer. | Construct a natural example where a cross-axis rule should be less specific than a single-axis rule with heavy attribute filtering. | 1 |
 | A4 | The CSS-shaped concrete syntax is equivalent in expressive power to non-recursive Datalog with stratified negation. | Find a Datalog program of that class with no umwelt-view equivalent. | 3 |
 | A5 | Every property declaration has a semantics specified by its `comparison` field (`exact`, `<=`, `>=`, `in`, `overlap`, `pattern-in`). | Find a property whose observed behavior differs from its declared comparison. | 1 |
+| A6 | World-axis permissions (properties on `file`/`dir`/`tool`/`network`) and action-axis permissions (properties on `use`) are semantically independent; neither desugars to the other. World-axis asks "is this resource editable?" (mount/inode-level); action-axis asks "does this access path grant edit?" (user-permission-level). A successful enforcement decision conjoins both. | Find a view where `file { editable: true; }` is silently treated as equivalent to `use[of="file#X"] { editable: true; }`, or a compiler that reads one axis when it should read both. | 1 |
 
 ### Category B — Enforcement claims (does the view bind the delegate)
 
@@ -191,7 +192,7 @@ Not all claims are equally load-bearing. Some are foundational (if false, the pr
 
 ### Tier 1 — load-bearing (falsify these and the value prop collapses)
 
-- A3 (cross-axis soundness), A5 (property comparison semantics), B2–B4 (altitude stacking, native-validator acceptance, out-of-altitude rejection), C1/C3 (proof-tree traceability and stability), D1 (failures can become rules), F2/F3 (actionable feedback, mode switching), G2 (specified band holds), H1/H3 (integrator adoption without fork, no wrapper dependency), I3 (alias transparency).
+- A3 (cross-axis soundness), A5 (property comparison semantics), A6 (axis independence), B2–B4 (altitude stacking, native-validator acceptance, out-of-altitude rejection), C1/C3 (proof-tree traceability and stability), D1 (failures can become rules), F2/F3 (actionable feedback, mode switching), G2 (specified band holds), H1/H3 (integrator adoption without fork, no wrapper dependency), I3 (alias transparency).
 
 ### Tier 2 — quality (falsify these and the project works but is worse)
 
@@ -249,6 +250,7 @@ If you can't produce that sentence, the evaluation framework isn't being run. Th
 | A2 | Cascade uses document order as tiebreaker (resolver.py L151-159). | **Verified** by construction for single-axis; extended by v0.5 Slice C for cross-axis. |
 | A3 | Introduced in v0.5 Slice C. | **Open pending v0.5 implementation**. |
 | A5 | Each registered property declares its comparison. Tested per-property in sandbox tests. | **Verified** by existing tests. |
+| A6 | Task 2 registered `use` permission properties additively; world-axis properties (`file.editable`, `tool.allow`, etc.) remain registered unchanged. Both axes are independently queryable. Spec §3a documents the distinction. | **Verified** by the coexistence of world-axis and action-axis property registrations. |
 | B1 | Compilers have snapshot tests for output stability (Task 6 of v0.5 plan), but no runtime round-trip in the actual sandbox. | **Partial** — continuity verified, correctness unverified. Open for v0.8/v0.9. |
 | B3 | No native-validator round-trip harness. | **Open — Tier 1**. Candidate for v0.7. |
 | C1 | `umwelt audit` reports per-rule source attribution. No formal proof tree. | **Partial**. Full proof trees v0.9+. |

--- a/docs/vision/notes/logic-semantics.md
+++ b/docs/vision/notes/logic-semantics.md
@@ -174,15 +174,27 @@ This is the move to defend. The argument:
 
 This is genuine novelty. The Ma series should own it.
 
-### C. `use[of=...]` as the action-axis projection
+### C. `use[of=...]` as the action-axis projection — additive to world-axis, not a replacement
 
-File-versus-file-descriptor is standard OS thinking. Capability theory (Levy, *Capability-Based Computer Systems*, 1984) made the distinction formal: a capability is an unforgeable reference that carries permission.
+Standard OS thinking separates a **file** (on disk, maybe on a read-only mount) from a **file descriptor** (a process's permissioned access to the file). A write succeeds only if both allow it. Capability theory (Levy, *Capability-Based Computer Systems*, 1984) formalizes the descriptor side as an unforgeable reference carrying permission.
 
-What's new: **lifting capabilities into the policy syntax as first-class selectable entities.** In OPA, permissions are derived at query time from relations; in Cedar, permissions are on `(principal, action, resource)` triples; in Polar, permissions are on predicates. None of them have a syntactic primitive that *is* the capability.
+umwelt lifts **both** into the policy syntax as first-class, independently-queryable predicates:
 
-`use[of="file#..."]` in umwelt *is* the capability. The view declares capabilities explicitly, cascades permissions over them, and compiles them into enforcement. The permissioned projection is visible in the source, not derived invisibly.
+- `file.editable` / `mount.readonly` / `tool.allow` — *world-axis*: property-of-the-resource. "Is this file mounted writable?" "Does this network endpoint exist?"
+- `use[of="file#X"].editable` / `use[of="tool#Y"].allow` — *action-axis*: property-of-the-access. "Does this access path grant edit rights through this tool?"
 
-Minor novelty but worth claiming — it makes audit explanations simpler ("rule R grants use U; delegate exercised U") and it's the construct that makes the three-way join (`inferencer × tool × use`) read naturally.
+An enforcement decision conjoins them: the delegate can write to `X` iff `file#X.editable ∧ ∃use U. of(U, file#X) ∧ use.editable(U)`.
+
+What's new relative to the landscape:
+
+- **OPA/Rego** derives permissions at query time from relations — no syntactic primitive for the capability itself; the distinction between "resource is editable" and "this user has edit access" is encoded implicitly in rule bodies.
+- **Cedar** puts permissions on `(principal, action, resource)` triples, collapsing the two axes into one evaluation.
+- **Polar** puts permissions on predicates, similar to OPA.
+- **umwelt** has distinct, first-class syntax for each axis. `file { editable: true }` expresses resource-nature; `use[of=file#X] { editable: true }` expresses access-grant. Both participate in cascade independently.
+
+This matters for altitude stacking: OS-altitude enforcers (nsjail, bwrap) should read the world-axis (mount-level rw/ro); language-altitude enforcers (lackpy, kibitzer) should read the action-axis (per-delegate tool gating). The split in the syntax mirrors the split in enforcement.
+
+Minor novelty in isolation but worth claiming — it makes audit explanations simpler ("resource R is editable (rule line 12); use U of R is editable (rule line 48); delegate exercised U") and it's the construct that lets the three-way join (`inferencer × tool × use[of=file]`) read naturally without conflating nature with access.
 
 ### D. Agent as subject
 

--- a/docs/vision/notes/logic-semantics.md
+++ b/docs/vision/notes/logic-semantics.md
@@ -1,0 +1,300 @@
+# Note: umwelt views as logic programs — relatives, precedents, and what's novel
+
+*Captured 2026-04-14, post-v0.5 design discussion. Intended as source material for a future blog post and as a reference when situating umwelt in the authorization-policy literature. Not user-facing — this is for whoever has to defend design choices against "isn't this just OPA?" questions.*
+
+---
+
+## Thesis
+
+A umwelt view is a **Datalog program with CSS-shaped concrete syntax, a Viable-System-Model-partitioned predicate schema, and defeasible cascade semantics.** Every primitive in our language maps to a standard logic-programming primitive. The novelty is in the *schema*, the *syntax*, and the *subject* (LLM agents, not users or services) — not in the underlying formalism.
+
+This note is a map of the territory.
+
+---
+
+## 1. The translation: view → Horn clauses
+
+Each simple selector is a predicate application. Each attribute filter is a conjunct. The descendant combinator is just `∧`. `:has(...)` is existential. `of=` is unification — the `of` relation binds one axis's entity to another's.
+
+Example. In umwelt syntax:
+
+```css
+inferencer#opus tool[name="Edit"] use[of="file#/src/auth.py"] {
+  editable: true;
+}
+```
+
+As a Horn clause:
+
+```prolog
+editable(U, true) :-
+    inferencer(Inf), id(Inf, 'opus'),
+    tool(T), name(T, 'Edit'),
+    use(U), of(U, File),
+    file(File), id(File, '/src/auth.py').
+```
+
+No construct in our syntax lacks a standard logic-programming translation:
+
+| umwelt syntax | Logic-programming counterpart |
+|---|---|
+| `element` | unary predicate `element/1` |
+| `#id` | `id(X, 'value')` conjunct |
+| `.class` | `has_class(X, 'value')` conjunct |
+| `[attr="value"]` | `attr(X, 'value')` conjunct |
+| `[attr^="prefix"]` | `attr(X, V), prefix(V, 'prefix')` |
+| `A B` (descendant) | `∧` (conjunction) |
+| `A:has(B)` | existential quantification |
+| `{ prop: value; }` | rule head |
+| `use[of="X"]` | binding via the `of` relation |
+| cascade specificity | defeasible preference over multiply-derived facts |
+
+The view is a logic program in a narrow sense: finite-relation, non-recursive, deterministic over the closed world of entities declared in the view plus runtime state (active mode, current inferencer, current tool). That puts it in **Datalog**, not full Prolog — no function symbols, no recursion (yet), guaranteed termination, PTIME evaluation.
+
+### Why this matters
+
+If views are Datalog, the compiler protocol is queryable. Each compiler asks a different question of the same program:
+
+- **nsjail**: `{(M, P, RO) : mount(M) ∧ path(M, P) ∧ readonly(M, RO)}`
+- **bwrap**: same set, different encoding
+- **lackpy-namespace**: `{T : tool(T) ∧ allow(T, true)}` plus denied/max-level/patterns
+- **kibitzer-hooks** (v0.6): `{(Mode, P) : active(Mode) ∧ editable(U, true) ∧ of(U, F) ∧ path(F, P)}`
+
+Today we hand-roll each compiler. Long-term, compiling views to Datalog IR and letting each compiler register queries collapses the compiler protocol into one primitive: `query: ResolvedView × Goal → FactSet`.
+
+---
+
+## 2. Cascade as defeasible reasoning
+
+Pure Prolog resolves rule conflicts by search order. Datalog resolves by fixed-point — if two rules produce contradictory facts, the program has no stable model.
+
+Neither is what CSS does, and neither is what we want.
+
+umwelt's cascade matches **Defeasible Logic Programming** (García & Simari, 2004). Multiple rules can derive contradictory `editable(U, _)` facts; a meta-rule picks the winner by specificity. The specific reference in the DeLP literature is *generalized specificity*: rule R₁ defeats R₂ if R₁'s body is strictly more specific than R₂'s (more conjuncts, more bindings, stricter patterns).
+
+Our `axis_count`-first specificity ordering is an approximation of strict generalized specificity. "Rules that touch more axes win over rules that touch fewer" is a weaker condition than "rules whose body conjuncts are a superset of other rules' bodies," but the two coincide for the selectors we care about. Tightening this to actual subset-defeat is a research-grade project; the approximation gets us 95% of the practical benefit.
+
+**Answer Set Programming with preferences** (Brewka's *Logic Programming with Ordered Disjunction*, 2003) is the other formal foundation worth knowing. ASP + preferences handles multiple stable models by ranking them; our cascade is a one-answer special case of this.
+
+### The specified-band connection
+
+The Ma series' specified-band guarantee reduces, in logic-programming terms, to:
+
+> Every entailed fact has a proof tree, and proof trees use only rules in the committed view.
+
+Datalog gives us this natively via SLD resolution — proof trees are a side effect of evaluation. That's the audit story. S3\*'s job is to emit those proof trees as decisions are made, so every permission the delegate exercises is traceable to rules in the view.
+
+This is directly the **proof-carrying authorization** tradition — Lampson (1999), Appel & Felten (PCA, late '90s), Abadi's delegation logic (2000s). We inherit their soundness machinery by choosing Datalog as the substrate.
+
+---
+
+## 3. The landscape — who else does this
+
+### Currently deployed
+
+**OPA / Rego** (Open Policy Agent, CNCF graduated 2021). Closest living relative. Rego is Datalog with extensions (set comprehensions, aggregations, partial evaluation). Deployed at Netflix, Pinterest, Capital One, Atlassian, Goldman Sachs. Kubernetes admission control uses it by default. *The* reference point for "logic-based cloud-native policy." Our differentiation from OPA: subject is an LLM agent, not a human or service; syntax is CSS, not a custom DSL; schema is VSM-partitioned; ratchet is a first-class authoring loop.
+
+**Amazon Cedar** (launched 2023). Designed as an XACML successor with formal verification. Cedar's `principal / action / resource` decomposition converged on roughly our `(intel, op, use)` trio from the opposite design direction — they started from authorization practice and arrived at a three-axis partition; we started from VSM theory and arrived at the same shape. Worth noting the convergence in the blog post: when you take agent authorization seriously, some version of this trio is forced. Cedar's formal-verification work (published in the POPL/PLDI orbit) sets the bar for policy-language soundness proofs; if we want to make the specified-band guarantee rigorous in a paper, Cedar's approach is the template.
+
+**Oso / Polar** (YC 2020). Literally a Prolog-for-authorization company. Polar is Prolog with surface-syntax ergonomics. Used in production at Intercom, Wayfair. Pivoted to a managed service (OSO Cloud) mid-2020s. Relevant as proof that "Prolog-shaped policy language" is commercially viable, not just academically interesting.
+
+**SpiceDB / Permify / Warrant** — Zanzibar-family (Google's paper, 2019). Graph authorization over a database of relation tuples. Not Datalog exactly, but same Herbrand-universe-of-relations flavor. Aimed at fine-grained sharing (Google Docs–style ACLs). Not directly comparable to our agent-authorization use case; mention in passing as "adjacent but solving a different problem."
+
+**Soufflé** (Oracle, 2016–present). Datalog engine for program analysis. Very active. Spawned successor languages (Flix, Datafun). If we ever need a production-grade Datalog backend, Soufflé is the reference implementation.
+
+### Academic precursors (mostly 2000s)
+
+**Binder** (DeTreville, MSR 2002). Distributed authorization in Datalog with explicit delegation predicates. Cited constantly but never productized. Ideas absorbed into OPA and Cedar. For delegate-chain reasoning (v1.1+ umwelt), Binder's delegation-predicate approach is the template.
+
+**SD3** (Jim, 2001). Secure Dynamic Distributed Datalog. Policy language with proof-carrying enforcement. Same era as Binder, similar fate — influential research, no product.
+
+**Cassandra** (Becker & Sewell, 2004). Another Datalog-based authorization system for medical records. Noteworthy for formal semantics given in the paper. Dead but cited.
+
+**Datalog with Negation as Failure** (Ullman's textbook, 1989 and since). The formal foundation. Any serious treatment of our cascade semantics needs to cite Ullman.
+
+### Research currents (active now)
+
+**Differential Dataflow / Materialize** (McSherry, 2010s–present). Incremental Datalog evaluation at scale. If umwelt ever needs fast re-evaluation on view changes (live-edit in an IDE, streaming observation feeds), differential dataflow is the right engine.
+
+**Flix** (active, major publications in POPL/ICFP). Datalog-with-effects, algebraic-effects-adjacent. Interesting for hook-dispatch semantics (our hooks are side-effecting; Flix has a story for that in a Datalog setting).
+
+**Cedar's verification work** (Amazon, POPL 2024 and adjacent). Formal-methods applied to policy languages. Sets the bar for "our semantics are provably sound."
+
+**Inductive Logic Programming** (Muggleton, FOIL, Progol, Aleph, 1990s–present). The tradition the ratchet lives in. Modern ILP systems (Metagol, Popper) do program synthesis from positive/negative examples. Our ratchet is specified ILP — rule induction without a learned model in the loop, just structural pattern mining over observation traces. The specified-band framing rules out neural ILP methods.
+
+### Dead ends
+
+**XACML** (OASIS, 2003–2010s). XML-based authorization. Committee-designed bloat. Nobody writes XACML by hand. Cedar's design doc explicitly cites XACML's failure modes as constraints: readable syntax, no XML, formal semantics. The umwelt equivalent of XACML's mistake would be emitting our Datalog IR as the user-facing syntax — don't. **The user writes CSS; the compiler sees Datalog.**
+
+**OWL-full for access control**. OWL is based on description logic, not Datalog. OWL-full is undecidable in general. Some authorization research tried to use it (2005–2010). Didn't scale. Interesting as a cautionary tale about choosing too-expressive a formalism.
+
+### The pattern in who survives
+
+Every productized policy language of the last twenty years has:
+
+1. A restricted logic-programming core (Datalog or near-Datalog).
+2. A readable surface syntax that isn't the logic directly.
+3. A compiler that lowers to an executable form.
+4. Separation between authoring (what the policy says) and enforcement (what the gates do).
+
+That's the shape we're building. Nothing novel in the structural choice.
+
+The novel parts are three, and they're worth defending explicitly.
+
+---
+
+## 4. What's genuinely novel in umwelt
+
+### A. CSS syntax as the authoring surface
+
+OPA/Rego, Cedar, Polar, Binder, SD3 — every prior language invented its own DSL. The syntax was always a fresh cognitive load. Users had to learn the language before they could write a policy.
+
+umwelt bets that **CSS is already a cognitive primitive for the agent-adjacent audience**. Every web developer, every documentation author, every person who has styled an HTML page knows how selectors work. Cascade is intuitive because people have debugged CSS specificity conflicts. Classes vs. IDs, attribute filters, descendant combinators — this is prior knowledge.
+
+If we're right, umwelt is readable-on-first-contact. If we're wrong, we've invented yet another DSL with the added cost of surprising readers who expected CSS behavior and got policy behavior.
+
+This is a UX bet, not a logic bet. The Datalog underneath is standard.
+
+### B. VSM as the predicate schema
+
+Stafford Beer's Viable System Model gets cited in:
+- Organizational cybernetics (steady work since the 1970s)
+- Agent-architecture literature (Stuart Russell's *Human Compatible*, Dietterich on reliable AI — passing mentions)
+- Software-architecture retrospectives (occasional invocations)
+
+**What I cannot find in the literature**: using VSM as the *partitioning of a policy language's predicate domains*. Using S1..S5 to structure *what the subject-predicates of a Datalog authorization schema should be*.
+
+This is the move to defend. The argument:
+
+1. Every authorization system has subjects, actions, and resources at minimum.
+2. Agent authorization additionally needs: coordination (the harness), control (current regulation), intelligence (the model), identity (the principal), and audit (the observer).
+3. These seven role-kinds aren't arbitrary — they're the five VSM systems plus environment and S3\* bypass.
+4. Beer already worked out what each system does and how they relate. We inherit that for free.
+5. The S3↔S4 inversion from Beer's original (regulator dominates regulated) is the specific move that makes the specified band coherent.
+
+This is genuine novelty. The Ma series should own it.
+
+### C. `use[of=...]` as the action-axis projection
+
+File-versus-file-descriptor is standard OS thinking. Capability theory (Levy, *Capability-Based Computer Systems*, 1984) made the distinction formal: a capability is an unforgeable reference that carries permission.
+
+What's new: **lifting capabilities into the policy syntax as first-class selectable entities.** In OPA, permissions are derived at query time from relations; in Cedar, permissions are on `(principal, action, resource)` triples; in Polar, permissions are on predicates. None of them have a syntactic primitive that *is* the capability.
+
+`use[of="file#..."]` in umwelt *is* the capability. The view declares capabilities explicitly, cascades permissions over them, and compiles them into enforcement. The permissioned projection is visible in the source, not derived invisibly.
+
+Minor novelty but worth claiming — it makes audit explanations simpler ("rule R grants use U; delegate exercised U") and it's the construct that makes the three-way join (`inferencer × tool × use`) read naturally.
+
+### D. Agent as subject
+
+Every authorization language of the last twenty years had a human or a service account as the subject. The subject was deterministic, had stable identity, and acted on behalf of a known party.
+
+LLM agents are:
+- **Non-deterministic** in action choice.
+- **Unbounded** in action-space expressivity (prompt-engineered tools appear and disappear).
+- **Stochastic** in outcome given the same inputs.
+- **Signal-generating** in their failures (ratchet-feedback).
+
+The Ma series takes seriously that this changes what authorization *is*. Permissions aren't gates on a deterministic caller; they're bounds on a possibility-space. Failure isn't an error; it's input to the next iteration's ratchet.
+
+This is the framing the blog post should lead with. "What if the subject of your policy language is an LLM?" Everything else — VSM, CSS syntax, `use[of=...]`, the ratchet — follows from answering that question rigorously.
+
+### E. The ratchet as specified ILP
+
+Ratchet = configuration ratchet = turn observations into specified rules.
+
+ILP (Inductive Logic Programming) has a thirty-year literature: Muggleton's FOIL (1990), Progol, Aleph, modern Metagol and Popper. Given positive and negative examples, induce a logic program that covers the positives and excludes the negatives.
+
+What's ours: **specified ILP** — rule induction without a neural or learned component in the mining loop. The ratchet sees failure traces, runs structural pattern matching, and proposes candidate rules in the *same Datalog our views are in*. The proposals are pasteable into the view. No model in the regulator.
+
+The "specified" qualifier is doing work. Modern ILP work increasingly uses neural oracle loops (DeepProbLog, neural-symbolic integration). The Ma framing rules those out — the specified-band requires no opaque component anywhere in the authoring loop. That puts us closer to pre-2010 ILP (Progol, Aleph) than to current research, but with modern computing resources the classical approaches are probably sufficient for our scale.
+
+### F. Proof trees as the audit artifact
+
+Not novel in isolation. Lampson's "Proof-carrying authorization" (1999), Appel & Felten's PCA work, Abadi's delegation logic all have proof trees as core artifacts.
+
+Newly relevant because: agent audit is a live problem *right now*. When a Claude Code instance makes a decision nobody understood in retrospect, "why did you let it do that?" is the question that matters. Grep-able logs of tool calls don't answer it. Proof trees do.
+
+Old technique, new audience.
+
+---
+
+## 5. The zeitgeist, sharpened
+
+**Is logic-programming-for-policy a dead tradition or a live one?** Live, but with a specific shape.
+
+- **Cloud-native human/service authorization**: solved. OPA won. Cedar is the formally-verified second-generation.
+- **Agent-to-tool authorization**: nascent. No standard language. Every framework (LangChain, AutoGPT, Claude Code hooks, OpenAI function-calling, MCP) hand-rolls its own ad-hoc guards.
+
+We sit at the second category. The first category's solutions don't transfer cleanly:
+- OPA's pull-based evaluation (service calls into OPA for each request) doesn't match hook-driven agent flow.
+- Cedar's principal/action/resource trio doesn't cover coordination or intelligence.
+- Polar's inheritance model targets RBAC, not stance-based regulation.
+
+The space is open, and it's a market — Oso's pivot to AI-agent authorization (mid-2020s) is evidence that somebody with enough capital sees the opportunity. The question isn't whether to fight for this space; it's what shape the winning language has.
+
+Our bet: agent-policy is different enough from service-policy that it needs a different schema (VSM), a different authoring surface (CSS), and a different feedback loop (ratchet). If we're right, umwelt is the reference language for the specified band. If we're wrong, we've built a well-designed boutique DSL.
+
+---
+
+## 6. Open questions and research directions
+
+Worth flagging for later work:
+
+1. **Strict generalized specificity** — prove or disprove that `axis_count`-first cascade approximates DeLP's subset-defeat. If it doesn't, find the counterexample and decide whether to fix it or accept the approximation.
+2. **Datalog IR as compiler target** — v1.x project. If views compile to Datalog IR and compilers register queries, the compiler protocol collapses to one primitive. Interesting engineering problem.
+3. **Recursive rules** — currently disallowed. Some policies want them ("transitively deny everything reachable from a denied resource"). Datalog with stratified negation handles this; requires careful semantics work.
+4. **Formal soundness proof** — following Cedar's template, mechanize the specified-band guarantee in Lean or Coq. Paper-grade work.
+5. **ILP backend for the ratchet** — currently ad-hoc pattern matching. Replacing with Aleph or Metagol would be rigorous. Open question whether the ergonomic cost is worth the formal gain.
+6. **Differential evaluation** — live-updating views as observations stream in. Materialize-style incremental Datalog. Useful for IDE integrations.
+
+---
+
+## 7. References (for the blog post to plunder)
+
+Not exhaustive. Just the names the blog author will want to have in hand.
+
+**Foundational**:
+- Ullman, *Principles of Database and Knowledge-Base Systems* (Datalog semantics, 1989)
+- Levy, *Capability-Based Computer Systems* (1984)
+- Beer, *Brain of the Firm* (VSM, 1972); *The Heart of Enterprise* (1979); *Diagnosing the System for Organizations* (1985)
+- Muggleton, "Inductive Logic Programming" (1991)
+
+**Classical access-control**:
+- Lampson, "Computer Security in the Real World" (2000); proof-carrying authorization work (1999)
+- Abadi, "Logic in Access Control" (2003), "A Calculus for Access Control in Distributed Systems" (1993)
+- Appel & Felten, "Proof-Carrying Authentication" (1999)
+
+**Datalog-based policy (2000s)**:
+- DeTreville, "Binder, a Logic-Based Security Language" (2002)
+- Jim, "SD3: A Trust Management System with Certified Evaluation" (2001)
+- Becker & Sewell, "Cassandra: Flexible Trust Management, Applied to Electronic Health Records" (2004)
+
+**Modern deployments**:
+- Sandall et al., OPA / Rego (CNCF project, ~2016–present)
+- Cutler et al., Cedar (Amazon, 2023); formal verification paper (POPL 2024 or adjacent)
+- Oso / Polar (company launched 2020)
+- Zanzibar paper (Google, 2019); SpiceDB as open-source successor
+
+**Defeasible reasoning**:
+- García & Simari, "Defeasible Logic Programming: An Argumentative Approach" (2004)
+- Brewka, "Logic Programming with Ordered Disjunction" (2003)
+
+**Research currents**:
+- McSherry et al., Differential Dataflow (2013–present)
+- Madsen et al., Flix (ongoing)
+- Scholz et al., Soufflé (2016–present)
+- Cropper & Dumančić, Popper (modern ILP, late 2010s–present)
+
+**The Ma series itself**:
+- `judgementalmonad.com/blog/ma/00-intro` and subsequent posts
+- `judgementalmonad.com/blog/fuel/00-ratchet-review`
+
+---
+
+## 8. One-paragraph summary (for if somebody stops us in the hallway)
+
+> A umwelt view is a Datalog program written in CSS syntax, partitioned by Stafford Beer's Viable System Model, cascading by generalized specificity, emitting proof trees for audit, and authored iteratively via an ILP-style ratchet over observed agent behavior. We're one of several tools reapplying logic-programming to policy in the LLM-agent era — alongside Oso, OPA, and Cedar — but the only one whose schema is VSM-derived and whose subject is explicitly a non-deterministic agent rather than a deterministic user or service. The formalism is forty years old; the syntax is thirty years old; the application is new.
+
+---
+
+*End of note. Blog author: everything in §4–§6 is fair game for a post; §7 is the citation pool.*

--- a/docs/vision/notes/vsm-alignment.md
+++ b/docs/vision/notes/vsm-alignment.md
@@ -1,0 +1,132 @@
+# Note: VSM alignment — umwelt taxa as Beer's Viable System Model
+
+*Captured 2026-04-14 during the v0.5 VSM restructure. Reader's on-ramp
+to "why Beer?" Companions: the formal spec at
+`docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md`
+and the Datalog-framing note at `logic-semantics.md`.*
+
+---
+
+## What VSM gave us
+
+Stafford Beer's Viable System Model (VSM, 1972–1985) names five systems
+inside an organism embedded in its environment:
+
+| System | Beer's name | What it does |
+|---|---|---|
+| S5 | Identity / policy | Who are we; what's our purpose. |
+| S4 | Intelligence | Outside-and-then: scanning environment, anticipating. |
+| S3 | Internal control | Inside-and-now: moment-to-moment regulation. |
+| S3\* | Audit | Bypass channel; direct observation of S1 without S2/S3 interference. |
+| S2 | Coordination | Anti-oscillation among S1 units. |
+| S1 | Operations | The doing. |
+| — | Environment | What S1 acts on and what S4 watches. |
+
+Before v0.5, umwelt had five taxa (`world`, `capability`, `state`,
+`actor`, `policy`) that were a mixed bag: `state` smeared S2 (hooks), S3
+(budgets, jobs), and S4 (observations) into one bucket; `actor` smeared
+S1 (executor), S4 (inferencer), and S5 (principal) into another. That's
+why adding modes had no clean home: `state` was three different systems
+wearing one hat.
+
+v0.5 splits them along Beer's axes. Seven taxa:
+
+| umwelt taxon | VSM system | Entities (v0.5) |
+|---|---|---|
+| `principal` | S5 | principal |
+| `world` | environment | file, dir, mount, network, env, exec, resource |
+| `audit` | S3\* | observation, manifest |
+| `control` (alias of `state`) | S3 | budget, job; mode (v1.1+) |
+| `coordination` (alias of `state`) | S2 | hook |
+| `intelligence` (alias of `actor`) | S4 | inferencer |
+| `operation` (alias of `capability`) | S1 | tool, kit, executor, use |
+
+The VSM names are aliases in v0.5 so legacy code keeps working; `state`
+and `actor` still resolve correctly. A physical split (separate
+`coordination` and `control` taxa with separate matchers) is a v0.6+
+concern.
+
+## The outside-in chain
+
+VSM is usually diagrammed as nested envelopes. umwelt preserves that
+nesting in selector order:
+
+```
+audit                                     ← outside everything (S3*)
+  principal                               S5    "running-in"
+    world                                 S0    "in"
+      control                             S3    "with mode / under budget"
+        coordination                      S2    "via harness"
+          intelligence                    S4    "reasoned-by inferencer"
+            operation                     S1    "through tool"
+              use[of=...]                       "operating on resource"
+```
+
+A rule like:
+
+```css
+principal#Teague world#sandbox-123 mode.testing harness#claude-code
+  inferencer#opus-46 tool#Bash exec#sed use[of="file#/foo.txt"]
+  { editable: true; }
+```
+
+reads naturally as a single cross-axis conjunction. The descendant
+combinator is one syntactic primitive; the meaning of each crossing is
+emergent from which axes it joins.
+
+## The S3↔S4 inversion
+
+In Beer's VSM, S3 (inside/now) and S4 (outside/then) are **peers** that
+resolve tension at S5. umwelt inverts this for bounded delegation:
+**S3/S2 dominate S4**. The regulator (coordination + control) constrains
+the reasoner (intelligence); the reasoner doesn't resolve tension with
+S3 as a peer.
+
+This is the architectural move that makes the specified band coherent.
+A delegate is a system whose own S4 is bounded by an externally-imposed
+S3. Without this inversion, a sufficiently capable inferencer could
+reason its way past its regulator — which is precisely the failure mode
+the specified band is designed to prevent.
+
+## Audit outside the world
+
+S3\* bypasses normal reporting. Beer's point: the auditor sees S1
+directly without going through S2/S3 interpretation. umwelt honors this
+architecturally: `@audit { ... }` is an at-rule scope that sits *outside*
+the world hierarchy. Audit entries are selectable from any scope, never
+subject to world-qualifiers.
+
+This maps naturally to how observation tools work in practice:
+`blq`, `ratchet-detect`, `strace` watch *from outside* the delegate's
+world. The observation stream they produce flows into `@audit`; it does
+not live inside `world`.
+
+## Why this matters for compilers
+
+Compilers live at different altitudes (OS, language, semantic). Each
+altitude reads a subset of the VSM axes:
+
+| Compiler | Altitude | Reads | Writes |
+|---|---|---|---|
+| nsjail | OS | world-axis (file, mount, resource, network, env, exec) | nsjail textproto |
+| bwrap | OS | world-axis | bwrap argv |
+| lackpy-namespace | language | operation-axis (tool allow/deny, use for tool-level gating) | Python dict |
+| kibitzer-hooks (v0.6) | semantic | control (mode writable), operation (use for per-tool gating) | TOML |
+
+The VSM partition tells each compiler which axes are in-scope. No
+compiler reads audit (that's what dedicated observation consumers will
+do in v0.7).
+
+## Why this matters for authors
+
+If you can say "this rule is about the principal," or "about the
+harness," or "about the current mode," the rule has a single home and
+the rest of the view is uncluttered. CSS-cascade familiarity carries
+over: more axes named → more specific rule → wins the cascade.
+
+## Further reading
+
+- `docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md` — the formal spec.
+- `docs/vision/notes/logic-semantics.md` — Datalog framing of the same structure.
+- `docs/vision/evaluation-framework.md` — claim ledger; G1 is the VSM-fidelity claim this note supports.
+- Beer, *Brain of the Firm* (1972), *The Heart of Enterprise* (1979), *Diagnosing the System for Organizations* (1985).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "umwelt"
-version = "0.4.0"
+version = "0.5.0"
 description = "The common language of the specified band. A CSS-shaped declarative format for policy specification."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/umwelt/__init__.py
+++ b/src/umwelt/__init__.py
@@ -9,7 +9,7 @@ from umwelt.errors import (
     ViewValidationError,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "ParseWarning",

--- a/src/umwelt/ast.py
+++ b/src/umwelt/ast.py
@@ -80,7 +80,7 @@ class ComplexSelector:
 
     parts: tuple[CompoundPart, ...]
     target_taxon: str
-    specificity: tuple[int, int, int]
+    specificity: tuple[int, ...]
 
 
 @dataclass(frozen=True)

--- a/src/umwelt/audit.py
+++ b/src/umwelt/audit.py
@@ -42,7 +42,7 @@ class PropertyAttribution:
     property_name: str
     value: str
     source_line: int
-    specificity: tuple[int, int, int]
+    specificity: tuple[int, ...]
     is_widening: bool = False
     widened_from_line: int | None = None
 

--- a/src/umwelt/cascade/resolver.py
+++ b/src/umwelt/cascade/resolver.py
@@ -72,7 +72,7 @@ def _filter_rules_by_world_indexed(
 class _RuleApplication:
     rule_index: int
     selector_index: int
-    specificity: tuple[int, int, int]
+    specificity: tuple[int, ...]
     rule: RuleBlock
     selector: ComplexSelector
 

--- a/src/umwelt/cascade/resolver.py
+++ b/src/umwelt/cascade/resolver.py
@@ -84,8 +84,15 @@ class ResolvedView:
     _by_taxon: dict[str, list[tuple[Any, dict[str, str]]]] = field(default_factory=dict)
 
     def entries(self, taxon: str) -> Iterator[tuple[Any, dict[str, str]]]:
-        """Iterate (entity, {property: value}) pairs for a taxon."""
-        yield from self._by_taxon.get(taxon, [])
+        """Iterate (entity, {property: value}) pairs for a taxon.
+
+        Resolves taxon aliases transparently: entries("operation") returns
+        the same results as entries("capability") when "operation" is an
+        alias for "capability".
+        """
+        from umwelt.registry.taxa import resolve_taxon
+        canonical = resolve_taxon(taxon)
+        yield from self._by_taxon.get(canonical, [])
 
     def add(self, taxon: str, entity: Any, properties: dict[str, str]) -> None:
         self._by_taxon.setdefault(taxon, []).append((entity, properties))
@@ -122,7 +129,7 @@ def resolve(view: View, eval_context: Any = None, world: str | None = None) -> R
     # Per-taxon accumulator: list of (entity_key, entity, matching_applications)
     per_taxon: dict[str, list[tuple[int, Any, list[_RuleApplication]]]] = {}
     for app in apps:
-        matched = match_complex(app.selector, eval_context=eval_context)
+        matched = match_complex(app.selector, eval_context=eval_context if eval_context is not None else view)
         for entity in matched:
             key = id(entity)  # entities are not generally hashable
             bucket = per_taxon.setdefault(app.selector.target_taxon, [])

--- a/src/umwelt/cli.py
+++ b/src/umwelt/cli.py
@@ -41,6 +41,7 @@ def _register_matchers(view_file: Path) -> None:
         from umwelt.registry import register_matcher
         from umwelt.sandbox.actor_matcher import ActorMatcher
         from umwelt.sandbox.capability_matcher import CapabilityMatcher
+        from umwelt.sandbox.principal_matcher import PrincipalMatcher
         from umwelt.sandbox.state_matcher import StateMatcher
         from umwelt.sandbox.world_matcher import WorldMatcher
 
@@ -53,6 +54,8 @@ def _register_matchers(view_file: Path) -> None:
             register_matcher(taxon="state", matcher=StateMatcher())
         with contextlib.suppress(RegistryError):
             register_matcher(taxon="actor", matcher=ActorMatcher())
+        with contextlib.suppress(RegistryError):
+            register_matcher(taxon="principal", matcher=PrincipalMatcher())
     except ImportError:
         pass
 

--- a/src/umwelt/cli.py
+++ b/src/umwelt/cli.py
@@ -56,6 +56,9 @@ def _register_matchers(view_file: Path) -> None:
             register_matcher(taxon="actor", matcher=ActorMatcher())
         with contextlib.suppress(RegistryError):
             register_matcher(taxon="principal", matcher=PrincipalMatcher())
+        from umwelt.sandbox.audit_matcher import AuditMatcher
+        with contextlib.suppress(RegistryError):
+            register_matcher(taxon="audit", matcher=AuditMatcher())
     except ImportError:
         pass
 

--- a/src/umwelt/registry/__init__.py
+++ b/src/umwelt/registry/__init__.py
@@ -30,7 +30,9 @@ from umwelt.registry.taxa import (
     get_taxon,
     list_taxa,
     register_taxon,
+    register_taxon_alias,
     registry_scope,
+    resolve_taxon,
 )
 from umwelt.registry.validators import (
     ValidatorProtocol,
@@ -58,7 +60,9 @@ __all__ = [
     "register_matcher",
     "register_property",
     "register_taxon",
+    "register_taxon_alias",
     "register_validator",
     "registry_scope",
     "resolve_entity_type",
+    "resolve_taxon",
 ]

--- a/src/umwelt/registry/entities.py
+++ b/src/umwelt/registry/entities.py
@@ -58,11 +58,22 @@ def register_entity(
     )
 
 
-def get_entity(taxon: str, name: str) -> EntitySchema:
-    """Look up a registered entity by (taxon, name)."""
+def _resolve_taxon(taxon: str) -> str:
+    """Resolve a taxon name through aliases to its canonical name."""
     state = _current_state()
+    return state.taxon_aliases.get(taxon, taxon)
+
+
+def get_entity(taxon: str, name: str) -> EntitySchema:
+    """Look up a registered entity by (taxon, name).
+
+    If `taxon` is an alias, the lookup is transparently resolved to the
+    canonical taxon name.
+    """
+    state = _current_state()
+    canonical = _resolve_taxon(taxon)
     try:
-        return state.entities[(taxon, name)]
+        return state.entities[(canonical, name)]
     except KeyError as exc:
         raise RegistryError(
             f"entity {name!r} not registered in taxon {taxon!r}"
@@ -70,9 +81,13 @@ def get_entity(taxon: str, name: str) -> EntitySchema:
 
 
 def list_entities(taxon: str) -> list[EntitySchema]:
-    """Return all entities registered under a taxon."""
+    """Return all entities registered under a taxon.
+
+    If `taxon` is an alias, entities are listed from the canonical taxon.
+    """
     state = _current_state()
-    return [e for (t, _n), e in state.entities.items() if t == taxon]
+    canonical = _resolve_taxon(taxon)
+    return [e for (t, _n), e in state.entities.items() if t == canonical]
 
 
 def resolve_entity_type(name: str) -> list[str]:

--- a/src/umwelt/registry/entities.py
+++ b/src/umwelt/registry/entities.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from umwelt.errors import RegistryError
-from umwelt.registry.taxa import _current_state, get_taxon
+from umwelt.registry.taxa import _current_state, get_taxon, resolve_taxon
 
 
 @dataclass(frozen=True)
@@ -42,26 +42,21 @@ def register_entity(
     """Register an entity type under a taxon."""
     # Verify the taxon exists first (raises RegistryError if not).
     get_taxon(taxon)
+    canonical = resolve_taxon(taxon)
     state = _current_state()
-    key = (taxon, name)
+    key = (canonical, name)
     if key in state.entities:
         raise RegistryError(
             f"entity {name!r} already registered in taxon {taxon!r}"
         )
     state.entities[key] = EntitySchema(
         name=name,
-        taxon=taxon,
+        taxon=canonical,
         parent=parent,
         attributes=dict(attributes),
         description=description,
         category=category,
     )
-
-
-def _resolve_taxon(taxon: str) -> str:
-    """Resolve a taxon name through aliases to its canonical name."""
-    state = _current_state()
-    return state.taxon_aliases.get(taxon, taxon)
 
 
 def get_entity(taxon: str, name: str) -> EntitySchema:
@@ -71,7 +66,7 @@ def get_entity(taxon: str, name: str) -> EntitySchema:
     canonical taxon name.
     """
     state = _current_state()
-    canonical = _resolve_taxon(taxon)
+    canonical = resolve_taxon(taxon)
     try:
         return state.entities[(canonical, name)]
     except KeyError as exc:
@@ -86,7 +81,7 @@ def list_entities(taxon: str) -> list[EntitySchema]:
     If `taxon` is an alias, entities are listed from the canonical taxon.
     """
     state = _current_state()
-    canonical = _resolve_taxon(taxon)
+    canonical = resolve_taxon(taxon)
     return [e for (t, _n), e in state.entities.items() if t == canonical]
 
 

--- a/src/umwelt/registry/matchers.py
+++ b/src/umwelt/registry/matchers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 from umwelt.errors import RegistryError
-from umwelt.registry.taxa import _current_state, get_taxon
+from umwelt.registry.taxa import _current_state, get_taxon, resolve_taxon
 
 
 @runtime_checkable
@@ -68,18 +68,20 @@ class MatcherProtocol(Protocol):
 
 
 def register_matcher(*, taxon: str, matcher: MatcherProtocol) -> None:
-    """Register a matcher for a taxon."""
+    """Register a matcher for a taxon. Resolves taxon aliases."""
     get_taxon(taxon)  # raises if unknown
+    canonical = resolve_taxon(taxon)
     state = _current_state()
-    if taxon in state.matchers:
+    if canonical in state.matchers:
         raise RegistryError(f"matcher for taxon {taxon!r} already registered")
-    state.matchers[taxon] = matcher
+    state.matchers[canonical] = matcher
 
 
 def get_matcher(taxon: str) -> MatcherProtocol:
-    """Look up the matcher for a taxon."""
+    """Look up the matcher for a taxon. Resolves taxon aliases."""
     state = _current_state()
+    canonical = resolve_taxon(taxon)
     try:
-        return state.matchers[taxon]
+        return state.matchers[canonical]
     except KeyError as exc:
         raise RegistryError(f"no matcher registered for taxon {taxon!r}") from exc

--- a/src/umwelt/registry/properties.py
+++ b/src/umwelt/registry/properties.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 
 from umwelt.errors import RegistryError
 from umwelt.registry.entities import get_entity
-from umwelt.registry.taxa import _current_state
+from umwelt.registry.taxa import _current_state, resolve_taxon
 
 Comparison = Literal["exact", "<=", ">=", "in", "overlap", "pattern-in"]
 
@@ -49,15 +49,16 @@ def register_property(
 ) -> None:
     """Register a property on a (taxon, entity) pair."""
     get_entity(taxon, entity)  # raises if unknown
+    canonical = resolve_taxon(taxon)
     state = _current_state()
-    key = (taxon, entity, name)
+    key = (canonical, entity, name)
     if key in state.properties:
         raise RegistryError(
             f"property {name!r} already registered on {taxon}.{entity}"
         )
     state.properties[key] = PropertySchema(
         name=name,
-        taxon=taxon,
+        taxon=canonical,
         entity=entity,
         value_type=value_type,
         comparison=comparison,
@@ -70,10 +71,11 @@ def register_property(
 
 
 def get_property(taxon: str, entity: str, name: str) -> PropertySchema:
-    """Look up a property by (taxon, entity, name)."""
+    """Look up a property by (taxon, entity, name). Resolves taxon aliases."""
     state = _current_state()
+    canonical = resolve_taxon(taxon)
     try:
-        return state.properties[(taxon, entity, name)]
+        return state.properties[(canonical, entity, name)]
     except KeyError as exc:
         raise RegistryError(
             f"property {name!r} not registered on {taxon}.{entity}"
@@ -81,10 +83,11 @@ def get_property(taxon: str, entity: str, name: str) -> PropertySchema:
 
 
 def list_properties(taxon: str, entity: str) -> list[PropertySchema]:
-    """Return all properties registered on an entity."""
+    """Return all properties registered on an entity. Resolves taxon aliases."""
     state = _current_state()
+    canonical = resolve_taxon(taxon)
     return [
         p
         for (t, e, _n), p in state.properties.items()
-        if t == taxon and e == entity
+        if t == canonical and e == entity
     ]

--- a/src/umwelt/registry/taxa.py
+++ b/src/umwelt/registry/taxa.py
@@ -35,6 +35,8 @@ class RegistryState:
     """
 
     taxa: dict[str, TaxonSchema] = field(default_factory=dict)
+    # Maps alias taxon name → canonical taxon name.
+    taxon_aliases: dict[str, str] = field(default_factory=dict)
     # Keyed by (taxon_name, entity_name)
     entities: dict[tuple[str, str], EntitySchema] = field(default_factory=dict)
     # Keyed by (taxon_name, entity_name, property_name)
@@ -78,9 +80,37 @@ def get_taxon(name: str) -> TaxonSchema:
         raise RegistryError(f"taxon {name!r} not registered") from exc
 
 
+def register_taxon_alias(alias: str, canonical: str) -> None:
+    """Register `alias` as another name for an existing `canonical` taxon.
+
+    After registration, get_taxon(alias) returns the same TaxonSchema as
+    get_taxon(canonical). Both names may be used interchangeably in
+    register_entity(taxon=...) and view.entries(...) calls.
+
+    Entity lookups via the alias are resolved transparently: get_entity(alias,
+    name) returns the same result as get_entity(canonical, name).
+
+    Raises:
+        KeyError: if `canonical` has not been registered.
+        ValueError: if `alias` is already a registered taxon or alias.
+    """
+    state = _current_state()
+    if canonical not in state.taxa:
+        raise KeyError(f"canonical taxon '{canonical}' not registered")
+    if alias in state.taxa:
+        raise ValueError(f"taxon '{alias}' already exists (cannot alias)")
+    state.taxa[alias] = state.taxa[canonical]
+    state.taxon_aliases[alias] = canonical
+
+
 def list_taxa() -> list[TaxonSchema]:
-    """Return all registered taxa in the active scope."""
-    return list(_current_state().taxa.values())
+    """Return all registered taxa in the active scope, excluding alias entries."""
+    state = _current_state()
+    return [
+        schema
+        for name, schema in state.taxa.items()
+        if name not in state.taxon_aliases
+    ]
 
 
 @contextmanager

--- a/src/umwelt/registry/taxa.py
+++ b/src/umwelt/registry/taxa.py
@@ -97,10 +97,25 @@ def register_taxon_alias(alias: str, canonical: str) -> None:
     state = _current_state()
     if canonical not in state.taxa:
         raise KeyError(f"canonical taxon '{canonical}' not registered")
+    if canonical in state.taxon_aliases:
+        raise ValueError(
+            f"'{canonical}' is itself an alias; alias the canonical directly"
+        )
     if alias in state.taxa:
         raise ValueError(f"taxon '{alias}' already exists (cannot alias)")
     state.taxa[alias] = state.taxa[canonical]
     state.taxon_aliases[alias] = canonical
+
+
+def resolve_taxon(name: str) -> str:
+    """Resolve a taxon name through aliases to its canonical name.
+
+    Public helper used by all registry submodules (entities, properties,
+    matchers, validators) to ensure lookups under an alias route to the
+    canonical key.
+    """
+    state = _current_state()
+    return state.taxon_aliases.get(name, name)
 
 
 def list_taxa() -> list[TaxonSchema]:

--- a/src/umwelt/registry/validators.py
+++ b/src/umwelt/registry/validators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from umwelt.registry.taxa import _current_state, get_taxon
+from umwelt.registry.taxa import _current_state, get_taxon, resolve_taxon
 
 
 @runtime_checkable
@@ -22,10 +22,12 @@ class ValidatorProtocol(Protocol):
 
 def register_validator(*, taxon: str, validator: ValidatorProtocol) -> None:
     get_taxon(taxon)
+    canonical = resolve_taxon(taxon)
     state = _current_state()
-    state.validators.setdefault(taxon, []).append(validator)
+    state.validators.setdefault(canonical, []).append(validator)
 
 
 def get_validators(taxon: str) -> list[ValidatorProtocol]:
     state = _current_state()
-    return list(state.validators.get(taxon, []))
+    canonical = resolve_taxon(taxon)
+    return list(state.validators.get(canonical, []))

--- a/src/umwelt/sandbox/actor_matcher.py
+++ b/src/umwelt/sandbox/actor_matcher.py
@@ -43,8 +43,17 @@ class ActorMatcher:
         return []
 
     def condition_met(self, selector: Any, context: Any = None) -> bool:
-        """No runtime actor state in v0.1 — always False."""
-        return False
+        """Return True if any actor in the list matches the selector.
+
+        When no actors have been registered (the default), returns False.
+        When actors are present, delegates to match_simple to check whether
+        the selector is satisfied by at least one known entity.
+        """
+        if not self._inferencers and not self._executors:
+            return False
+        from umwelt.selector.match import match_simple
+        all_actors: list[Any] = [*self._inferencers, *self._executors]
+        return len(match_simple(selector, self, all_actors)) > 0
 
     def get_attribute(self, entity: Any, name: str) -> Any:
         return getattr(entity, name, None)

--- a/src/umwelt/sandbox/audit_matcher.py
+++ b/src/umwelt/sandbox/audit_matcher.py
@@ -1,0 +1,63 @@
+"""Matcher for the audit taxon (S3*).
+
+Synthesizes ObservationEntity and ManifestEntity instances from parsed
+rules. Same pattern as PrincipalMatcher and UseMatcher.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from umwelt.sandbox.entities import ManifestEntity, ObservationEntity
+
+
+class AuditMatcher:
+    """MatcherProtocol implementation for the audit taxon."""
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        if type_name == "observation":
+            return list(self._synthesize(context, "observation", ObservationEntity))
+        if type_name == "manifest":
+            return list(self._synthesize(context, "manifest", ManifestEntity))
+        if type_name == "*":
+            return (
+                list(self._synthesize(context, "observation", ObservationEntity))
+                + list(self._synthesize(context, "manifest", ManifestEntity))
+            )
+        return []
+
+    def _synthesize(self, context: Any, type_name: str, cls) -> list[Any]:
+        if context is None:
+            return []
+        rules = getattr(context, "rules", None)
+        if rules is None:
+            return []
+        seen: set[str | None] = set()
+        out: list[Any] = []
+        for rule in rules:
+            for sel in rule.selectors:
+                for part in sel.parts:
+                    if part.selector.type_name != type_name:
+                        continue
+                    ident = part.selector.id_value
+                    if ident in seen:
+                        continue
+                    seen.add(ident)
+                    out.append(cls(name=ident))
+        return out
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        return []
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        # Audit entries don't gate other-taxon rules in v0.5.
+        return True
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        if isinstance(entity, (ObservationEntity, ManifestEntity)) and name == "name":
+            return entity.name
+        return None
+
+    def get_id(self, entity: Any) -> str | None:
+        if isinstance(entity, (ObservationEntity, ManifestEntity)):
+            return entity.name
+        return None

--- a/src/umwelt/sandbox/audit_matcher.py
+++ b/src/umwelt/sandbox/audit_matcher.py
@@ -25,7 +25,7 @@ class AuditMatcher:
             )
         return []
 
-    def _synthesize(self, context: Any, type_name: str, cls) -> list[Any]:
+    def _synthesize(self, context: Any, type_name: str, cls: type) -> list[Any]:
         if context is None:
             return []
         rules = getattr(context, "rules", None)

--- a/src/umwelt/sandbox/capability_matcher.py
+++ b/src/umwelt/sandbox/capability_matcher.py
@@ -1,14 +1,15 @@
 """Capability matcher for the capability taxon.
 
-Wraps lists of ToolEntity and KitEntity for selector evaluation by the
-core engine.
+Wraps lists of ToolEntity, KitEntity, and UseEntity for selector evaluation.
+UseEntity instances are synthesized at match time from the view's rules
+(via the context= argument to match_type).
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from umwelt.sandbox.entities import KitEntity, ToolEntity
+from umwelt.sandbox.entities import KitEntity, ToolEntity, UseEntity
 
 
 class CapabilityMatcher:
@@ -27,35 +28,75 @@ class CapabilityMatcher:
             return list(self._tools)
         if type_name == "kit":
             return list(self._kits)
+        if type_name == "use":
+            return list(self._synthesize_uses(context))
         if type_name == "*":
             result: list[Any] = []
             result.extend(self._tools)
             result.extend(self._kits)
+            result.extend(self._synthesize_uses(context))
             return result
         return []
+
+    def _synthesize_uses(self, context: Any) -> list[UseEntity]:
+        """Derive UseEntity instances from use[...] selectors in the view.
+
+        context is the View being resolved. If context is None or has no
+        rules attribute, yield nothing.
+        """
+        if context is None:
+            return []
+        rules = getattr(context, "rules", None)
+        if rules is None:
+            return []
+        seen: set[tuple[str | None, str | None, str | None]] = set()
+        result: list[UseEntity] = []
+        for rule in rules:
+            for sel in rule.selectors:
+                for part in sel.parts:
+                    if part.selector.type_name != "use":
+                        continue
+                    of = None
+                    of_kind = None
+                    of_like = None
+                    for attr in part.selector.attributes:
+                        if attr.name == "of":
+                            of = attr.value
+                        elif attr.name == "of-kind":
+                            of_kind = attr.value
+                        elif attr.name == "of-like":
+                            of_like = attr.value
+                    key = (of, of_kind, of_like)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    result.append(UseEntity(of=of, of_kind=of_kind, of_like=of_like))
+        return result
 
     def children(self, parent: Any, child_type: str) -> list[Any]:
         """No parent-child relationships in the capability taxon."""
         return []
 
     def condition_met(self, selector: Any, context: Any = None) -> bool:
-        """Return True if any tool in this matcher satisfies the selector.
-
-        Used for cross-taxon context qualifiers like:
-            tool[name="Bash"] file[...] { ... }
-
-        The selector is a SimpleSelector whose attribute filters are evaluated
-        against each tool via match_simple.
-        """
         from umwelt.selector.match import match_simple
-
         matched = match_simple(selector, self, list(self._tools))
         return len(matched) > 0
 
     def get_attribute(self, entity: Any, name: str) -> Any:
+        # UseEntity uses of_kind/of_like internally but of-kind/of-like in selectors.
+        if isinstance(entity, UseEntity):
+            if name == "of":
+                return entity.of
+            if name == "of-kind":
+                return entity.of_kind
+            if name == "of-like":
+                return entity.of_like
+            return None
         return getattr(entity, name, None)
 
     def get_id(self, entity: Any) -> str | None:
+        if isinstance(entity, UseEntity):
+            return None  # UseEntity has no natural #id
         name = getattr(entity, "name", None)
         if name is not None:
             return str(name)

--- a/src/umwelt/sandbox/desugar.py
+++ b/src/umwelt/sandbox/desugar.py
@@ -30,6 +30,7 @@ def register_sandbox_sugar() -> None:
     register_sugar("network", _desugar_network)
     register_sugar("budget", _desugar_budget)
     register_sugar("env", _desugar_env)
+    register_sugar("audit", _desugar_audit)
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +367,40 @@ def _desugar_env(
                     span=_span(d),
                 ))
     return rules
+
+
+# ---------------------------------------------------------------------------
+# @audit { observation#coach { source: "kibitzer"; } manifest#current { ... } }
+# → the body's rules, passed through unchanged. Because observation and
+# manifest entities are registered under the audit taxon, the selector
+# parser automatically tags them with target_taxon="audit".
+# ---------------------------------------------------------------------------
+
+def _desugar_audit(
+    node: Any,
+    warnings: list[Any],
+    source_path: Path | None,
+) -> list[RuleBlock]:
+    """Parse @audit body as regular rules; rules target the audit taxon automatically."""
+    content = list(getattr(node, "content", []) or [])
+    if not content:
+        return []
+
+    # Re-parse the @audit body as a rule list.
+    inner_nodes = tinycss2.parse_rule_list(
+        content, skip_comments=True, skip_whitespace=True
+    )
+
+    from umwelt.parser import _build_rule_block  # internal; same pattern as parser internals
+
+    out: list[RuleBlock] = []
+    for inner in inner_nodes:
+        if getattr(inner, "type", None) != "qualified-rule":
+            continue
+        rb = _build_rule_block(inner, warnings, source_path=source_path)
+        if rb is not None:
+            out.append(rb)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/umwelt/sandbox/entities.py
+++ b/src/umwelt/sandbox/entities.py
@@ -153,3 +153,14 @@ class UseEntity:
     of: str | None = None
     of_kind: str | None = None
     of_like: str | None = None
+
+
+@dataclass(frozen=True)
+class PrincipalEntity:
+    """The commissioning principal (S5 — identity axis).
+
+    Carries name (id-like), intent (why), grade (optional Ma-grade 0-4).
+    Principals appear as the outermost qualifier in selectors:
+        principal#Teague use[of="file#X"] { editable: true; }
+    """
+    name: str | None = None

--- a/src/umwelt/sandbox/entities.py
+++ b/src/umwelt/sandbox/entities.py
@@ -164,3 +164,18 @@ class PrincipalEntity:
         principal#Teague use[of="file#X"] { editable: true; }
     """
     name: str | None = None
+
+
+@dataclass(frozen=True)
+class ObservationEntity:
+    """An observation entry emitted by a Layer-2 observer (blq, ratchet-detect).
+
+    Lives in the audit taxon (S3*) — outside the world the delegate occupies.
+    """
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class ManifestEntity:
+    """A workspace manifest reference in the audit taxon."""
+    name: str | None = None

--- a/src/umwelt/sandbox/entities.py
+++ b/src/umwelt/sandbox/entities.py
@@ -135,3 +135,21 @@ class ExecEntity:
     name: str | None = None
     path: str | None = None
     search_path: str | None = None
+
+
+@dataclass(frozen=True)
+class UseEntity:
+    """A permissioned projection of a world entity into the action axis.
+
+    `of` is the target world entity selector, stored as the raw string
+    (e.g. 'file#/src/auth.py'). `of_kind` and `of_like` are kind/prefix
+    forms captured from of-kind= / of-like= attributes.
+
+    Permissions (editable, visible, allow, deny, show) land on use
+    entities during cascade resolution, not on the world entities
+    themselves. See docs/vision/evaluation-framework.md claim A5.
+    """
+
+    of: str | None = None
+    of_kind: str | None = None
+    of_like: str | None = None

--- a/src/umwelt/sandbox/principal_matcher.py
+++ b/src/umwelt/sandbox/principal_matcher.py
@@ -1,0 +1,60 @@
+"""Matcher for the principal taxon (S5).
+
+Synthesizes PrincipalEntity instances from principal[id=] selectors in a
+view — same pattern as UseMatcher. Consumed via context passed from
+cascade/resolver.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from umwelt.sandbox.entities import PrincipalEntity
+
+
+class PrincipalMatcher:
+    """MatcherProtocol implementation for principal taxon."""
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        if type_name not in ("principal", "*"):
+            return []
+        return list(self._synthesize_principals(context))
+
+    def _synthesize_principals(self, context: Any) -> list[PrincipalEntity]:
+        if context is None:
+            return []
+        rules = getattr(context, "rules", None)
+        if rules is None:
+            return []
+        seen: set[str | None] = set()
+        result: list[PrincipalEntity] = []
+        for rule in rules:
+            for sel in rule.selectors:
+                for part in sel.parts:
+                    if part.selector.type_name != "principal":
+                        continue
+                    ident = part.selector.id_value
+                    if ident in seen:
+                        continue
+                    seen.add(ident)
+                    result.append(PrincipalEntity(name=ident))
+        return result
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        return []
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        from umwelt.selector.match import match_simple
+        candidates = self._synthesize_principals(context)
+        return len(match_simple(selector, self, candidates)) > 0
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        if not isinstance(entity, PrincipalEntity):
+            return None
+        if name == "name":
+            return entity.name
+        return None
+
+    def get_id(self, entity: Any) -> str | None:
+        if not isinstance(entity, PrincipalEntity):
+            return None
+        return entity.name

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -13,6 +13,7 @@ from umwelt.registry import (
     register_property,
     register_taxon,
     register_validator,
+    register_taxon_alias,
 )
 
 
@@ -22,8 +23,27 @@ def register_sandbox_vocabulary() -> None:
     _register_capability()
     _register_state()
     _register_actor()
+    _register_vsm_aliases()
     _register_validators()
     _register_sugar()
+
+
+def _register_vsm_aliases() -> None:
+    """Register VSM taxon names as aliases of legacy taxa.
+
+    v0.5: operation/coordination/control/intelligence point at the same
+    underlying taxa as capability/state/actor. The spec's logical split of
+    `state` into `coordination` and `control` is virtual in v0.5 — both
+    names resolve to the same bucket. The physical split happens in v0.6+
+    when the legacy-shim is retired.
+
+    `principal` and `audit` are genuinely new taxa and are registered
+    directly (Task 9 and Task 10), not as aliases.
+    """
+    register_taxon_alias(alias="operation", canonical="capability")
+    register_taxon_alias(alias="coordination", canonical="state")
+    register_taxon_alias(alias="control", canonical="state")
+    register_taxon_alias(alias="intelligence", canonical="actor")
 
 
 def _register_sugar() -> None:

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -25,6 +25,7 @@ def register_sandbox_vocabulary() -> None:
     _register_actor()
     _register_vsm_aliases()
     _register_use()               # NEW
+    _register_principal()         # Task 9: S5 identity axis
     _register_validators()
     _register_sugar()
 
@@ -96,6 +97,28 @@ def _register_use() -> None:
     register_property(taxon="operation", entity="use", name="deny-pattern", value_type=list,
                       comparison="pattern-in",
                       description="Glob patterns for denied invocations of this use.")
+
+
+def _register_principal() -> None:
+    """Register the `principal` taxon — S5 identity axis."""
+    register_taxon(
+        name="principal",
+        description="S5: commissioning identity. Who set the bounds for the delegate.",
+        ma_concept="principal_axis",
+    )
+    register_entity(
+        taxon="principal",
+        name="principal",
+        attributes={
+            "name": AttrSchema(type=str, description="Principal identifier (used as #id)."),
+        },
+        description="The commissioning principal.",
+        category="identity",
+    )
+    register_property(taxon="principal", entity="principal", name="intent", value_type=str,
+                      description="Free-form description of why this delegate was commissioned.")
+    register_property(taxon="principal", entity="principal", name="grade", value_type=int,
+                      description="Ma-grade label (0-4). Consumed by audit; other compilers ignore.")
 
 
 def _register_validators() -> None:

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -24,6 +24,7 @@ def register_sandbox_vocabulary() -> None:
     _register_state()
     _register_actor()
     _register_vsm_aliases()
+    _register_use()               # NEW
     _register_validators()
     _register_sugar()
 
@@ -50,6 +51,51 @@ def _register_sugar() -> None:
     from umwelt.sandbox.desugar import register_sandbox_sugar
 
     register_sandbox_sugar()
+
+
+def _register_use() -> None:
+    """Register the `use` entity — permissioned projection of world resources."""
+    register_entity(
+        taxon="operation",
+        name="use",
+        attributes={
+            "of": AttrSchema(
+                type=str,
+                description="Selector pointing at the world entity (e.g. 'file#/src/auth.py').",
+            ),
+            "of-kind": AttrSchema(
+                type=str,
+                description="Match all uses whose target is of a given kind (e.g. 'file', 'network').",
+            ),
+            "of-like": AttrSchema(
+                type=str,
+                description="Prefix-like match against target paths (e.g. 'file#/src').",
+            ),
+        },
+        description=(
+            "A permissioned projection of a world entity into the action axis. "
+            "Permissions (editable, visible, allow, deny) live on uses, not on "
+            "world entities themselves."
+        ),
+        category="access",
+    )
+
+    register_property(taxon="operation", entity="use", name="editable", value_type=bool,
+                      description="Whether this use grants edit access.")
+    register_property(taxon="operation", entity="use", name="visible", value_type=bool,
+                      description="Whether this use grants visibility.")
+    register_property(taxon="operation", entity="use", name="show", value_type=str,
+                      description="Projection kind: body, outline, signature.")
+    register_property(taxon="operation", entity="use", name="allow", value_type=bool,
+                      description="Whether this use is permitted.")
+    register_property(taxon="operation", entity="use", name="deny", value_type=str,
+                      description="Deny pattern ('*' for blanket deny).")
+    register_property(taxon="operation", entity="use", name="allow-pattern", value_type=list,
+                      comparison="pattern-in",
+                      description="Glob patterns for allowed invocations of this use.")
+    register_property(taxon="operation", entity="use", name="deny-pattern", value_type=list,
+                      comparison="pattern-in",
+                      description="Glob patterns for denied invocations of this use.")
 
 
 def _register_validators() -> None:

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -12,8 +12,8 @@ from umwelt.registry import (
     register_entity,
     register_property,
     register_taxon,
-    register_validator,
     register_taxon_alias,
+    register_validator,
 )
 
 

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -26,6 +26,7 @@ def register_sandbox_vocabulary() -> None:
     _register_vsm_aliases()
     _register_use()               # NEW
     _register_principal()         # Task 9: S5 identity axis
+    _register_audit()             # Task 10: S3* cross-cut observer
     _register_validators()
     _register_sugar()
 
@@ -119,6 +120,40 @@ def _register_principal() -> None:
                       description="Free-form description of why this delegate was commissioned.")
     register_property(taxon="principal", entity="principal", name="grade", value_type=int,
                       description="Ma-grade label (0-4). Consumed by audit; other compilers ignore.")
+
+
+def _register_audit() -> None:
+    """Register the audit taxon (S3*) — cross-cut observer outside the world."""
+    register_taxon(
+        name="audit",
+        description="S3* cross-cut observer. Outside the world it observes.",
+        ma_concept="audit_axis",
+    )
+    register_entity(
+        taxon="audit",
+        name="observation",
+        attributes={
+            "name": AttrSchema(type=str, description="Observation identifier (used as #id)."),
+        },
+        description="A Layer-2 observation entry (blq, ratchet-detect output).",
+        category="observation",
+    )
+    register_entity(
+        taxon="audit",
+        name="manifest",
+        attributes={
+            "name": AttrSchema(type=str, description="Manifest identifier."),
+        },
+        description="A workspace manifest reference.",
+        category="manifest",
+    )
+
+    register_property(taxon="audit", entity="observation", name="source", value_type=str,
+                     description="Observer source (e.g. 'kibitzer', 'ratchet-detect').")
+    register_property(taxon="audit", entity="observation", name="enabled", value_type=bool,
+                     description="Whether this observation is enabled.")
+    register_property(taxon="audit", entity="manifest", name="path", value_type=str,
+                     description="Path to the manifest file.")
 
 
 def _register_validators() -> None:

--- a/src/umwelt/selector/match.py
+++ b/src/umwelt/selector/match.py
@@ -137,9 +137,9 @@ def match_complex(
             if type_name == "*":
                 # Universal — the matcher doesn't know about * natively; use
                 # a best-effort approach: match every type the matcher owns.
-                candidates: list[Any] = matcher.match_type("*")
+                candidates: list[Any] = matcher.match_type("*", context=eval_context)
             else:
-                candidates = matcher.match_type(type_name)
+                candidates = matcher.match_type(type_name, context=eval_context)
         else:
             # Subsequent structural part: navigate from the previous frontier.
             type_name = part.selector.type_name or "*"

--- a/src/umwelt/selector/specificity.py
+++ b/src/umwelt/selector/specificity.py
@@ -1,38 +1,93 @@
-"""CSS3 specificity computation for umwelt selectors.
+"""Cross-axis cascade specificity.
 
-Per CSS3, specificity is a tuple (ids, classes+attrs+pseudos, types):
+v0.5 extends CSS3 specificity with an axis_count-first tuple that captures
+how many distinct taxon-axes a compound selector names. A rule joining more
+axes is more specific than a rule naming fewer axes, regardless of within-
+axis CSS3 counts. Matches the VSM-lattice view: a rule scoped to
+(inferencer, tool, use) is more contextualized than a rule scoped to just
+(use).
 
-- Count of IDs in the selector.
-- Count of classes + attribute selectors + pseudo-classes.
-- Count of type selectors (the universal selector * contributes 0).
+Tuple layout:
+    (
+        axis_count,
+        principal_weight,
+        world_weight,
+        state_weight,        # coordination + control
+        actor_weight,        # intelligence
+        capability_weight,   # operation + use
+        audit_weight,
+    )
 
-For a compound selector, each simple selector's tuple is summed
-component-wise.
+Each axis weight packs CSS3's (id, class+attr+pseudo, type) counts into a
+single integer via id*10_000 + cap*100 + types. This lets axis_count
+dominate the tuple's primary ordering while preserving exact within-axis
+CSS3 behavior as the secondary ordering.
+
+See docs/vision/evaluation-framework.md claims A2 and A3.
 """
-
 from __future__ import annotations
 
 from umwelt.ast import ComplexSelector, SimpleSelector
 
 
-def simple_specificity(selector: SimpleSelector) -> tuple[int, int, int]:
+_AXES = ("principal", "world", "state", "actor", "capability", "audit")
+
+
+def _simple_weight(selector: SimpleSelector) -> int:
     ids = 1 if selector.id_value is not None else 0
-    classes_attrs_pseudos = (
+    cap = (
         len(selector.classes)
         + len(selector.attributes)
         + len(selector.pseudo_classes)
     )
     types = 1 if (selector.type_name is not None and selector.type_name != "*") else 0
-    return (ids, classes_attrs_pseudos, types)
+    return ids * 10_000 + cap * 100 + types
 
 
-def compound_specificity(compound: ComplexSelector) -> tuple[int, int, int]:
-    total_ids = 0
-    total_cap = 0
-    total_types = 0
+def _canonical_axis(taxon: str) -> str:
+    """Map alias taxa to canonical axis names for specificity accounting."""
+    if taxon in ("coordination", "control"):
+        return "state"
+    if taxon == "intelligence":
+        return "actor"
+    if taxon == "operation":
+        return "capability"
+    return taxon
+
+
+def compound_specificity(compound: ComplexSelector) -> tuple:
+    weights = {axis: 0 for axis in _AXES}
+    other_weight = 0
+    axes_seen: set[str] = set()
     for part in compound.parts:
-        ids, cap, types = simple_specificity(part.selector)
-        total_ids += ids
-        total_cap += cap
-        total_types += types
-    return (total_ids, total_cap, total_types)
+        axis = _canonical_axis(part.selector.taxon)
+        w = _simple_weight(part.selector)
+        if axis in weights:
+            weights[axis] += w
+        else:
+            other_weight += w
+        if part.selector.type_name is not None and part.selector.type_name != "*":
+            axes_seen.add(axis)
+    return (
+        len(axes_seen),
+        weights.get("principal", 0),
+        weights.get("world", 0),
+        weights.get("state", 0),
+        weights.get("actor", 0),
+        weights.get("capability", 0),
+        weights.get("audit", 0),
+        other_weight,
+    )
+
+
+# Back-compat: some callers still expect simple_specificity to return a
+# 3-tuple. Preserve the CSS3-shape output for them.
+def simple_specificity(selector: SimpleSelector) -> tuple[int, int, int]:
+    ids = 1 if selector.id_value is not None else 0
+    cap = (
+        len(selector.classes)
+        + len(selector.attributes)
+        + len(selector.pseudo_classes)
+    )
+    types = 1 if (selector.type_name is not None and selector.type_name != "*") else 0
+    return (ids, cap, types)

--- a/src/umwelt/selector/specificity.py
+++ b/src/umwelt/selector/specificity.py
@@ -54,7 +54,7 @@ def _canonical_axis(taxon: str) -> str:
     return taxon
 
 
-def compound_specificity(compound: ComplexSelector) -> tuple:
+def compound_specificity(compound: ComplexSelector) -> tuple[int, ...]:
     weights = {axis: 0 for axis in _AXES}
     other_weight = 0
     axes_seen: set[str] = set()

--- a/src/umwelt/selector/specificity.py
+++ b/src/umwelt/selector/specificity.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 from umwelt.ast import ComplexSelector, SimpleSelector
 
-
 _AXES = ("principal", "world", "state", "actor", "capability", "audit")
 
 

--- a/tests/cascade/test_cross_axis_specificity.py
+++ b/tests/cascade/test_cross_axis_specificity.py
@@ -1,0 +1,132 @@
+"""Cross-axis cascade specificity tests.
+
+Verifies claims A2 (cascade is well-ordered — no cycles across the new
+axis_count primacy) and A3 (cross-axis soundness: rules that join more
+taxa-axes are more specific than rules naming fewer axes). See
+docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+import pytest
+from umwelt.parser import parse
+from umwelt.cascade.resolver import resolve
+from umwelt.registry import registry_scope, register_matcher
+from umwelt.sandbox.actor_matcher import ActorMatcher
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.entities import InferencerEntity, UseEntity
+from umwelt.sandbox.state_matcher import StateMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+
+@pytest.fixture
+def vocab_with_matchers(tmp_path):
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=tmp_path))
+        register_matcher(taxon="capability", matcher=CapabilityMatcher())
+        register_matcher(taxon="state", matcher=StateMatcher())
+        # Include a live inferencer so condition_met can match it.
+        register_matcher(
+            taxon="actor",
+            matcher=ActorMatcher(inferencers=[InferencerEntity(model="gpt-4o")]),
+        )
+        yield tmp_path
+
+
+def _parse(text: str, tmp_path):
+    p = tmp_path / "test.umw"
+    p.write_text(text)
+    return parse(p)
+
+
+def _specs(view):
+    return [sel.specificity for rule in view.rules for sel in rule.selectors]
+
+
+def test_single_axis_specificity_has_axis_count_one(vocab_with_matchers):
+    """A3: a single-axis selector has axis_count=1."""
+    view = _parse('file[path="x"] { editable: true; }', vocab_with_matchers)
+    spec = _specs(view)[0]
+    assert len(spec) >= 2
+    assert spec[0] == 1
+
+
+def test_cross_axis_has_higher_axis_count(vocab_with_matchers):
+    """A3: a two-axis selector has axis_count=2, strictly greater than 1."""
+    one_axis = _specs(_parse('file[path="x"] { editable: true; }', vocab_with_matchers))[0]
+    two_axis = _specs(_parse(
+        'inferencer tool[name="Edit"] { allow: true; }', vocab_with_matchers,
+    ))[0]
+    assert two_axis[0] > one_axis[0]
+    assert two_axis > one_axis
+
+
+def test_three_axis_beats_two_axis(vocab_with_matchers):
+    """A3: three-axis selector beats two-axis selector by tuple comparison."""
+    two = _specs(_parse(
+        'tool[name="Edit"] use[of="file#x"] { editable: true; }', vocab_with_matchers,
+    ))[0]
+    three = _specs(_parse(
+        'inferencer tool[name="Edit"] use[of="file#x"] { editable: true; }',
+        vocab_with_matchers,
+    ))[0]
+    assert three > two
+
+
+def test_bare_selector_less_specific_than_attribute_selector(vocab_with_matchers):
+    """A2: within a single axis, attribute filters beat bare selectors."""
+    bare = _specs(_parse('use { editable: true; }', vocab_with_matchers))[0]
+    attr = _specs(_parse('use[of="file#x"] { editable: true; }', vocab_with_matchers))[0]
+    assert attr > bare
+
+
+def test_id_beats_class_within_same_axis(vocab_with_matchers):
+    """A2: standard CSS specificity preserved within an axis."""
+    cls = _specs(_parse('file.foo { editable: true; }', vocab_with_matchers))[0]
+    ide = _specs(_parse('file#foo { editable: true; }', vocab_with_matchers))[0]
+    assert ide > cls
+
+
+def test_cross_axis_rule_wins_over_single_axis_in_cascade(vocab_with_matchers):
+    """A3: the cross-axis rule resolves to the winning value even when document order favors the single-axis rule."""
+    # Single-axis rule comes first (lower document order), cross-axis rule second.
+    # Cross-axis should win because axis_count=2 > axis_count=1.
+    view = _parse('''
+        use[of="file#/src/auth.py"] { editable: false; }
+        inferencer use[of="file#/src/auth.py"] { editable: true; }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    specific = [p for e, p in uses if e.of == "file#/src/auth.py"]
+    assert specific, "expected a use entity with of=file#/src/auth.py"
+    assert any(p.get("editable") == "true" for p in specific), (
+        "cross-axis rule should win over single-axis"
+    )
+
+
+def test_document_order_breaks_ties_within_same_specificity(vocab_with_matchers):
+    """A2: identical specificity → later rule wins (document order tiebreaker)."""
+    view = _parse('''
+        use[of="file#x"] { editable: false; }
+        use[of="file#x"] { editable: true; }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    specific = [p for e, p in uses if e.of == "file#x"]
+    assert any(p.get("editable") == "true" for p in specific)
+
+
+def test_specificity_tuple_is_well_ordered_no_cycles(vocab_with_matchers):
+    """A2: tuple comparison never yields cycles. Sample ordering across common cases."""
+    specs = [
+        _specs(_parse('use { editable: true; }', vocab_with_matchers))[0],
+        _specs(_parse('use[of-kind="file"] { editable: true; }', vocab_with_matchers))[0],
+        _specs(_parse('use[of="file#x"] { editable: true; }', vocab_with_matchers))[0],
+        _specs(_parse('tool use[of="file#x"] { editable: true; }', vocab_with_matchers))[0],
+        _specs(_parse('inferencer tool use[of="file#x"] { editable: true; }', vocab_with_matchers))[0],
+    ]
+    # Strictly monotone by construction.
+    for a, b in zip(specs, specs[1:]):
+        assert b >= a, f"expected non-decreasing specificity: {a} → {b}"
+    assert specs[-1] > specs[0]

--- a/tests/cascade/test_cross_axis_specificity.py
+++ b/tests/cascade/test_cross_axis_specificity.py
@@ -7,10 +7,13 @@ docs/vision/evaluation-framework.md.
 """
 from __future__ import annotations
 
+import itertools
+
 import pytest
-from umwelt.parser import parse
+
 from umwelt.cascade.resolver import resolve
-from umwelt.registry import registry_scope, register_matcher
+from umwelt.parser import parse
+from umwelt.registry import register_matcher, registry_scope
 from umwelt.sandbox.actor_matcher import ActorMatcher
 from umwelt.sandbox.capability_matcher import CapabilityMatcher
 from umwelt.sandbox.entities import InferencerEntity, UseEntity
@@ -127,6 +130,6 @@ def test_specificity_tuple_is_well_ordered_no_cycles(vocab_with_matchers):
         _specs(_parse('inferencer tool use[of="file#x"] { editable: true; }', vocab_with_matchers))[0],
     ]
     # Strictly monotone by construction.
-    for a, b in zip(specs, specs[1:]):
+    for a, b in itertools.pairwise(specs):
         assert b >= a, f"expected non-decreasing specificity: {a} → {b}"
     assert specs[-1] > specs[0]

--- a/tests/cascade/test_determinism.py
+++ b/tests/cascade/test_determinism.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from umwelt.parser import parse
+
 from umwelt.cascade.resolver import resolve
-from umwelt.registry import registry_scope, register_matcher
+from umwelt.parser import parse
+from umwelt.registry import register_matcher, registry_scope
 from umwelt.sandbox.actor_matcher import ActorMatcher
 from umwelt.sandbox.capability_matcher import CapabilityMatcher
 from umwelt.sandbox.state_matcher import StateMatcher

--- a/tests/cascade/test_determinism.py
+++ b/tests/cascade/test_determinism.py
@@ -1,0 +1,64 @@
+"""Verifies claim A1 (resolver determinism): resolving the same view twice
+produces identical ResolvedView.
+
+Tier 0 — foundational. See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from umwelt.parser import parse
+from umwelt.cascade.resolver import resolve
+from umwelt.registry import registry_scope, register_matcher
+from umwelt.sandbox.actor_matcher import ActorMatcher
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.state_matcher import StateMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "src" / "umwelt" / "_fixtures"
+
+
+@pytest.fixture(autouse=True)
+def vocab_scope():
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=FIXTURE_DIR))
+        register_matcher(taxon="capability", matcher=CapabilityMatcher())
+        register_matcher(taxon="state", matcher=StateMatcher())
+        register_matcher(taxon="actor", matcher=ActorMatcher())
+        yield
+
+
+def _resolved_signature(rv):
+    """A stable, hashable signature of a ResolvedView for comparison."""
+    sig = []
+    for taxon in sorted(rv.taxa()):
+        for entity, props in rv.entries(taxon):
+            sig.append((taxon, type(entity).__name__, tuple(sorted(props.items()))))
+    return tuple(sig)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted(FIXTURE_DIR.glob("*.umw")),
+    ids=lambda p: p.name,
+)
+def test_resolve_is_deterministic(fixture):
+    """A1: resolving the same view twice yields the same ResolvedView."""
+    view = parse(fixture)
+    rv1 = resolve(view)
+    rv2 = resolve(view)
+    assert _resolved_signature(rv1) == _resolved_signature(rv2)
+
+
+def test_resolve_deterministic_across_many_runs():
+    """A1: 50 runs of the same fixture all produce identical signatures."""
+    fixtures = sorted(FIXTURE_DIR.glob("*.umw"))
+    if not fixtures:
+        pytest.skip("no fixtures to test")
+    fixture = fixtures[0]
+    view = parse(fixture)
+    signatures = {_resolved_signature(resolve(view)) for _ in range(50)}
+    assert len(signatures) == 1, f"resolver non-deterministic: {len(signatures)} distinct results"

--- a/tests/core/test_of_attr_parse.py
+++ b/tests/core/test_of_attr_parse.py
@@ -1,0 +1,76 @@
+"""Tests that the selector parser accepts complex of= attribute values.
+
+These values contain '/', '#', and pseudo-class expressions because they
+are world-entity selectors embedded as attribute strings. Locks in
+parser behavior for the Task 4 UseMatcher.
+"""
+from __future__ import annotations
+
+from umwelt.parser import parse
+from umwelt.registry import registry_scope
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+
+def _install():
+    """Register the sandbox vocabulary (including `use`) into the active scope."""
+    register_sandbox_vocabulary()
+
+
+def test_of_attr_with_slash_and_hash():
+    with registry_scope():
+        _install()
+        view = parse('use[of="file#/src/auth.py"] { editable: true; }')
+    assert len(view.rules) == 1
+    rule = view.rules[0]
+    assert len(rule.selectors) == 1
+    sel = rule.selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    of_attr = next((a for a in attrs if a.name == "of"), None)
+    assert of_attr is not None
+    assert of_attr.value == "file#/src/auth.py"
+
+
+def test_of_kind_attr():
+    with registry_scope():
+        _install()
+        view = parse('use[of-kind="file"] { editable: false; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    ok = next((a for a in attrs if a.name == "of-kind"), None)
+    assert ok is not None
+    assert ok.value == "file"
+
+
+def test_of_like_attr():
+    with registry_scope():
+        _install()
+        view = parse('use[of-like="file#/src"] { editable: true; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    ol = next((a for a in attrs if a.name == "of-like"), None)
+    assert ol is not None
+    assert ol.value == "file#/src"
+
+
+def test_of_attr_preserves_pseudo_class_syntax():
+    """The parser should not mangle a pseudo-class expression inside of=."""
+    with registry_scope():
+        _install()
+        view = parse("use[of=\"file:glob('src/**/*.py')\"] { editable: true; }")
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    of_attr = next((a for a in attrs if a.name == "of"), None)
+    assert of_attr is not None
+    # The parser should preserve the whole pseudo-class expression as a string.
+    assert "glob" in of_attr.value
+
+
+def test_of_attr_with_multiple_segments():
+    with registry_scope():
+        _install()
+        view = parse('use[of="file#/a/b/c/d/e/f.py"] { editable: true; }')
+    sel = view.rules[0].selectors[0]
+    attrs = sel.parts[-1].selector.attributes
+    of_attr = next((a for a in attrs if a.name == "of"), None)
+    assert of_attr is not None
+    assert of_attr.value == "file#/a/b/c/d/e/f.py"

--- a/tests/core/test_specificity.py
+++ b/tests/core/test_specificity.py
@@ -1,4 +1,13 @@
-"""Tests for CSS3 specificity computation."""
+"""Tests for CSS3 specificity computation.
+
+v0.5: the specificity tuple is now axis_count-first. These tests verify
+the ordering invariants (A2: well-ordered) rather than exact tuple values,
+since the internal encoding changed. The ordering must remain:
+  universal < bare-type < class/attr < id.
+
+For cross-taxon compound selectors, the axis_count component (spec[0])
+must be > 1 when multiple distinct taxa are present.
+"""
 
 from __future__ import annotations
 
@@ -11,79 +20,96 @@ def _spec(view, rule_idx: int = 0, sel_idx: int = 0):
     return view.rules[rule_idx].selectors[sel_idx].specificity
 
 
-def test_bare_type_is_0_0_1():
+def test_bare_type_is_less_specific_than_id():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse("thing { }")
-    assert _spec(view) == (0, 0, 1)
+        bare = _spec(parse("thing { }"))
+        with_id = _spec(parse("thing#alpha { }"))
+    assert with_id > bare
 
 
 def test_universal_selector_is_0_0_0():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse("* { }")
-    assert _spec(view) == (0, 0, 0)
+        universal = _spec(parse("* { }"))
+        bare = _spec(parse("thing { }"))
+    # Universal is less specific than any typed selector.
+    assert bare > universal
+    # axis_count for universal is 0 (no type_name).
+    assert universal[0] == 0
 
 
-def test_id_selector_is_1_0_0():
+def test_id_selector_beats_bare_type():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse("thing#alpha { }")
-    assert _spec(view) == (1, 0, 1)
+        bare = _spec(parse("thing { }"))
+        with_id = _spec(parse("thing#alpha { }"))
+    assert with_id > bare
 
 
-def test_attribute_selector_is_0_1_1():
+def test_attribute_selector_beats_bare_type():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse('thing[color="red"] { }')
-    assert _spec(view) == (0, 1, 1)
+        bare = _spec(parse("thing { }"))
+        with_attr = _spec(parse('thing[color="red"] { }'))
+    assert with_attr > bare
 
 
-def test_class_selector_is_0_1_1():
+def test_class_selector_beats_bare_type():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse("thing.highlighted { }")
-    assert _spec(view) == (0, 1, 1)
+        bare = _spec(parse("thing { }"))
+        with_cls = _spec(parse("thing.highlighted { }"))
+    assert with_cls > bare
 
 
-def test_pseudo_class_is_0_1_1():
+def test_pseudo_class_beats_bare_type():
     with registry_scope():
         install_toy_taxonomy()
-        view = parse('thing:glob("*.py") { }')
-    assert _spec(view) == (0, 1, 1)
+        bare = _spec(parse("thing { }"))
+        with_pseudo = _spec(parse('thing:glob("*.py") { }'))
+    assert with_pseudo > bare
 
 
 def test_descendant_accumulates():
-    # thing widget -> (0,0,1) + (0,0,1) = (0,0,2)
+    # thing widget has two typed parts, so it should be more specific than thing.
     with registry_scope():
         install_toy_taxonomy()
-        view = parse("thing widget { }")
-    assert _spec(view) == (0, 0, 2)
+        single = _spec(parse("thing { }"))
+        compound = _spec(parse("thing widget { }"))
+    assert compound > single
 
 
 def test_complex_compound_specificity():
-    # thing#alpha[color="red"] widget.highlighted
-    # left: (1,1,1)
-    # right: (0,1,1)
-    # total: (1,2,2)
+    # thing#alpha[color="red"] widget.highlighted should beat thing#alpha.
     with registry_scope():
         install_toy_taxonomy()
-        view = parse('thing#alpha[color="red"] widget.highlighted { }')
-    assert _spec(view) == (1, 2, 2)
+        simple = _spec(parse("thing#alpha { }"))
+        complex_ = _spec(parse('thing#alpha[color="red"] widget.highlighted { }'))
+    assert complex_ > simple
 
 
-def test_cross_taxon_compound_accumulates_same():
-    # The mode classification doesn't affect specificity — both parts
-    # contribute their tuples regardless.
+def test_cross_taxon_compound_has_axis_count_two():
+    # actor + thing spans two distinct taxa → axis_count == 2.
     with registry_scope():
         install_toy_taxonomy()
-        view = parse('actor[role="admin"] thing#beta { }')
-    assert _spec(view) == (1, 1, 2)
+        spec = _spec(parse('actor[role="admin"] thing#beta { }'))
+    assert spec[0] == 2
+
+
+def test_cross_taxon_beats_single_taxon():
+    with registry_scope():
+        install_toy_taxonomy()
+        single = _spec(parse("thing#beta { }"))
+        cross = _spec(parse('actor[role="admin"] thing#beta { }'))
+    assert cross > single
 
 
 def test_multiple_selectors_each_get_specificity():
     with registry_scope():
         install_toy_taxonomy()
         view = parse("thing, thing#alpha { }")
-    assert view.rules[0].selectors[0].specificity == (0, 0, 1)
-    assert view.rules[0].selectors[1].specificity == (1, 0, 1)
+    spec0 = view.rules[0].selectors[0].specificity
+    spec1 = view.rules[0].selectors[1].specificity
+    # thing#alpha is more specific than thing.
+    assert spec1 > spec0

--- a/tests/registry/test_taxon_aliases.py
+++ b/tests/registry/test_taxon_aliases.py
@@ -1,0 +1,42 @@
+"""Tests for taxon aliasing — multiple names pointing to the same TaxonSchema."""
+from __future__ import annotations
+
+import pytest
+from umwelt.registry import (
+    get_taxon,
+    register_taxon,
+    registry_scope,
+)
+from umwelt.registry.taxa import register_taxon_alias
+
+
+def test_alias_resolves_to_same_schema():
+    with registry_scope():
+        register_taxon(name="state", description="observation layer")
+        register_taxon_alias(alias="coordination", canonical="state")
+        state = get_taxon("state")
+        coordination = get_taxon("coordination")
+        assert state is coordination
+
+
+def test_alias_for_unknown_canonical_raises():
+    with registry_scope():
+        with pytest.raises(KeyError):
+            register_taxon_alias(alias="coordination", canonical="state")
+
+
+def test_alias_collides_with_existing_taxon_raises():
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon(name="coordination", description="")
+        with pytest.raises(ValueError):
+            register_taxon_alias(alias="coordination", canonical="state")
+
+
+def test_list_taxa_includes_aliases():
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon_alias(alias="coordination", canonical="state")
+        from umwelt.registry import list_taxa
+        names = {t.name for t in list_taxa()}
+        assert "state" in names

--- a/tests/registry/test_taxon_aliases.py
+++ b/tests/registry/test_taxon_aliases.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+
 from umwelt.registry import (
     get_taxon,
     register_taxon,
@@ -20,9 +21,8 @@ def test_alias_resolves_to_same_schema():
 
 
 def test_alias_for_unknown_canonical_raises():
-    with registry_scope():
-        with pytest.raises(KeyError):
-            register_taxon_alias(alias="coordination", canonical="state")
+    with registry_scope(), pytest.raises(KeyError):
+        register_taxon_alias(alias="coordination", canonical="state")
 
 
 def test_alias_collides_with_existing_taxon_raises():

--- a/tests/registry/test_taxon_aliases.py
+++ b/tests/registry/test_taxon_aliases.py
@@ -33,10 +33,66 @@ def test_alias_collides_with_existing_taxon_raises():
             register_taxon_alias(alias="coordination", canonical="state")
 
 
-def test_list_taxa_includes_aliases():
+def test_list_taxa_excludes_alias_entries():
     with registry_scope():
         register_taxon(name="state", description="")
         register_taxon_alias(alias="coordination", canonical="state")
         from umwelt.registry import list_taxa
         names = {t.name for t in list_taxa()}
         assert "state" in names
+        assert "coordination" not in names
+
+
+def test_aliasing_an_alias_raises():
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon_alias(alias="coordination", canonical="state")
+        with pytest.raises(ValueError):
+            register_taxon_alias(alias="control", canonical="coordination")
+
+
+def test_properties_resolve_through_alias():
+    from umwelt.registry import (
+        get_property,
+        list_properties,
+        register_entity,
+        register_property,
+    )
+    from umwelt.registry.entities import AttrSchema
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon_alias(alias="coordination", canonical="state")
+        register_entity(
+            taxon="state",
+            name="hook",
+            attributes={"event": AttrSchema(type=str, required=True)},
+            description="",
+        )
+        register_property(
+            taxon="coordination", entity="hook", name="run",
+            value_type=str, description="",
+        )
+        via_canonical = get_property("state", "hook", "run")
+        via_alias = get_property("coordination", "hook", "run")
+        assert via_canonical is via_alias
+        assert len(list_properties("state", "hook")) == 1
+        assert len(list_properties("coordination", "hook")) == 1
+
+
+def test_matchers_resolve_through_alias():
+    from umwelt.registry import get_matcher, register_matcher
+
+    class StubMatcher:
+        def match_type(self, type_name, context=None): return []
+        def children(self, parent, child_type): return []
+        def condition_met(self, selector, context=None): return True
+        def get_attribute(self, entity, name): return None
+        def get_id(self, entity): return None
+
+    with registry_scope():
+        register_taxon(name="state", description="")
+        register_taxon_alias(alias="coordination", canonical="state")
+        m = StubMatcher()
+        register_matcher(taxon="coordination", matcher=m)
+        assert get_matcher("state") is m
+        assert get_matcher("coordination") is m

--- a/tests/sandbox/golden/v05/actor-conditioned.bwrap.golden
+++ b/tests/sandbox/golden/v05/actor-conditioned.bwrap.golden
@@ -1,0 +1,21 @@
+{
+  "argv": [
+    "--clearenv",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/lib",
+    "/lib",
+    "--ro-bind",
+    "/lib64",
+    "/lib64",
+    "--ro-bind",
+    "/sbin",
+    "/sbin"
+  ],
+  "wrapper": []
+}

--- a/tests/sandbox/golden/v05/actor-conditioned.lackpy-namespace.golden
+++ b/tests/sandbox/golden/v05/actor-conditioned.lackpy-namespace.golden
@@ -1,0 +1,8 @@
+{
+  "allow_patterns": {},
+  "allowed_tools": [],
+  "denied_tools": [],
+  "deny_patterns": {},
+  "kits": [],
+  "max_level": null
+}

--- a/tests/sandbox/golden/v05/actor-conditioned.nsjail.golden
+++ b/tests/sandbox/golden/v05/actor-conditioned.nsjail.golden
@@ -1,0 +1,55 @@
+name: "umwelt-sandbox"
+hostname: "umwelt"
+
+mount {
+  src: "/bin"
+  dst: "/bin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/usr"
+  dst: "/usr"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib"
+  dst: "/lib"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib64"
+  dst: "/lib64"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/sbin"
+  dst: "/sbin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  dst: "/proc"
+  fstype: "proc"
+  is_bind: false
+}
+
+mount {
+  dst: "/dev"
+  fstype: "tmpfs"
+  is_bind: false
+}
+
+mount {
+  dst: "/tmp"
+  fstype: "tmpfs"
+  is_bind: false
+}

--- a/tests/sandbox/golden/v05/auth-fix.bwrap.golden
+++ b/tests/sandbox/golden/v05/auth-fix.bwrap.golden
@@ -1,0 +1,27 @@
+{
+  "argv": [
+    "--clearenv",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/lib",
+    "/lib",
+    "--ro-bind",
+    "/lib64",
+    "/lib64",
+    "--ro-bind",
+    "/sbin",
+    "/sbin",
+    "--unshare-net"
+  ],
+  "wrapper": [
+    "prlimit",
+    "--as=536870912",
+    "timeout",
+    "300"
+  ]
+}

--- a/tests/sandbox/golden/v05/auth-fix.lackpy-namespace.golden
+++ b/tests/sandbox/golden/v05/auth-fix.lackpy-namespace.golden
@@ -1,0 +1,8 @@
+{
+  "allow_patterns": {},
+  "allowed_tools": [],
+  "denied_tools": [],
+  "deny_patterns": {},
+  "kits": [],
+  "max_level": null
+}

--- a/tests/sandbox/golden/v05/auth-fix.nsjail.golden
+++ b/tests/sandbox/golden/v05/auth-fix.nsjail.golden
@@ -1,0 +1,62 @@
+name: "umwelt-sandbox"
+hostname: "umwelt"
+
+time_limit: 300
+
+clone_newnet: true
+
+rlimit_as: 512
+rlimit_as_type: SOFT
+
+mount {
+  src: "/bin"
+  dst: "/bin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/usr"
+  dst: "/usr"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib"
+  dst: "/lib"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib64"
+  dst: "/lib64"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/sbin"
+  dst: "/sbin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  dst: "/proc"
+  fstype: "proc"
+  is_bind: false
+}
+
+mount {
+  dst: "/dev"
+  fstype: "tmpfs"
+  is_bind: false
+}
+
+mount {
+  dst: "/tmp"
+  fstype: "tmpfs"
+  is_bind: false
+}

--- a/tests/sandbox/golden/v05/lackpy-delegate.bwrap.golden
+++ b/tests/sandbox/golden/v05/lackpy-delegate.bwrap.golden
@@ -1,0 +1,27 @@
+{
+  "argv": [
+    "--clearenv",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/lib",
+    "/lib",
+    "--ro-bind",
+    "/lib64",
+    "/lib64",
+    "--ro-bind",
+    "/sbin",
+    "/sbin",
+    "--unshare-net"
+  ],
+  "wrapper": [
+    "prlimit",
+    "--as=268435456",
+    "timeout",
+    "120"
+  ]
+}

--- a/tests/sandbox/golden/v05/lackpy-delegate.lackpy-namespace.golden
+++ b/tests/sandbox/golden/v05/lackpy-delegate.lackpy-namespace.golden
@@ -1,0 +1,8 @@
+{
+  "allow_patterns": {},
+  "allowed_tools": [],
+  "denied_tools": [],
+  "deny_patterns": {},
+  "kits": [],
+  "max_level": null
+}

--- a/tests/sandbox/golden/v05/lackpy-delegate.nsjail.golden
+++ b/tests/sandbox/golden/v05/lackpy-delegate.nsjail.golden
@@ -1,0 +1,62 @@
+name: "umwelt-sandbox"
+hostname: "umwelt"
+
+time_limit: 120
+
+clone_newnet: true
+
+rlimit_as: 256
+rlimit_as_type: SOFT
+
+mount {
+  src: "/bin"
+  dst: "/bin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/usr"
+  dst: "/usr"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib"
+  dst: "/lib"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib64"
+  dst: "/lib64"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/sbin"
+  dst: "/sbin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  dst: "/proc"
+  fstype: "proc"
+  is_bind: false
+}
+
+mount {
+  dst: "/dev"
+  fstype: "tmpfs"
+  is_bind: false
+}
+
+mount {
+  dst: "/tmp"
+  fstype: "tmpfs"
+  is_bind: false
+}

--- a/tests/sandbox/golden/v05/minimal.bwrap.golden
+++ b/tests/sandbox/golden/v05/minimal.bwrap.golden
@@ -1,0 +1,21 @@
+{
+  "argv": [
+    "--clearenv",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/lib",
+    "/lib",
+    "--ro-bind",
+    "/lib64",
+    "/lib64",
+    "--ro-bind",
+    "/sbin",
+    "/sbin"
+  ],
+  "wrapper": []
+}

--- a/tests/sandbox/golden/v05/minimal.lackpy-namespace.golden
+++ b/tests/sandbox/golden/v05/minimal.lackpy-namespace.golden
@@ -1,0 +1,8 @@
+{
+  "allow_patterns": {},
+  "allowed_tools": [],
+  "denied_tools": [],
+  "deny_patterns": {},
+  "kits": [],
+  "max_level": null
+}

--- a/tests/sandbox/golden/v05/minimal.nsjail.golden
+++ b/tests/sandbox/golden/v05/minimal.nsjail.golden
@@ -1,0 +1,55 @@
+name: "umwelt-sandbox"
+hostname: "umwelt"
+
+mount {
+  src: "/bin"
+  dst: "/bin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/usr"
+  dst: "/usr"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib"
+  dst: "/lib"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib64"
+  dst: "/lib64"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/sbin"
+  dst: "/sbin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  dst: "/proc"
+  fstype: "proc"
+  is_bind: false
+}
+
+mount {
+  dst: "/dev"
+  fstype: "tmpfs"
+  is_bind: false
+}
+
+mount {
+  dst: "/tmp"
+  fstype: "tmpfs"
+  is_bind: false
+}

--- a/tests/sandbox/golden/v05/readonly-exploration.bwrap.golden
+++ b/tests/sandbox/golden/v05/readonly-exploration.bwrap.golden
@@ -1,0 +1,25 @@
+{
+  "argv": [
+    "--clearenv",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/lib",
+    "/lib",
+    "--ro-bind",
+    "/lib64",
+    "/lib64",
+    "--ro-bind",
+    "/sbin",
+    "/sbin",
+    "--unshare-net"
+  ],
+  "wrapper": [
+    "timeout",
+    "60"
+  ]
+}

--- a/tests/sandbox/golden/v05/readonly-exploration.lackpy-namespace.golden
+++ b/tests/sandbox/golden/v05/readonly-exploration.lackpy-namespace.golden
@@ -1,0 +1,8 @@
+{
+  "allow_patterns": {},
+  "allowed_tools": [],
+  "denied_tools": [],
+  "deny_patterns": {},
+  "kits": [],
+  "max_level": null
+}

--- a/tests/sandbox/golden/v05/readonly-exploration.nsjail.golden
+++ b/tests/sandbox/golden/v05/readonly-exploration.nsjail.golden
@@ -1,0 +1,59 @@
+name: "umwelt-sandbox"
+hostname: "umwelt"
+
+time_limit: 60
+
+clone_newnet: true
+
+mount {
+  src: "/bin"
+  dst: "/bin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/usr"
+  dst: "/usr"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib"
+  dst: "/lib"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/lib64"
+  dst: "/lib64"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  src: "/sbin"
+  dst: "/sbin"
+  is_bind: true
+  rw: false
+}
+
+mount {
+  dst: "/proc"
+  fstype: "proc"
+  is_bind: false
+}
+
+mount {
+  dst: "/dev"
+  fstype: "tmpfs"
+  is_bind: false
+}
+
+mount {
+  dst: "/tmp"
+  fstype: "tmpfs"
+  is_bind: false
+}

--- a/tests/sandbox/test_audit_taxon.py
+++ b/tests/sandbox/test_audit_taxon.py
@@ -9,9 +9,10 @@ Distinct from tests/test_audit.py which covers the `umwelt audit` CLI.
 from __future__ import annotations
 
 import pytest
-from umwelt.parser import parse
+
 from umwelt.cascade.resolver import resolve
-from umwelt.registry import registry_scope, register_matcher, get_taxon, get_entity
+from umwelt.parser import parse
+from umwelt.registry import get_entity, get_taxon, register_matcher, registry_scope
 from umwelt.sandbox.audit_matcher import AuditMatcher
 from umwelt.sandbox.entities import ManifestEntity, ObservationEntity
 from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
@@ -71,7 +72,7 @@ def test_at_audit_parses_manifest_rule(vocab_with_matchers):
         if isinstance(e, ManifestEntity)
     ]
     assert manifests
-    entity, props = manifests[0]
+    entity, _props = manifests[0]
     assert entity.name == "current"
 
 

--- a/tests/sandbox/test_audit_taxon.py
+++ b/tests/sandbox/test_audit_taxon.py
@@ -1,0 +1,117 @@
+"""Tests for the audit taxon (S3*) and @audit at-rule.
+
+Verifies claim G1 (VSM fidelity — audit is the S3* cross-cut observer
+placed outside the world) and C1-scaffold (audit provides the structural
+hook for future proof-tree traceability). See docs/vision/evaluation-framework.md.
+
+Distinct from tests/test_audit.py which covers the `umwelt audit` CLI.
+"""
+from __future__ import annotations
+
+import pytest
+from umwelt.parser import parse
+from umwelt.cascade.resolver import resolve
+from umwelt.registry import registry_scope, register_matcher, get_taxon, get_entity
+from umwelt.sandbox.audit_matcher import AuditMatcher
+from umwelt.sandbox.entities import ManifestEntity, ObservationEntity
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+
+@pytest.fixture
+def vocab_with_matchers(tmp_path):
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=tmp_path))
+        register_matcher(taxon="audit", matcher=AuditMatcher())
+        yield tmp_path
+
+
+def _parse(text, tmp_path):
+    p = tmp_path / "test.umw"
+    p.write_text(text)
+    return parse(p)
+
+
+def test_audit_taxon_registered(vocab_with_matchers):
+    """G1: audit is a standalone S3* taxon with observation + manifest entities."""
+    assert get_taxon("audit") is not None
+    assert get_entity(taxon="audit", name="observation") is not None
+    assert get_entity(taxon="audit", name="manifest") is not None
+
+
+def test_at_audit_parses_observation_rule(vocab_with_matchers):
+    """G1: @audit { observation#X { source: Y; } } produces an observation entry."""
+    view = _parse('''
+        @audit {
+            observation#coach { source: "kibitzer"; }
+        }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    observations = [
+        (e, p) for e, p in rv.entries("audit")
+        if isinstance(e, ObservationEntity)
+    ]
+    assert observations
+    entity, props = observations[0]
+    assert entity.name == "coach"
+    assert props.get("source") in ('"kibitzer"', "kibitzer")
+
+
+def test_at_audit_parses_manifest_rule(vocab_with_matchers):
+    """G1: @audit { manifest#X { path: ...; } } produces a manifest entry."""
+    view = _parse('''
+        @audit {
+            manifest#current { path: ".umwelt/manifest.json"; }
+        }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    manifests = [
+        (e, p) for e, p in rv.entries("audit")
+        if isinstance(e, ManifestEntity)
+    ]
+    assert manifests
+    entity, props = manifests[0]
+    assert entity.name == "current"
+
+
+def test_multiple_audit_entries(vocab_with_matchers):
+    """G1: multiple entries inside @audit all resolve."""
+    view = _parse('''
+        @audit {
+            observation#coach { source: "kibitzer"; }
+            observation#ratchet { source: "ratchet-detect"; }
+            manifest#current { path: ".umwelt/manifest.json"; }
+        }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    observations = [
+        (e, p) for e, p in rv.entries("audit")
+        if isinstance(e, ObservationEntity)
+    ]
+    manifests = [
+        (e, p) for e, p in rv.entries("audit")
+        if isinstance(e, ManifestEntity)
+    ]
+    assert {e.name for e, _ in observations} == {"coach", "ratchet"}
+    assert {e.name for e, _ in manifests} == {"current"}
+
+
+def test_audit_entries_not_affected_by_world_filter(vocab_with_matchers):
+    """G1: @audit lives outside any world. world-scoped resolve still sees audit entries."""
+    view = _parse('''
+        world#dev file { editable: true; }
+        @audit { observation#coach { source: "kibitzer"; } }
+    ''', vocab_with_matchers)
+    rv = resolve(view, world="dev")
+    audit_entries = [
+        (e, p) for e, p in rv.entries("audit")
+        if isinstance(e, ObservationEntity)
+    ]
+    assert audit_entries, "world-scoped resolve should still surface audit entries"
+
+
+def test_audit_taxon_not_an_alias(vocab_with_matchers):
+    """G1: audit is a real standalone taxon, not an alias."""
+    from umwelt.registry import resolve_taxon
+    assert resolve_taxon("audit") == "audit"

--- a/tests/sandbox/test_principal.py
+++ b/tests/sandbox/test_principal.py
@@ -6,9 +6,10 @@ See docs/vision/evaluation-framework.md.
 from __future__ import annotations
 
 import pytest
-from umwelt.parser import parse
+
 from umwelt.cascade.resolver import resolve
-from umwelt.registry import registry_scope, register_matcher, get_taxon, get_entity
+from umwelt.parser import parse
+from umwelt.registry import get_entity, get_taxon, register_matcher, registry_scope
 from umwelt.sandbox.capability_matcher import CapabilityMatcher
 from umwelt.sandbox.entities import PrincipalEntity, UseEntity
 from umwelt.sandbox.principal_matcher import PrincipalMatcher

--- a/tests/sandbox/test_principal.py
+++ b/tests/sandbox/test_principal.py
@@ -1,0 +1,81 @@
+"""Tests for the principal taxon (S5).
+
+Verifies claim G1 (VSM fidelity — principal is the S5 identity axis).
+See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+import pytest
+from umwelt.parser import parse
+from umwelt.cascade.resolver import resolve
+from umwelt.registry import registry_scope, register_matcher, get_taxon, get_entity
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.entities import PrincipalEntity, UseEntity
+from umwelt.sandbox.principal_matcher import PrincipalMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+
+@pytest.fixture
+def vocab_with_matchers(tmp_path):
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=tmp_path))
+        register_matcher(taxon="capability", matcher=CapabilityMatcher())
+        register_matcher(taxon="principal", matcher=PrincipalMatcher())
+        yield tmp_path
+
+
+def _parse(text, tmp_path):
+    p = tmp_path / "test.umw"
+    p.write_text(text)
+    return parse(p)
+
+
+def test_principal_taxon_registered(vocab_with_matchers):
+    """G1: principal is registered as a standalone S5 taxon."""
+    assert get_taxon("principal") is not None
+    assert get_entity(taxon="principal", name="principal") is not None
+
+
+def test_principal_id_selector_matches(vocab_with_matchers):
+    """G1: principal#id parses and the ID flows into a PrincipalEntity."""
+    view = _parse('principal#Teague { intent: "code review"; grade: 2; }', vocab_with_matchers)
+    rv = resolve(view)
+    principals = list(rv.entries("principal"))
+    matching = [(e, p) for e, p in principals if isinstance(e, PrincipalEntity)]
+    assert matching
+    entity, props = matching[0]
+    assert entity.name == "Teague"
+    assert props.get("intent") == '"code review"' or props.get("intent") == "code review"
+    assert props.get("grade") == "2"
+
+
+def test_multiple_principals(vocab_with_matchers):
+    """G1: distinct #ids produce distinct PrincipalEntity instances."""
+    view = _parse('''
+        principal#Alice { intent: "review"; }
+        principal#Bob { intent: "implement"; }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    principals = [(e, p) for e, p in rv.entries("principal") if isinstance(e, PrincipalEntity)]
+    names = {e.name for e, _ in principals}
+    assert names == {"Alice", "Bob"}
+
+
+def test_principal_cross_axis_qualifier(vocab_with_matchers):
+    """G1: principal#X use[of=Y] { ... } composes across the principal and operation axes."""
+    view = _parse('''
+        principal#Teague use[of="file#/src/x.py"] { editable: true; }
+    ''', vocab_with_matchers)
+    rv = resolve(view)
+    # Just confirm no error and the view resolves.
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    # The use rule should resolve (principal qualifier is satisfied because Teague exists).
+    assert any(p.get("editable") == "true" for _, p in uses)
+
+
+def test_principal_taxon_not_an_alias(vocab_with_matchers):
+    """G1: principal is a real standalone taxon, not an alias of an existing one."""
+    from umwelt.registry import resolve_taxon
+    assert resolve_taxon("principal") == "principal"

--- a/tests/sandbox/test_use_entity.py
+++ b/tests/sandbox/test_use_entity.py
@@ -1,0 +1,74 @@
+"""Tests that use[of=...] registers as a first-class entity.
+
+Verifies claim A5 (property comparison semantics — each `use` permission
+property declares its comparison field). See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+import pytest
+from umwelt.registry import get_entity, get_property, register_taxon_alias, registry_scope
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+
+@pytest.fixture
+def vocab_scope():
+    with registry_scope():
+        register_sandbox_vocabulary()
+        yield
+
+
+def test_use_entity_registered(vocab_scope):
+    entity = get_entity(taxon="operation", name="use")
+    assert entity is not None
+    assert "of" in entity.attributes
+    assert "of-kind" in entity.attributes
+    assert "of-like" in entity.attributes
+
+
+def test_use_editable_property_registered(vocab_scope):
+    """A5: editable is a bool property with exact comparison."""
+    prop = get_property(taxon="operation", entity="use", name="editable")
+    assert prop.value_type is bool
+
+
+def test_use_visible_property_registered(vocab_scope):
+    """A5: visible is a bool property."""
+    prop = get_property(taxon="operation", entity="use", name="visible")
+    assert prop.value_type is bool
+
+
+def test_use_show_property_registered(vocab_scope):
+    """A5: show is a str property (enum-like: body/outline/signature)."""
+    prop = get_property(taxon="operation", entity="use", name="show")
+    assert prop.value_type is str
+
+
+def test_use_allow_property_registered(vocab_scope):
+    """A5: allow is a bool property."""
+    prop = get_property(taxon="operation", entity="use", name="allow")
+    assert prop.value_type is bool
+
+
+def test_use_deny_property_registered(vocab_scope):
+    """A5: deny is a str property."""
+    prop = get_property(taxon="operation", entity="use", name="deny")
+    assert prop.value_type is str
+
+
+def test_use_allow_pattern_uses_pattern_comparison(vocab_scope):
+    """A5: allow-pattern has comparison='pattern-in'."""
+    prop = get_property(taxon="operation", entity="use", name="allow-pattern")
+    assert prop.comparison == "pattern-in"
+
+
+def test_use_deny_pattern_uses_pattern_comparison(vocab_scope):
+    """A5: deny-pattern has comparison='pattern-in'."""
+    prop = get_property(taxon="operation", entity="use", name="deny-pattern")
+    assert prop.comparison == "pattern-in"
+
+
+def test_use_findable_under_capability_alias(vocab_scope):
+    """I3: use is findable under 'capability' too (operation is an alias)."""
+    via_op = get_entity(taxon="operation", name="use")
+    via_cap = get_entity(taxon="capability", name="use")
+    assert via_op is via_cap

--- a/tests/sandbox/test_use_entity.py
+++ b/tests/sandbox/test_use_entity.py
@@ -6,7 +6,8 @@ property declares its comparison field). See docs/vision/evaluation-framework.md
 from __future__ import annotations
 
 import pytest
-from umwelt.registry import get_entity, get_property, register_taxon_alias, registry_scope
+
+from umwelt.registry import get_entity, get_property, registry_scope
 from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
 
 

--- a/tests/sandbox/test_use_matcher.py
+++ b/tests/sandbox/test_use_matcher.py
@@ -1,0 +1,92 @@
+"""Tests for use[of=...] matching and cascade.
+
+Verifies claims A5 (property comparison semantics) and the integration
+test for use entity resolution. See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+import pytest
+from umwelt.parser import parse
+from umwelt.cascade.resolver import resolve
+from umwelt.registry import registry_scope, register_matcher
+from umwelt.sandbox.entities import UseEntity
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+
+@pytest.fixture
+def vocab_with_matchers(tmp_path):
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="capability", matcher=CapabilityMatcher())
+        yield tmp_path
+
+
+def _parse_view_text(text: str, tmp_path):
+    path = tmp_path / "test.umw"
+    path.write_text(text)
+    return parse(path)
+
+
+def test_use_with_of_exact(vocab_with_matchers):
+    view = _parse_view_text(
+        'use[of="file#/src/auth.py"] { editable: true; }',
+        vocab_with_matchers,
+    )
+    rv = resolve(view)
+    entries = list(rv.entries("operation"))
+    uses = [(e, p) for e, p in entries if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    entity, props = uses[0]
+    assert entity.of == "file#/src/auth.py"
+    assert props.get("editable") == "true"
+
+
+def test_use_with_of_kind(vocab_with_matchers):
+    view = _parse_view_text(
+        'use[of-kind="file"] { visible: true; }',
+        vocab_with_matchers,
+    )
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    assert uses[0][0].of_kind == "file"
+    assert uses[0][1].get("visible") == "true"
+
+
+def test_use_with_of_like(vocab_with_matchers):
+    view = _parse_view_text(
+        'use[of-like="file#/src"] { editable: true; }',
+        vocab_with_matchers,
+    )
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 1
+    assert uses[0][0].of_like == "file#/src"
+
+
+def test_multiple_distinct_uses(vocab_with_matchers):
+    view = _parse_view_text(
+        '''
+        use[of="file#/a.py"] { editable: true; }
+        use[of="file#/b.py"] { editable: false; }
+        ''',
+        vocab_with_matchers,
+    )
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) == 2
+    of_values = {e.of for e, _ in uses}
+    assert of_values == {"file#/a.py", "file#/b.py"}
+
+
+def test_use_bare_rule_creates_bare_entity(vocab_with_matchers):
+    """A bare `use { ... }` rule creates a UseEntity with all fields None."""
+    view = _parse_view_text('use { editable: false; }', vocab_with_matchers)
+    rv = resolve(view)
+    uses = [(e, p) for e, p in rv.entries("operation") if isinstance(e, UseEntity)]
+    assert len(uses) >= 1
+    bare = [(e, p) for e, p in uses if e.of is None and e.of_kind is None and e.of_like is None]
+    assert bare
+    entity, props = bare[0]
+    assert props.get("editable") == "false"

--- a/tests/sandbox/test_use_matcher.py
+++ b/tests/sandbox/test_use_matcher.py
@@ -6,11 +6,12 @@ test for use entity resolution. See docs/vision/evaluation-framework.md.
 from __future__ import annotations
 
 import pytest
-from umwelt.parser import parse
+
 from umwelt.cascade.resolver import resolve
-from umwelt.registry import registry_scope, register_matcher
-from umwelt.sandbox.entities import UseEntity
+from umwelt.parser import parse
+from umwelt.registry import register_matcher, registry_scope
 from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.entities import UseEntity
 from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
 
 
@@ -88,5 +89,5 @@ def test_use_bare_rule_creates_bare_entity(vocab_with_matchers):
     assert len(uses) >= 1
     bare = [(e, p) for e, p in uses if e.of is None and e.of_kind is None and e.of_like is None]
     assert bare
-    entity, props = bare[0]
+    _entity, props = bare[0]
     assert props.get("editable") == "false"

--- a/tests/sandbox/test_v04_byte_compat.py
+++ b/tests/sandbox/test_v04_byte_compat.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 
 import pytest
+
 from umwelt.cascade.resolver import resolve
 from umwelt.parser import parse
 from umwelt.registry import register_matcher, registry_scope

--- a/tests/sandbox/test_v04_byte_compat.py
+++ b/tests/sandbox/test_v04_byte_compat.py
@@ -1,0 +1,103 @@
+"""Snapshot tests that compiler output remains byte-identical across v0.5.
+
+Guards claims B1-continuity (compiler output stable across the VSM
+restructure), C3-continuity (proof-tree stability proxy), H1 (all three
+compilers still work after taxa restructure), A6 (compilers continue
+reading world-axis as before — the action-axis was additive only), and
+I1 (diff completeness indirect). See
+docs/vision/evaluation-framework.md.
+
+The test runs every fixture through every compiler, captures output, and
+compares to stored golden files under tests/sandbox/golden/v05/. To
+regenerate goldens after an intentional output change, set the
+UMWELT_UPDATE_GOLDENS environment variable to "1".
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from umwelt.cascade.resolver import resolve
+from umwelt.parser import parse
+from umwelt.registry import register_matcher, registry_scope
+from umwelt.sandbox.actor_matcher import ActorMatcher
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.compilers.bwrap import BwrapCompiler
+from umwelt.sandbox.compilers.lackpy_namespace import LackpyNamespaceCompiler
+from umwelt.sandbox.compilers.nsjail import NsjailCompiler
+from umwelt.sandbox.state_matcher import StateMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "src" / "umwelt" / "_fixtures"
+GOLDEN_DIR = Path(__file__).parent / "golden" / "v05"
+
+
+def _serialize(output) -> str:
+    """Serialize compiler output to a stable string for snapshot comparison."""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        return "\n".join(str(x) for x in output)
+    if isinstance(output, dict):
+        return json.dumps(output, indent=2, sort_keys=True, default=str)
+    return repr(output)
+
+
+COMPILERS: list[tuple[str, object]] = [
+    ("nsjail", NsjailCompiler()),
+    ("bwrap", BwrapCompiler()),
+    ("lackpy-namespace", LackpyNamespaceCompiler()),
+]
+
+
+def _collect_fixtures() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.umw"))
+
+
+@pytest.fixture
+def vocab_with_matchers():
+    """Register vocabulary + matchers with base_dir pointing at the fixture dir.
+
+    We use the real fixture directory so WorldMatcher can resolve paths.
+    """
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=FIXTURE_DIR))
+        register_matcher(taxon="capability", matcher=CapabilityMatcher())
+        register_matcher(taxon="state", matcher=StateMatcher())
+        register_matcher(taxon="actor", matcher=ActorMatcher())
+        yield
+
+
+@pytest.mark.parametrize(
+    ("fixture", "target"),
+    [(f, t) for f in _collect_fixtures() for t, _ in COMPILERS],
+    ids=lambda v: v.name if isinstance(v, Path) else str(v),
+)
+def test_compiler_output_byte_identical(vocab_with_matchers, fixture, target):
+    compiler = next(c for t, c in COMPILERS if t == target)
+    view = parse(fixture)
+    rv = resolve(view)
+    output = compiler.compile(rv)
+    serialized = _serialize(output)
+    golden = GOLDEN_DIR / f"{fixture.stem}.{target}.golden"
+
+    if os.environ.get("UMWELT_UPDATE_GOLDENS") == "1":
+        golden.parent.mkdir(parents=True, exist_ok=True)
+        golden.write_text(serialized)
+        return
+
+    if not golden.exists():
+        pytest.skip(
+            f"no golden for {fixture.name} / {target} yet — run with UMWELT_UPDATE_GOLDENS=1"
+        )
+
+    expected = golden.read_text()
+    assert serialized == expected, (
+        f"output drift for {fixture.name} compiled by {target}. "
+        f"If intended, run: UMWELT_UPDATE_GOLDENS=1 python3 -m pytest "
+        f"tests/sandbox/test_v04_byte_compat.py"
+    )

--- a/tests/sandbox/test_vsm_taxa.py
+++ b/tests/sandbox/test_vsm_taxa.py
@@ -1,0 +1,74 @@
+"""Tests that VSM taxa are registered as aliases of legacy taxa.
+
+Verifies claims G1 (VSM fidelity — VSM taxa names resolve correctly) and
+I3 (alias transparency — entity lookups work through aliases).
+See docs/vision/evaluation-framework.md.
+"""
+from __future__ import annotations
+
+import pytest
+
+from umwelt.registry import (
+    get_entity,
+    get_property,
+    get_taxon,
+    registry_scope,
+)
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+
+@pytest.fixture
+def vocab_scope():
+    """Fresh registry scope with sandbox vocabulary registered."""
+    with registry_scope():
+        register_sandbox_vocabulary()
+        yield
+
+
+def test_operation_aliases_capability(vocab_scope):
+    """G1: operation is the S1 alias for capability."""
+    assert get_taxon("operation") is get_taxon("capability")
+
+
+def test_coordination_aliases_state(vocab_scope):
+    """G1: coordination is the S2 alias for state (v0.5 virtual split)."""
+    assert get_taxon("coordination") is get_taxon("state")
+
+
+def test_control_aliases_state(vocab_scope):
+    """G1: control is the S3 alias for state (v0.5 virtual split)."""
+    assert get_taxon("control") is get_taxon("state")
+
+
+def test_intelligence_aliases_actor(vocab_scope):
+    """G1: intelligence is the S4 alias for actor."""
+    assert get_taxon("intelligence") is get_taxon("actor")
+
+
+def test_tool_entity_findable_under_operation(vocab_scope):
+    """I3: entity lookup via the alias returns the same schema as via canonical."""
+    tool_via_capability = get_entity(taxon="capability", name="tool")
+    tool_via_operation = get_entity(taxon="operation", name="tool")
+    assert tool_via_capability is tool_via_operation
+
+
+def test_hook_entity_findable_under_coordination(vocab_scope):
+    """I3: hook is findable under the coordination alias."""
+    hook_via_state = get_entity(taxon="state", name="hook")
+    hook_via_coordination = get_entity(taxon="coordination", name="hook")
+    assert hook_via_state is hook_via_coordination
+
+
+def test_inferencer_findable_under_intelligence(vocab_scope):
+    """I3: inferencer is findable under the intelligence alias."""
+    inf_via_actor = get_entity(taxon="actor", name="inferencer")
+    inf_via_intelligence = get_entity(taxon="intelligence", name="inferencer")
+    assert inf_via_actor is inf_via_intelligence
+
+
+def test_property_registered_under_alias_resolves_canonically(vocab_scope):
+    """I3: a property registered via an alias can be retrieved via canonical."""
+    # hook.run is registered under taxon="state" in the sandbox vocabulary.
+    prop_via_state = get_property(taxon="state", entity="hook", name="run")
+    prop_via_coordination = get_property(taxon="coordination", entity="hook", name="run")
+    assert prop_via_state is prop_via_coordination


### PR DESCRIPTION
## Summary

v0.5 reorganizes umwelt's taxa along Stafford Beer's Viable System Model, introduces `use[of=...]` as the action-axis permission primitive, and adds cross-axis cascade specificity. 16 commits, +~5,500/-300 lines (mostly docs and tests), 558 tests passing (1 skipped), v0.5.0 tag staged.

- **VSM-aligned taxa**: `principal` (S5) and `audit` (S3*) as new top-level taxa; `operation` / `coordination` / `control` / `intelligence` as aliases of `capability` / `state` / `actor`. Legacy names remain fully functional.
- **`use[of=...]` entity**: first-class action-axis permissioned projection of a world resource. Additive to world-axis permissions — the two axes are semantically independent (mount-readonly vs user-permission analogy, see spec §3a).
- **Cross-axis cascade specificity**: rules joining more taxa-axes are more specific. Specificity tuple widened to `(axis_count, principal, world, state, actor, capability, audit, other)`. Single-axis v0.4 rules retain identical ordering.
- **`@audit { ... }` at-rule** for declaring audit entries outside the world.
- **Evaluation framework** (`docs/vision/evaluation-framework.md`): ~35 falsifiable claims across 9 categories; Tier-0 claim **A1 (resolver determinism) verified** via 50-run property test; B1 has continuity coverage via byte-compat snapshots (5 fixtures × 3 compilers).

## Claim coverage

v0.5 verifies or strengthens: **A1**, A2, A3, A5, **A6** (new), B1-continuity, G1, H1, H3, I1, I3.

No Tier-0 claim is newly falsified. A1 moves from Open → Verified.

## Test plan

- [ ] CI green (`pytest -q`: 558 passed, 1 skipped)
- [ ] Wheel and sdist build cleanly (`python3 -m build` → `umwelt-0.5.0-*`)
- [ ] No Python-wrapper dependency on enforcement tools (H3 grep, empty)
- [ ] Byte-compat snapshots match for every fixture × compiler
- [ ] Manually inspect `docs/guide/entity-reference.md` for the new sections (use / principal / audit / VSM aliases)
- [ ] Tag `v0.5.0` pushes cleanly after merge

## Not in this PR

- Kibitzer-hooks compiler (v0.6)
- Compiler axis-migration (v0.6)
- Security pass (v0.7)
- Public API freeze (v0.9)
- `ratchet-detect` + audit compiler (v0.7)

## Docs

- Spec: `docs/superpowers/specs/2026-04-13-umwelt-v05-vsm-restructure-design.md`
- Plan: `docs/superpowers/plans/2026-04-14-umwelt-v05.md`
- VSM note: `docs/vision/notes/vsm-alignment.md`
- Logic-semantics note: `docs/vision/notes/logic-semantics.md`
- Evaluation framework: `docs/vision/evaluation-framework.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)