### PR TITLE
feat(sql): SQLite-backed policy compiler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,17 @@ dev = [
   "ruff>=0.5",
   "mypy>=1.10",
 ]
+sql = [
+  "pypika>=0.48",
+]
+duckdb = [
+  "umwelt[sql]",
+  "duckdb>=1.0",
+]
+sqldb = [
+  "umwelt[sql]",
+  "sqlalchemy>=2.0",
+]
 
 [project.scripts]
 umwelt = "umwelt.cli:main"
@@ -64,6 +75,10 @@ files = ["src/umwelt"]
 
 [[tool.mypy.overrides]]
 module = ["tinycss2"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["pypika", "pypika.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,16 +36,8 @@ dev = [
   "ruff>=0.5",
   "mypy>=1.10",
 ]
-sql = [
-  "pypika>=0.48",
-]
 duckdb = [
-  "umwelt[sql]",
   "duckdb>=1.0",
-]
-sqldb = [
-  "umwelt[sql]",
-  "sqlalchemy>=2.0",
 ]
 
 [project.scripts]
@@ -75,10 +67,6 @@ files = ["src/umwelt"]
 
 [[tool.mypy.overrides]]
 module = ["tinycss2"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["pypika", "pypika.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/umwelt/cli.py
+++ b/src/umwelt/cli.py
@@ -132,9 +132,9 @@ def _cmd_compile(args: argparse.Namespace) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    # duckdb target: compile to a policy database via ducklog
-    if args.target == "duckdb":
-        return _cmd_compile_duckdb(args, view)
+    SQL_TARGETS = {"sqlite", "duckdb"}
+    if args.target in SQL_TARGETS:
+        return _cmd_compile_sql(args, view)
 
     _register_matchers(Path(args.file))
 
@@ -149,7 +149,7 @@ def _cmd_compile(args: argparse.Namespace) -> int:
         names = ", ".join(available) if available else "(none)"
         print(
             f"error: no compiler registered for target {args.target!r}. "
-            f"Available: {names}, duckdb",
+            f"Available: {names}, sqlite, duckdb",
             file=sys.stderr,
         )
         return 1
@@ -167,117 +167,64 @@ def _cmd_compile(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_compile_duckdb(args: argparse.Namespace, view) -> int:
-    """Compile a view to a DuckDB policy database via ducklog.
-
-    Requires ducklog to be installed. The output path defaults to
-    <view-stem>.duckdb alongside the source file.
-    """
+def _cmd_compile_sql(args: argparse.Namespace, view) -> int:
+    """Compile a view to SQL text or a database."""
     try:
-        import duckdb
-        from ducklog.compiler import compile_view
+        from umwelt.compilers.sql.dialects import get_dialect
+        from umwelt.compilers.sql.schema import create_schema
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.populate import populate_entities
+        from umwelt.compilers.sql.resolution import create_resolution_views, resolution_ddl
     except ImportError:
         print(
-            "error: duckdb target requires the 'ducklog' package. "
-            "Install with: pip install ducklog",
+            "error: SQL compilation requires the 'sql' extras. "
+            "Install with: pip install umwelt[sql]",
             file=sys.stderr,
         )
         return 1
 
+    dialect = get_dialect(args.target)
     view_path = Path(args.file)
-    output = getattr(args, "output", None)
-    if output:
-        db_path = output
-    else:
-        db_path = str(view_path.with_suffix(".duckdb"))
-
-    con = duckdb.connect(db_path)
-
-    # Create minimal entity schema
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS entities (
-            id INTEGER PRIMARY KEY,
-            taxon VARCHAR NOT NULL,
-            type_name VARCHAR NOT NULL,
-            entity_id VARCHAR,
-            classes VARCHAR[],
-            attributes MAP(VARCHAR, VARCHAR),
-            parent_id INTEGER,
-        );
-        CREATE TABLE IF NOT EXISTS entity_closure (
-            ancestor_id INTEGER NOT NULL,
-            descendant_id INTEGER NOT NULL,
-            depth INTEGER NOT NULL,
-            PRIMARY KEY (ancestor_id, descendant_id),
-        );
-    """)
-
-    # Register matchers and populate entities from the workspace
     _register_matchers(view_path)
-    _populate_entities_from_matchers(con, view_path)
 
-    # Compile the policy
-    compile_view(con, view, source_file=str(view_path))
+    db_path = getattr(args, "db", None)
+    output_path = getattr(args, "output", None)
 
-    resolved_n = con.execute("SELECT COUNT(*) FROM resolved_properties").fetchone()[0]
-    entity_n = con.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+    # Generate SQL text
+    sql_text = create_schema(dialect)
 
-    con.close()
-    print(f"Compiled {db_path}: {entity_n} entities, {resolved_n} resolved properties")
+    if db_path:
+        if args.target == "sqlite":
+            import sqlite3
+            con = sqlite3.connect(db_path)
+            con.executescript(sql_text)
+            populate_entities(con, view_path.resolve().parent)
+            compile_view(con, view, dialect, source_file=str(view_path))
+            entity_n = con.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+            resolved_n = con.execute("SELECT COUNT(*) FROM resolved_properties").fetchone()[0]
+            con.commit()
+            con.close()
+            print(f"Compiled {db_path}: {entity_n} entities, {resolved_n} resolved properties")
+        elif args.target == "duckdb":
+            try:
+                import duckdb
+            except ImportError:
+                print("error: --db with duckdb target requires: pip install umwelt[duckdb]", file=sys.stderr)
+                return 1
+            print("error: DuckDB --db execution not yet implemented", file=sys.stderr)
+            return 1
+
+    if output_path:
+        sql_with_resolution = sql_text + "\n\n" + resolution_ddl(dialect)
+        Path(output_path).write_text(sql_with_resolution)
+        if not db_path:
+            print(f"SQL written to {output_path}")
+
+    if not db_path and not output_path:
+        sql_with_resolution = sql_text + "\n\n" + resolution_ddl(dialect)
+        print(sql_with_resolution, end="")
+
     return 0
-
-
-def _populate_entities_from_matchers(con, view_path: Path) -> None:
-    """Populate the entities table from workspace matchers."""
-    import contextlib
-
-    base_dir = view_path.resolve().parent
-    entity_id = 0
-
-    # Files
-    with contextlib.suppress(Exception):
-        for p in sorted(base_dir.rglob("*")):
-            if not p.is_file():
-                continue
-            rel = str(p.relative_to(base_dir))
-            skip = (".git/", "__pycache__", ".mypy_cache", ".pytest_cache",
-                    ".ruff_cache", "dist/", ".claude/", ".eggs/")
-            if any(s in rel for s in skip):
-                continue
-            entity_id += 1
-            lang = {".py": "python", ".js": "javascript", ".ts": "typescript",
-                    ".rs": "rust", ".md": "markdown", ".toml": "toml",
-                    ".json": "json", ".yaml": "yaml", ".yml": "yaml",
-                    ".sql": "sql", ".css": "css", ".umw": "umwelt"}.get(p.suffix, "")
-            con.execute(
-                "INSERT INTO entities VALUES (?, 'world', 'file', ?, NULL, MAP{'path': ?, 'name': ?, 'language': ?}, NULL)",
-                [entity_id, rel, rel, p.name, lang],
-            )
-
-    # Tools (from CLI's registered vocabulary — use the known Claude Code tools)
-    tools = [("Read", "os", "2"), ("Write", "os", "3"), ("Edit", "os", "3"),
-             ("Glob", "os", "1"), ("Grep", "os", "1"), ("Bash", "os", "5"),
-             ("Agent", "semantic", "7"), ("WebSearch", "semantic", "2"),
-             ("WebFetch", "semantic", "2")]
-    for name, alt, lvl in tools:
-        entity_id += 1
-        con.execute(
-            "INSERT INTO entities VALUES (?, 'capability', 'tool', ?, NULL, MAP{'name': ?, 'altitude': ?, 'level': ?}, NULL)",
-            [entity_id, name, name, alt, lvl],
-        )
-
-    # Resources + network
-    for kind in ("memory", "wall-time", "cpu-time"):
-        entity_id += 1
-        con.execute(
-            "INSERT INTO entities VALUES (?, 'world', 'resource', ?, NULL, MAP{'kind': ?}, NULL)",
-            [entity_id, kind, kind],
-        )
-    entity_id += 1
-    con.execute(
-        "INSERT INTO entities VALUES (?, 'world', 'network', NULL, NULL, MAP{}, NULL)",
-        [entity_id],
-    )
 
 
 def _cmd_diff(args: argparse.Namespace) -> int:
@@ -424,7 +371,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_compile.add_argument(
         "-o", "--output", default=None,
-        help="output file path (for duckdb target; defaults to <view>.duckdb)",
+        help="output file path for SQL text",
+    )
+    p_compile.add_argument(
+        "-d", "--db", default=None,
+        help="database connection string or file path (executes SQL)",
     )
     p_compile.set_defaults(func=_cmd_compile)
 

--- a/src/umwelt/compilers/sql/__init__.py
+++ b/src/umwelt/compilers/sql/__init__.py
@@ -1,0 +1,1 @@
+"""SQL policy compiler — translates .umw views to SQL databases."""

--- a/src/umwelt/compilers/sql/__init__.py
+++ b/src/umwelt/compilers/sql/__init__.py
@@ -1,1 +1,49 @@
-"""SQL policy compiler — translates .umw views to SQL databases."""
+"""SQL policy compiler — translates .umw views to SQL databases.
+
+Public API:
+  compile_to_sql(view, dialect, base_dir, source_file) -> SQL text
+  compile_to_db(con, view, dialect, base_dir, source_file) -> None (mutates db)
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+    from umwelt.ast import View
+    from umwelt.compilers.sql.dialects import Dialect
+
+
+def compile_to_db(
+    con: sqlite3.Connection,
+    view: View,
+    dialect: Dialect,
+    base_dir: Path | None = None,
+    source_file: str = "",
+) -> None:
+    """Compile a view into an existing database connection."""
+    from umwelt.compilers.sql.compiler import compile_view
+    from umwelt.compilers.sql.populate import populate_entities
+    from umwelt.compilers.sql.schema import create_schema
+
+    con.executescript(create_schema(dialect))
+    if base_dir is not None:
+        populate_entities(con, base_dir)
+    compile_view(con, view, dialect, source_file=source_file)
+
+
+def compile_to_sql(
+    view: View,
+    dialect: Dialect,
+    base_dir: Path | None = None,
+    source_file: str = "",
+) -> str:
+    """Compile a view to SQL text (schema + inserts + resolution views)."""
+    import sqlite3 as _sqlite3
+    from umwelt.compilers.sql.resolution import resolution_ddl
+    from umwelt.compilers.sql.schema import create_schema
+
+    parts = [create_schema(dialect)]
+    parts.append(resolution_ddl(dialect))
+    return "\n\n".join(parts)

--- a/src/umwelt/compilers/sql/__init__.py
+++ b/src/umwelt/compilers/sql/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import sqlite3
     from pathlib import Path
+
     from umwelt.ast import View
     from umwelt.compilers.sql.dialects import Dialect
 
@@ -40,7 +41,6 @@ def compile_to_sql(
     source_file: str = "",
 ) -> str:
     """Compile a view to SQL text (schema + inserts + resolution views)."""
-    import sqlite3 as _sqlite3
     from umwelt.compilers.sql.resolution import resolution_ddl
     from umwelt.compilers.sql.schema import create_schema
 

--- a/src/umwelt/compilers/sql/__init__.py
+++ b/src/umwelt/compilers/sql/__init__.py
@@ -40,10 +40,24 @@ def compile_to_sql(
     base_dir: Path | None = None,
     source_file: str = "",
 ) -> str:
-    """Compile a view to SQL text (schema + inserts + resolution views)."""
-    from umwelt.compilers.sql.resolution import resolution_ddl
-    from umwelt.compilers.sql.schema import create_schema
+    """Compile a view to a self-contained SQL script.
 
-    parts = [create_schema(dialect)]
-    parts.append(resolution_ddl(dialect))
-    return "\n\n".join(parts)
+    Builds an in-memory SQLite database, compiles the view into it,
+    then dumps the full SQL (schema + inserts + resolution views).
+    """
+    import sqlite3 as _sqlite3
+
+    con = _sqlite3.connect(":memory:")
+    try:
+        compile_to_db(con, view, dialect, base_dir=base_dir, source_file=source_file)
+        return _dump_sql(con)
+    finally:
+        con.close()
+
+
+def _dump_sql(con: sqlite3.Connection) -> str:
+    """Dump an in-memory database to a SQL script."""
+    lines: list[str] = []
+    for line in con.iterdump():
+        lines.append(line)
+    return "\n".join(lines)

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -51,7 +51,8 @@ def _compile_simple(simple: SimpleSelector, alias: str, dialect: Dialect) -> str
     clauses: list[str] = []
 
     if simple.type_name and simple.type_name != "*":
-        clauses.append(f"{alias}.type_name = '{simple.type_name}'")
+        safe_type = simple.type_name.replace("'", "''")
+        clauses.append(f"{alias}.type_name = '{safe_type}'")
 
     if simple.id_value is not None:
         safe_id = simple.id_value.replace("'", "''")
@@ -88,8 +89,9 @@ def _compile_attr_filter(attr, alias: str, dialect: Dialect) -> str:
     if attr.op == "*=":
         return f"{col} LIKE '%{safe_val}%'"
     if attr.op == "~=":
+        safe_name = attr.name.replace("'", "''")
         return (
-            f"EXISTS(SELECT 1 FROM json_each(json_extract({alias}.attributes, '$.{attr.name}')) "
+            f"EXISTS(SELECT 1 FROM json_each(json_extract({alias}.attributes, '$.{safe_name}')) "
             f"WHERE value = '{safe_val}')"
         )
     if attr.op == "|=":
@@ -170,8 +172,6 @@ def _infer_comparison(property_name: str) -> str:
     """Infer comparison type from property name conventions."""
     if property_name.startswith("max-"):
         return "<="
-    if property_name.startswith("min-"):
-        return ">="
     if property_name in ("allow-pattern", "deny-pattern"):
         return "pattern-in"
     return "exact"

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import sqlite3
+
     from umwelt.ast import ComplexSelector, SimpleSelector, View
     from umwelt.compilers.sql.dialects import Dialect
 
@@ -41,7 +42,7 @@ def compile_selector(selector: ComplexSelector, dialect: Dialect) -> str:
         else:
             qualifier_clauses.append(_compile_context_qualifier(qual.selector, q_alias, dialect))
 
-    all_clauses = [target_sql] + qualifier_clauses
+    all_clauses = [target_sql, *qualifier_clauses]
     return " AND ".join(all_clauses)
 
 

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -1,0 +1,132 @@
+"""Compile umwelt CSS selectors to SQL WHERE clauses.
+
+Walks umwelt's AST (ComplexSelector, SimpleSelector, CompoundPart) and
+emits SQL fragments using dialect-specific helpers. The returned strings
+are valid SQL expressions for use as: SELECT e.id FROM entities e WHERE <expr>
+
+Entry points:
+  compile_selector(selector, dialect) -> SQL WHERE clause string
+  compile_view(con, view, dialect, source_file) -> populates cascade_candidates
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from umwelt.ast import ComplexSelector, SimpleSelector
+    from umwelt.compilers.sql.dialects import Dialect
+
+
+def compile_selector(selector: ComplexSelector, dialect: Dialect) -> str:
+    """Compile a ComplexSelector to a SQL WHERE clause."""
+    parts = selector.parts
+    if not parts:
+        return "FALSE"
+
+    target = parts[-1]
+    qualifiers = parts[:-1]
+
+    target_sql = _compile_simple(target.selector, "e", dialect)
+
+    qualifier_clauses = []
+    for i, qual in enumerate(qualifiers):
+        q_alias = f"q{i}"
+        is_structural = (
+            qual.selector.taxon == target.selector.taxon
+            and qual.mode != "context"
+        )
+        if is_structural:
+            qualifier_clauses.append(_compile_structural_ancestor(qual.selector, q_alias, dialect))
+        else:
+            qualifier_clauses.append(_compile_context_qualifier(qual.selector, q_alias, dialect))
+
+    all_clauses = [target_sql] + qualifier_clauses
+    return " AND ".join(all_clauses)
+
+
+def _compile_simple(simple: SimpleSelector, alias: str, dialect: Dialect) -> str:
+    """Compile a SimpleSelector to SQL WHERE fragments."""
+    clauses: list[str] = []
+
+    if simple.type_name and simple.type_name != "*":
+        clauses.append(f"{alias}.type_name = '{simple.type_name}'")
+
+    if simple.id_value is not None:
+        safe_id = simple.id_value.replace("'", "''")
+        clauses.append(f"{alias}.entity_id = '{safe_id}'")
+
+    for cls in simple.classes:
+        clauses.append(dialect.list_contains(alias, "classes", cls))
+
+    for attr in simple.attributes:
+        clauses.append(_compile_attr_filter(attr, alias, dialect))
+
+    for pseudo in simple.pseudo_classes:
+        clause = _compile_pseudo(pseudo, alias, dialect)
+        if clause:
+            clauses.append(clause)
+
+    if not clauses:
+        return "TRUE"
+    return " AND ".join(clauses)
+
+
+def _compile_attr_filter(attr, alias: str, dialect: Dialect) -> str:
+    """Compile an AttrFilter to a SQL expression."""
+    col = dialect.json_attr(alias, attr.name)
+    if attr.op is None:
+        return f"{col} IS NOT NULL"
+    safe_val = (attr.value or "").replace("'", "''")
+    if attr.op == "=":
+        return f"{col} = '{safe_val}'"
+    if attr.op == "^=":
+        return f"{col} LIKE '{safe_val}%'"
+    if attr.op == "$=":
+        return f"{col} LIKE '%{safe_val}'"
+    if attr.op == "*=":
+        return f"{col} LIKE '%{safe_val}%'"
+    if attr.op == "~=":
+        return (
+            f"EXISTS(SELECT 1 FROM json_each(json_extract({alias}.attributes, '$.{attr.name}')) "
+            f"WHERE value = '{safe_val}')"
+        )
+    if attr.op == "|=":
+        return f"({col} = '{safe_val}' OR {col} LIKE '{safe_val}-%')"
+    return "TRUE"
+
+
+def _compile_pseudo(pseudo, alias: str, dialect: Dialect) -> str | None:
+    """Compile a pseudo-class to a SQL expression."""
+    if pseudo.name == "glob":
+        pattern = (pseudo.argument or "").strip().strip("'\"")
+        sql_pattern = _glob_to_like(pattern)
+        col = dialect.json_attr(alias, "path")
+        return f"{col} LIKE '{sql_pattern}'"
+    return None
+
+
+def _glob_to_like(pattern: str) -> str:
+    """Convert a glob pattern to a SQL LIKE pattern."""
+    result = pattern.replace("**", "\x00")
+    result = result.replace("*", "%")
+    result = result.replace("?", "_")
+    result = result.replace("\x00", "%")
+    return result.replace("'", "''")
+
+
+def _compile_context_qualifier(simple: SimpleSelector, alias: str, dialect: Dialect) -> str:
+    """Compile a cross-axis context qualifier to an EXISTS subquery."""
+    where = _compile_simple(simple, alias, dialect)
+    return f"EXISTS (SELECT 1 FROM entities {alias} WHERE {where})"
+
+
+def _compile_structural_ancestor(simple: SimpleSelector, alias: str, dialect: Dialect) -> str:
+    """Compile a structural-descent qualifier to a closure-table EXISTS."""
+    where = _compile_simple(simple, alias, dialect)
+    return (
+        f"EXISTS ("
+        f"SELECT 1 FROM entities {alias} "
+        f"JOIN entity_closure ec ON ec.ancestor_id = {alias}.id "
+        f"WHERE ec.descendant_id = e.id AND ec.depth > 0 AND {where}"
+        f")"
+    )

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from umwelt.ast import ComplexSelector, SimpleSelector
+    import sqlite3
+    from umwelt.ast import ComplexSelector, SimpleSelector, View
     from umwelt.compilers.sql.dialects import Dialect
 
 
@@ -130,3 +131,46 @@ def _compile_structural_ancestor(simple: SimpleSelector, alias: str, dialect: Di
         f"WHERE ec.descendant_id = e.id AND ec.depth > 0 AND {where}"
         f")"
     )
+
+
+def compile_view(
+    con: sqlite3.Connection,
+    view: View,
+    dialect: Dialect,
+    source_file: str = "",
+) -> None:
+    """Compile a parsed View into cascade_candidates rows + resolution views."""
+    from umwelt.compilers.sql.resolution import create_resolution_views
+
+    for rule_idx, rule in enumerate(view.rules):
+        for selector in rule.selectors:
+            where_sql = compile_selector(selector, dialect)
+            spec = selector.specificity if hasattr(selector, "specificity") else (0,) * 8
+            spec_str = dialect.format_specificity(spec)
+            src_line = rule.span.line if hasattr(rule, "span") else 0
+
+            for decl in rule.declarations:
+                comparison = _infer_comparison(decl.property_name)
+                value = ", ".join(decl.values)
+                con.execute(
+                    "INSERT INTO cascade_candidates "
+                    "(entity_id, property_name, property_value, comparison, "
+                    "specificity, rule_index, source_file, source_line) "
+                    f"SELECT e.id, ?, ?, ?, ?, ?, ?, ? "
+                    f"FROM entities e WHERE {where_sql}",
+                    (decl.property_name, value, comparison,
+                     spec_str, rule_idx, source_file, src_line),
+                )
+    con.commit()
+    create_resolution_views(con, dialect)
+
+
+def _infer_comparison(property_name: str) -> str:
+    """Infer comparison type from property name conventions."""
+    if property_name.startswith("max-"):
+        return "<="
+    if property_name.startswith("min-"):
+        return ">="
+    if property_name in ("allow-pattern", "deny-pattern"):
+        return "pattern-in"
+    return "exact"

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -83,20 +83,28 @@ def _compile_attr_filter(attr, alias: str, dialect: Dialect) -> str:
     if attr.op == "=":
         return f"{col} = '{safe_val}'"
     if attr.op == "^=":
-        return f"{col} LIKE '{safe_val}%'"
+        like_val = _escape_like(attr.value or "")
+        return f"{col} LIKE '{like_val}%' ESCAPE '\\'"
     if attr.op == "$=":
-        return f"{col} LIKE '%{safe_val}'"
+        like_val = _escape_like(attr.value or "")
+        return f"{col} LIKE '%{like_val}' ESCAPE '\\'"
     if attr.op == "*=":
-        return f"{col} LIKE '%{safe_val}%'"
+        like_val = _escape_like(attr.value or "")
+        return f"{col} LIKE '%{like_val}%' ESCAPE '\\'"
     if attr.op == "~=":
-        safe_name = attr.name.replace("'", "''")
-        return (
-            f"EXISTS(SELECT 1 FROM json_each(json_extract({alias}.attributes, '$.{safe_name}')) "
-            f"WHERE value = '{safe_val}')"
-        )
+        return dialect.json_attr_list_contains(alias, attr.name, attr.value or "")
     if attr.op == "|=":
-        return f"({col} = '{safe_val}' OR {col} LIKE '{safe_val}-%')"
-    return "TRUE"
+        like_val = _escape_like(attr.value or "")
+        return f"({col} = '{safe_val}' OR {col} LIKE '{like_val}-%' ESCAPE '\\')"
+    raise ValueError(f"unknown attribute operator: {attr.op!r}")
+
+
+def _escape_like(val: str) -> str:
+    """Escape LIKE metacharacters and single quotes for safe interpolation."""
+    val = val.replace("\\", "\\\\")
+    val = val.replace("%", "\\%")
+    val = val.replace("_", "\\_")
+    return val.replace("'", "''")
 
 
 def _compile_pseudo(pseudo, alias: str, dialect: Dialect) -> str | None:
@@ -105,13 +113,16 @@ def _compile_pseudo(pseudo, alias: str, dialect: Dialect) -> str | None:
         pattern = (pseudo.argument or "").strip().strip("'\"")
         sql_pattern = _glob_to_like(pattern)
         col = dialect.json_attr(alias, "path")
-        return f"{col} LIKE '{sql_pattern}'"
+        return f"{col} LIKE '{sql_pattern}' ESCAPE '\\'"
     return None
 
 
 def _glob_to_like(pattern: str) -> str:
     """Convert a glob pattern to a SQL LIKE pattern."""
-    result = pattern.replace("**", "\x00")
+    result = pattern.replace("\\", "\\\\")
+    result = result.replace("%", "\\%")
+    result = result.replace("_", "\\_")
+    result = result.replace("**", "\x00")
     result = result.replace("*", "%")
     result = result.replace("?", "_")
     result = result.replace("\x00", "%")
@@ -119,7 +130,13 @@ def _glob_to_like(pattern: str) -> str:
 
 
 def _compile_context_qualifier(simple: SimpleSelector, alias: str, dialect: Dialect) -> str:
-    """Compile a cross-axis context qualifier to an EXISTS subquery."""
+    """Compile a cross-axis context qualifier to an EXISTS subquery.
+
+    Semantics: checks global existence — the qualifier matches if ANY entity
+    of the given type/id exists in the database, not scoped to an active
+    session or principal. Multi-principal filtering requires the populator
+    to only insert the active principal's entity.
+    """
     where = _compile_simple(simple, alias, dialect)
     return f"EXISTS (SELECT 1 FROM entities {alias} WHERE {where})"
 

--- a/src/umwelt/compilers/sql/dialects.py
+++ b/src/umwelt/compilers/sql/dialects.py
@@ -41,16 +41,6 @@ class Dialect(ABC):
         """Format a dict as a MAP/JSON literal."""
         ...
 
-    @abstractmethod
-    def distinct_first(
-        self, columns: str, partition_by: str, order_by: str
-    ) -> tuple[str, str]:
-        """Return (select_wrapper, where_filter) for picking the first row per partition.
-
-        For DuckDB: DISTINCT ON. For SQLite: ROW_NUMBER window function.
-        Returns a tuple of (extra_column_expr, filter_clause).
-        """
-        ...
 
 
 class SQLiteDialect(Dialect):
@@ -77,14 +67,6 @@ class SQLiteDialect(Dialect):
     def map_literal(self, mapping: dict[str, str]) -> str:
         return json.dumps(mapping, separators=(",", ":"))
 
-    def distinct_first(
-        self, columns: str, partition_by: str, order_by: str
-    ) -> tuple[str, str]:
-        return (
-            f"ROW_NUMBER() OVER (PARTITION BY {partition_by} ORDER BY {order_by}) AS _rn",
-            "_rn = 1",
-        )
-
 
 class DuckDBDialect(Dialect):
     name = "duckdb"
@@ -107,11 +89,6 @@ class DuckDBDialect(Dialect):
     def map_literal(self, mapping: dict[str, str]) -> str:
         pairs = ",".join(f"'{k}':'{v}'" for k, v in mapping.items())
         return f"MAP{{{pairs}}}"
-
-    def distinct_first(
-        self, columns: str, partition_by: str, order_by: str
-    ) -> tuple[str, str]:
-        return ("", "")  # DuckDB uses DISTINCT ON directly
 
 
 _DIALECTS: dict[str, type[Dialect]] = {

--- a/src/umwelt/compilers/sql/dialects.py
+++ b/src/umwelt/compilers/sql/dialects.py
@@ -41,6 +41,11 @@ class Dialect(ABC):
         """Format a dict as a MAP/JSON literal."""
         ...
 
+    @abstractmethod
+    def json_attr_list_contains(self, alias: str, key: str, value: str) -> str:
+        """Check if a JSON attribute's array value contains an element."""
+        ...
+
 
 
 class SQLiteDialect(Dialect):
@@ -67,6 +72,14 @@ class SQLiteDialect(Dialect):
     def map_literal(self, mapping: dict[str, str]) -> str:
         return json.dumps(mapping, separators=(",", ":"))
 
+    def json_attr_list_contains(self, alias: str, key: str, value: str) -> str:
+        safe_key = key.replace("'", "''")
+        safe_val = value.replace("'", "''")
+        return (
+            f"EXISTS(SELECT 1 FROM json_each(json_extract({alias}.attributes, '$.{safe_key}')) "
+            f"WHERE value = '{safe_val}')"
+        )
+
 
 class DuckDBDialect(Dialect):
     name = "duckdb"
@@ -83,12 +96,20 @@ class DuckDBDialect(Dialect):
         return f"[{','.join(str(s) for s in spec)}]::INTEGER[]"
 
     def array_literal(self, values: list[str]) -> str:
-        inner = ",".join(f"'{v}'" for v in values)
+        inner = ",".join(f"'{v.replace(chr(39), chr(39)*2)}'" for v in values)
         return f"[{inner}]"
 
     def map_literal(self, mapping: dict[str, str]) -> str:
-        pairs = ",".join(f"'{k}':'{v}'" for k, v in mapping.items())
+        pairs = ",".join(
+            f"'{k.replace(chr(39), chr(39)*2)}':'{v.replace(chr(39), chr(39)*2)}'"
+            for k, v in mapping.items()
+        )
         return f"MAP{{{pairs}}}"
+
+    def json_attr_list_contains(self, alias: str, key: str, value: str) -> str:
+        safe_key = key.replace("'", "''")
+        safe_val = value.replace("'", "''")
+        return f"list_contains({alias}.attributes['{safe_key}'], '{safe_val}')"
 
 
 _DIALECTS: dict[str, type[Dialect]] = {

--- a/src/umwelt/compilers/sql/dialects.py
+++ b/src/umwelt/compilers/sql/dialects.py
@@ -1,0 +1,134 @@
+"""SQL dialect abstraction for the policy compiler.
+
+Each dialect provides expression helpers that abstract database-specific
+syntax: JSON access, array operations, specificity encoding, and literal
+formatting. The compiler builds SQL using these helpers rather than
+hardcoding any dialect's syntax.
+"""
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+
+
+class Dialect(ABC):
+    """Base class for SQL dialect-specific expression helpers."""
+
+    name: str
+
+    @abstractmethod
+    def json_attr(self, alias: str, key: str) -> str:
+        """Access a key from a JSON/MAP attributes column."""
+        ...
+
+    @abstractmethod
+    def list_contains(self, alias: str, column: str, value: str) -> str:
+        """Check if a JSON array / list column contains a value."""
+        ...
+
+    @abstractmethod
+    def format_specificity(self, spec: tuple[int, ...]) -> str:
+        """Format a specificity tuple as a storable/sortable literal."""
+        ...
+
+    @abstractmethod
+    def array_literal(self, values: list[str]) -> str:
+        """Format a list of strings as an array literal."""
+        ...
+
+    @abstractmethod
+    def map_literal(self, mapping: dict[str, str]) -> str:
+        """Format a dict as a MAP/JSON literal."""
+        ...
+
+    @abstractmethod
+    def distinct_first(
+        self, columns: str, partition_by: str, order_by: str
+    ) -> tuple[str, str]:
+        """Return (select_wrapper, where_filter) for picking the first row per partition.
+
+        For DuckDB: DISTINCT ON. For SQLite: ROW_NUMBER window function.
+        Returns a tuple of (extra_column_expr, filter_clause).
+        """
+        ...
+
+
+class SQLiteDialect(Dialect):
+    name = "sqlite"
+
+    def json_attr(self, alias: str, key: str) -> str:
+        safe_key = key.replace("'", "''")
+        return f"json_extract({alias}.attributes, '$.{safe_key}')"
+
+    def list_contains(self, alias: str, column: str, value: str) -> str:
+        safe_val = value.replace("'", "''")
+        return (
+            f"EXISTS(SELECT 1 FROM json_each({alias}.{column}) "
+            f"WHERE value = '{safe_val}')"
+        )
+
+    def format_specificity(self, spec: tuple[int, ...]) -> str:
+        padded = [f"{v:05d}" for v in spec]
+        return json.dumps(padded, separators=(",", ":"))
+
+    def array_literal(self, values: list[str]) -> str:
+        return json.dumps(values, separators=(",", ":"))
+
+    def map_literal(self, mapping: dict[str, str]) -> str:
+        return json.dumps(mapping, separators=(",", ":"))
+
+    def distinct_first(
+        self, columns: str, partition_by: str, order_by: str
+    ) -> tuple[str, str]:
+        return (
+            f"ROW_NUMBER() OVER (PARTITION BY {partition_by} ORDER BY {order_by}) AS _rn",
+            "_rn = 1",
+        )
+
+
+class DuckDBDialect(Dialect):
+    name = "duckdb"
+
+    def json_attr(self, alias: str, key: str) -> str:
+        safe_key = key.replace("'", "''")
+        return f"{alias}.attributes['{safe_key}']"
+
+    def list_contains(self, alias: str, column: str, value: str) -> str:
+        safe_val = value.replace("'", "''")
+        return f"list_contains({alias}.{column}, '{safe_val}')"
+
+    def format_specificity(self, spec: tuple[int, ...]) -> str:
+        return f"[{','.join(str(s) for s in spec)}]::INTEGER[]"
+
+    def array_literal(self, values: list[str]) -> str:
+        inner = ",".join(f"'{v}'" for v in values)
+        return f"[{inner}]"
+
+    def map_literal(self, mapping: dict[str, str]) -> str:
+        pairs = ",".join(f"'{k}':'{v}'" for k, v in mapping.items())
+        return f"MAP{{{pairs}}}"
+
+    def distinct_first(
+        self, columns: str, partition_by: str, order_by: str
+    ) -> tuple[str, str]:
+        return ("", "")  # DuckDB uses DISTINCT ON directly
+
+
+_DIALECTS: dict[str, type[Dialect]] = {
+    "sqlite": SQLiteDialect,
+    "duckdb": DuckDBDialect,
+}
+
+
+def get_dialect(name: str) -> Dialect:
+    """Look up a dialect by name."""
+    cls = _DIALECTS.get(name)
+    if cls is None:
+        available = ", ".join(sorted(_DIALECTS))
+        raise ValueError(f"unknown SQL dialect {name!r}; available: {available}")
+    return cls()
+
+
+def register_dialect(name: str, cls: type[Dialect]) -> None:
+    """Register a custom dialect."""
+    _DIALECTS[name] = cls

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -69,7 +69,6 @@ def _extract_attributes(entity: Any) -> dict[str, str]:
 def populate_entities(con: Any, base_dir: Path) -> None:
     """Query all registered matchers and INSERT their entities."""
     state = _current_state()
-    entity_id = 0
 
     for taxon, matcher in state.matchers.items():
         type_names = _get_type_names(taxon)
@@ -79,12 +78,11 @@ def populate_entities(con: Any, base_dir: Path) -> None:
             except Exception:
                 continue
             for entity in entities:
-                entity_id += 1
                 row = entity_to_row(taxon, type_name, entity)
                 con.execute(
-                    "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, depth) "
-                    "VALUES (?, ?, ?, ?, ?, ?, 0)",
-                    (entity_id, row["taxon"], row["type_name"], row["entity_id"],
+                    "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+                    "VALUES (?, ?, ?, ?, ?, 0)",
+                    (row["taxon"], row["type_name"], row["entity_id"],
                      row["classes"], row["attributes"]),
                 )
 

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -1,0 +1,141 @@
+"""Populate the entities table from the matcher registry.
+
+Bridges umwelt's Matcher protocol to SQL INSERT statements. Each
+registered matcher is queried for entities, which are serialized
+to JSON-column rows and inserted.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+from umwelt.registry.taxa import _current_state
+
+
+def entity_to_row(taxon: str, type_name: str, entity: Any) -> dict[str, Any]:
+    """Convert a matcher entity object to an insertable row dict."""
+    entity_id = _extract_id(entity)
+    classes = _extract_classes(entity)
+    attributes = _extract_attributes(entity)
+
+    return {
+        "taxon": taxon,
+        "type_name": type_name,
+        "entity_id": entity_id,
+        "classes": json.dumps(classes) if classes else None,
+        "attributes": json.dumps(attributes) if attributes else None,
+    }
+
+
+def _extract_id(entity: Any) -> str | None:
+    """Extract an identity value from an entity, trying common id fields."""
+    for attr in ("path", "name", "kind", "id"):
+        val = getattr(entity, attr, None)
+        if val is not None:
+            return str(val)
+    return None
+
+
+def _extract_classes(entity: Any) -> list[str]:
+    """Extract CSS-like class labels from an entity."""
+    classes = getattr(entity, "classes", None)
+    if classes is not None:
+        return list(classes)
+    return []
+
+
+def _extract_attributes(entity: Any) -> dict[str, str]:
+    """Extract all dataclass fields as a flat string-valued dict.
+
+    Skips abs_path (not serializable to JSON) and classes (stored
+    in a dedicated column).
+    """
+    attrs: dict[str, str] = {}
+    skip = {"abs_path", "classes"}
+    try:
+        for f in fields(entity):
+            if f.name in skip:
+                continue
+            val = getattr(entity, f.name)
+            if val is not None:
+                attrs[f.name] = str(val)
+    except TypeError:
+        pass
+    return attrs
+
+
+def populate_entities(con: Any, base_dir: Path) -> None:
+    """Query all registered matchers and INSERT their entities."""
+    state = _current_state()
+    entity_id = 0
+
+    for taxon, matcher in state.matchers.items():
+        type_names = _get_type_names(taxon)
+        for type_name in type_names:
+            try:
+                entities = matcher.match_type(type_name)
+            except Exception:
+                continue
+            for entity in entities:
+                entity_id += 1
+                row = entity_to_row(taxon, type_name, entity)
+                con.execute(
+                    "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, depth) "
+                    "VALUES (?, ?, ?, ?, ?, ?, 0)",
+                    (entity_id, row["taxon"], row["type_name"], row["entity_id"],
+                     row["classes"], row["attributes"]),
+                )
+
+    con.commit()
+    _rebuild_hierarchy(con, base_dir)
+    _rebuild_closure(con)
+
+
+def _get_type_names(taxon: str) -> list[str]:
+    """Return the entity type names to query for a taxon."""
+    state = _current_state()
+    types = []
+    for (t, name) in state.entities:
+        if t == taxon:
+            types.append(name)
+    return types if types else ["*"]
+
+
+def _rebuild_hierarchy(con: Any, base_dir: Path) -> None:
+    """Set parent_id for file/dir entities based on filesystem paths."""
+    dirs = con.execute(
+        "SELECT id, entity_id FROM entities WHERE type_name = 'dir'"
+    ).fetchall()
+    dir_map = {path: eid for eid, path in dirs}
+
+    files = con.execute(
+        "SELECT id, entity_id FROM entities WHERE type_name IN ('file', 'dir') AND entity_id IS NOT NULL"
+    ).fetchall()
+    for file_id, file_path in files:
+        if file_path is None:
+            continue
+        parent_path = str(Path(file_path).parent)
+        if parent_path == ".":
+            continue
+        parent_id = dir_map.get(parent_path)
+        if parent_id is not None:
+            con.execute("UPDATE entities SET parent_id = ? WHERE id = ?", (parent_id, file_id))
+    con.commit()
+
+
+def _rebuild_closure(con: Any) -> None:
+    """Rebuild the entity_closure table from parent_id relationships."""
+    con.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure
+        WITH RECURSIVE closure(ancestor_id, descendant_id, depth) AS (
+            SELECT id, id, 0 FROM entities
+            UNION ALL
+            SELECT c.ancestor_id, e.id, c.depth + 1
+            FROM closure c
+            JOIN entities e ON e.parent_id = c.descendant_id
+        )
+        SELECT DISTINCT * FROM closure;
+    """)

--- a/src/umwelt/compilers/sql/resolution.py
+++ b/src/umwelt/compilers/sql/resolution.py
@@ -105,7 +105,7 @@ SELECT entity_id, property_name, property_value, comparison,
        '' AS source_file, 0 AS source_line
 FROM agg;"""
 
-    union_keyword = "UNION ALL" if is_sqlite else "UNION ALL BY NAME"
+    union_keyword = "UNION ALL"
     resolved_view_prefix = "CREATE VIEW IF NOT EXISTS" if is_sqlite else "CREATE OR REPLACE VIEW"
 
     resolved_view = f"""

--- a/src/umwelt/compilers/sql/resolution.py
+++ b/src/umwelt/compilers/sql/resolution.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import sqlite3
+
     from umwelt.compilers.sql.dialects import Dialect
 
 

--- a/src/umwelt/compilers/sql/resolution.py
+++ b/src/umwelt/compilers/sql/resolution.py
@@ -84,14 +84,10 @@ WITH agg AS (
     FROM cascade_candidates WHERE comparison = 'pattern-in'
     GROUP BY entity_id, property_name
 )
-SELECT a.entity_id, a.property_name, a.property_value, a.comparison,
-       a.specificity, a.rule_index,
-       c.source_file, c.source_line
-FROM agg a
-LEFT JOIN cascade_candidates c
-    ON a.entity_id = c.entity_id AND a.property_name = c.property_name
-    AND a.specificity = c.specificity AND a.rule_index = c.rule_index
-    AND c.comparison = 'pattern-in';"""
+SELECT entity_id, property_name, property_value, comparison,
+       specificity, rule_index,
+       '' AS source_file, 0 AS source_line
+FROM agg;"""
     else:
         pattern_view = """
 CREATE OR REPLACE VIEW _resolved_pattern AS
@@ -104,14 +100,10 @@ WITH agg AS (
     FROM cascade_candidates WHERE comparison = 'pattern-in'
     GROUP BY entity_id, property_name
 )
-SELECT a.entity_id, a.property_name, a.property_value, a.comparison,
-       a.specificity, a.rule_index,
-       c.source_file, c.source_line
-FROM agg a
-LEFT JOIN cascade_candidates c
-    ON a.entity_id = c.entity_id AND a.property_name = c.property_name
-    AND a.specificity = c.specificity AND a.rule_index = c.rule_index
-    AND c.comparison = 'pattern-in';"""
+SELECT entity_id, property_name, property_value, comparison,
+       specificity, rule_index,
+       '' AS source_file, 0 AS source_line
+FROM agg;"""
 
     union_keyword = "UNION ALL" if is_sqlite else "UNION ALL BY NAME"
     resolved_view_prefix = "CREATE VIEW IF NOT EXISTS" if is_sqlite else "CREATE OR REPLACE VIEW"

--- a/src/umwelt/compilers/sql/resolution.py
+++ b/src/umwelt/compilers/sql/resolution.py
@@ -1,0 +1,124 @@
+"""Cascade resolution views for the policy database.
+
+Creates SQL views that implement comparison-aware cascade resolution:
+- exact: highest specificity wins (document order breaks ties)
+- <=: tightest bound (MIN value) wins
+- pattern-in: all values aggregate via set union
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+    from umwelt.compilers.sql.dialects import Dialect
+
+
+def create_resolution_views(con: sqlite3.Connection, dialect: Dialect) -> str:
+    """Create resolution views and return the DDL as SQL text.
+
+    Also executes the DDL against `con` if provided.
+    """
+    ddl = _resolution_ddl(dialect)
+    con.executescript(ddl)
+    return ddl
+
+
+def resolution_ddl(dialect: Dialect) -> str:
+    """Return the resolution view DDL as SQL text without executing."""
+    return _resolution_ddl(dialect)
+
+
+def _resolution_ddl(dialect: Dialect) -> str:
+    is_sqlite = dialect.name == "sqlite"
+
+    if is_sqlite:
+        exact_view = """
+CREATE VIEW IF NOT EXISTS _resolved_exact AS
+SELECT entity_id, property_name, property_value, comparison,
+       specificity, rule_index, source_file, source_line
+FROM (
+    SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY entity_id, property_name
+        ORDER BY specificity DESC, rule_index DESC
+    ) AS _rn
+    FROM cascade_candidates WHERE comparison = 'exact'
+) WHERE _rn = 1;"""
+    else:
+        exact_view = """
+CREATE OR REPLACE VIEW _resolved_exact AS
+SELECT DISTINCT ON (entity_id, property_name)
+    entity_id, property_name, property_value, comparison,
+    specificity, rule_index, source_file, source_line
+FROM cascade_candidates
+WHERE comparison = 'exact'
+ORDER BY entity_id, property_name, specificity DESC, rule_index DESC;"""
+
+    cap_view_body = """
+WITH ranked AS (
+    SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY entity_id, property_name
+        ORDER BY CAST(property_value AS INTEGER) ASC, specificity DESC
+    ) AS _rn
+    FROM cascade_candidates WHERE comparison = '<='
+)
+SELECT entity_id, property_name, property_value, comparison,
+       specificity, rule_index, source_file, source_line
+FROM ranked WHERE _rn = 1"""
+
+    if is_sqlite:
+        cap_view = f"CREATE VIEW IF NOT EXISTS _resolved_cap AS\n{cap_view_body};"
+    else:
+        cap_view = f"CREATE OR REPLACE VIEW _resolved_cap AS\n{cap_view_body};"
+
+    if is_sqlite:
+        pattern_view = """
+CREATE VIEW IF NOT EXISTS _resolved_pattern AS
+WITH agg AS (
+    SELECT entity_id, property_name,
+        GROUP_CONCAT(DISTINCT property_value) AS property_value,
+        'pattern-in' AS comparison,
+        MAX(specificity) AS specificity,
+        MAX(rule_index) AS rule_index
+    FROM cascade_candidates WHERE comparison = 'pattern-in'
+    GROUP BY entity_id, property_name
+)
+SELECT a.entity_id, a.property_name, a.property_value, a.comparison,
+       a.specificity, a.rule_index,
+       c.source_file, c.source_line
+FROM agg a
+LEFT JOIN cascade_candidates c
+    ON a.entity_id = c.entity_id AND a.property_name = c.property_name
+    AND a.specificity = c.specificity AND a.rule_index = c.rule_index
+    AND c.comparison = 'pattern-in';"""
+    else:
+        pattern_view = """
+CREATE OR REPLACE VIEW _resolved_pattern AS
+WITH agg AS (
+    SELECT entity_id, property_name,
+        STRING_AGG(DISTINCT property_value, ', ' ORDER BY property_value) AS property_value,
+        'pattern-in' AS comparison,
+        MAX(specificity) AS specificity,
+        MAX(rule_index) AS rule_index
+    FROM cascade_candidates WHERE comparison = 'pattern-in'
+    GROUP BY entity_id, property_name
+)
+SELECT a.entity_id, a.property_name, a.property_value, a.comparison,
+       a.specificity, a.rule_index,
+       c.source_file, c.source_line
+FROM agg a
+LEFT JOIN cascade_candidates c
+    ON a.entity_id = c.entity_id AND a.property_name = c.property_name
+    AND a.specificity = c.specificity AND a.rule_index = c.rule_index
+    AND c.comparison = 'pattern-in';"""
+
+    union_keyword = "UNION ALL" if is_sqlite else "UNION ALL BY NAME"
+    resolved_view_prefix = "CREATE VIEW IF NOT EXISTS" if is_sqlite else "CREATE OR REPLACE VIEW"
+
+    resolved_view = f"""
+{resolved_view_prefix} resolved_properties AS
+SELECT * FROM _resolved_exact
+{union_keyword} SELECT * FROM _resolved_cap
+{union_keyword} SELECT * FROM _resolved_pattern;"""
+
+    return "\n".join([exact_view, cap_view, pattern_view, resolved_view])

--- a/src/umwelt/compilers/sql/schema.py
+++ b/src/umwelt/compilers/sql/schema.py
@@ -1,0 +1,112 @@
+"""DDL generation for the policy database schema.
+
+Generates CREATE TABLE/INDEX statements for the policy database.
+The schema structure is dialect-agnostic; only column type names
+and literal syntax differ between dialects.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from umwelt.compilers.sql.dialects import Dialect
+
+EXPECTED_TABLES = [
+    "taxa",
+    "entity_types",
+    "property_types",
+    "entities",
+    "entity_closure",
+    "cascade_candidates",
+]
+
+
+def create_schema(dialect: Dialect) -> str:
+    """Generate the full DDL for the policy database."""
+    is_sqlite = dialect.name == "sqlite"
+    text_type = "TEXT" if is_sqlite else "VARCHAR"
+    int_type = "INTEGER"
+    autoincrement = (
+        "INTEGER PRIMARY KEY AUTOINCREMENT"
+        if is_sqlite
+        else "INTEGER PRIMARY KEY DEFAULT nextval('entity_seq')"
+    )
+
+    sections = []
+
+    # -- Vocabulary tables
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS taxa (
+    name            {text_type} PRIMARY KEY,
+    canonical       {text_type},
+    vsm_system      {text_type},
+    description     {text_type}
+);
+
+CREATE TABLE IF NOT EXISTS entity_types (
+    name            {text_type} NOT NULL,
+    taxon           {text_type} NOT NULL REFERENCES taxa(name),
+    parent_type     {text_type},
+    category        {text_type},
+    description     {text_type},
+    PRIMARY KEY (taxon, name)
+);
+
+CREATE TABLE IF NOT EXISTS property_types (
+    name            {text_type} NOT NULL,
+    taxon           {text_type} NOT NULL,
+    entity_type     {text_type} NOT NULL,
+    value_type      {text_type} NOT NULL,
+    comparison      {text_type} DEFAULT 'exact',
+    description     {text_type},
+    PRIMARY KEY (taxon, entity_type, name),
+    FOREIGN KEY (taxon, entity_type) REFERENCES entity_types(taxon, name)
+);""")
+
+    # -- Entity tables
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS entities (
+    id              {autoincrement},
+    taxon           {text_type} NOT NULL,
+    type_name       {text_type} NOT NULL,
+    entity_id       {text_type},
+    classes         {text_type},
+    attributes      {text_type},
+    parent_id       {int_type} REFERENCES entities(id),
+    depth           {int_type} DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_taxon ON entities(taxon);
+CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(type_name);
+CREATE INDEX IF NOT EXISTS idx_entities_id ON entities(entity_id);
+CREATE INDEX IF NOT EXISTS idx_entities_parent ON entities(parent_id);""")
+
+    # -- Closure table
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS entity_closure (
+    ancestor_id     {int_type} NOT NULL REFERENCES entities(id),
+    descendant_id   {int_type} NOT NULL REFERENCES entities(id),
+    depth           {int_type} NOT NULL,
+    PRIMARY KEY (ancestor_id, descendant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_closure_ancestor ON entity_closure(ancestor_id);
+CREATE INDEX IF NOT EXISTS idx_closure_descendant ON entity_closure(descendant_id);""")
+
+    # -- Cascade candidates (materialized, not a view)
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS cascade_candidates (
+    entity_id       {int_type} NOT NULL REFERENCES entities(id),
+    property_name   {text_type} NOT NULL,
+    property_value  {text_type} NOT NULL,
+    comparison      {text_type} NOT NULL DEFAULT 'exact',
+    specificity     {text_type} NOT NULL,
+    rule_index      {int_type} NOT NULL,
+    source_file     {text_type},
+    source_line     {int_type}
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidates_entity_prop ON cascade_candidates(entity_id, property_name);
+CREATE INDEX IF NOT EXISTS idx_candidates_comparison ON cascade_candidates(comparison);""")
+
+    return "\n".join(sections)

--- a/tests/test_compilers_sql/conftest.py
+++ b/tests/test_compilers_sql/conftest.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
 import pytest
+
 from umwelt.compilers.sql.dialects import SQLiteDialect
 from umwelt.compilers.sql.schema import create_schema
 
@@ -88,11 +90,11 @@ def populated_db(db):
 
 def parse_selector(css_text: str):
     """Parse a CSS selector string via umwelt's parser."""
+    import contextlib
+
     from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
-    try:
+    with contextlib.suppress(Exception):
         register_sandbox_vocabulary()
-    except Exception:
-        pass
     from umwelt.parser import parse
     view = parse(css_text + " { _test: true; }", validate=False)
     assert view.rules, f"no rules parsed from: {css_text}"
@@ -101,11 +103,11 @@ def parse_selector(css_text: str):
 
 def parse_view(css_text: str):
     """Parse a full .umw view string."""
+    import contextlib
+
     from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
-    try:
+    with contextlib.suppress(Exception):
         register_sandbox_vocabulary()
-    except Exception:
-        pass
     from umwelt.parser import parse
     return parse(css_text, validate=False)
 

--- a/tests/test_compilers_sql/conftest.py
+++ b/tests/test_compilers_sql/conftest.py
@@ -1,0 +1,116 @@
+"""Shared fixtures for SQL compiler tests."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import pytest
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.schema import create_schema
+
+
+@pytest.fixture
+def dialect():
+    return SQLiteDialect()
+
+
+@pytest.fixture
+def db(dialect):
+    """In-memory SQLite with the policy schema."""
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    yield con
+    con.close()
+
+
+@pytest.fixture
+def populated_db(db):
+    """DB with a representative set of entities across all taxa."""
+    entities = [
+        # world: files
+        (1,  "world", "file", "src/auth.py",       None, json.dumps({"path": "src/auth.py", "name": "auth.py", "language": "python"}), None, 0),
+        (2,  "world", "file", "src/util.py",        None, json.dumps({"path": "src/util.py", "name": "util.py", "language": "python"}), None, 0),
+        (3,  "world", "file", "tests/test_auth.py", None, json.dumps({"path": "tests/test_auth.py", "name": "test_auth.py", "language": "python"}), None, 0),
+        (4,  "world", "file", "README.md",          None, json.dumps({"path": "README.md", "name": "README.md", "language": "markdown"}), None, 0),
+        (5,  "world", "file", "src/main.pyc",       None, json.dumps({"path": "src/main.pyc", "name": "main.pyc"}), None, 0),
+        # world: dirs
+        (10, "world", "dir",  "src",                None, json.dumps({"path": "src", "name": "src"}), None, 0),
+        (11, "world", "dir",  "tests",              None, json.dumps({"path": "tests", "name": "tests"}), None, 0),
+        # world: resources
+        (20, "world", "resource", "memory",         None, json.dumps({"kind": "memory"}), None, 0),
+        (21, "world", "resource", "wall-time",      None, json.dumps({"kind": "wall-time"}), None, 0),
+        # world: network
+        (25, "world", "network", None,               None, json.dumps({}), None, 0),
+        # world: exec
+        (30, "world", "exec", "bash",               None, json.dumps({"name": "bash", "path": "/bin/bash"}), None, 0),
+        # capability: tools
+        (40, "capability", "tool", "Read",           None, json.dumps({"name": "Read", "altitude": "os", "level": "2"}), None, 0),
+        (41, "capability", "tool", "Edit",           None, json.dumps({"name": "Edit", "altitude": "os", "level": "3"}), None, 0),
+        (42, "capability", "tool", "Bash",           None, json.dumps({"name": "Bash", "altitude": "os", "level": "5"}), None, 0),
+        (43, "capability", "tool", "Grep",           None, json.dumps({"name": "Grep", "altitude": "os", "level": "1"}), None, 0),
+        (44, "capability", "tool", "Agent",          None, json.dumps({"name": "Agent", "altitude": "semantic", "level": "7"}), None, 0),
+        (45, "capability", "tool", "Glob",           None, json.dumps({"name": "Glob", "altitude": "os", "level": "1"}), None, 0),
+        (46, "capability", "tool", "Write",          None, json.dumps({"name": "Write", "altitude": "os", "level": "3"}), None, 0),
+        # state: modes
+        (50, "state", "mode", None, json.dumps(["implement"]),      json.dumps({"writable": "src/, lib/", "strategy": ""}), None, 0),
+        (51, "state", "mode", None, json.dumps(["test"]),           json.dumps({"writable": "tests/", "strategy": "Write tests for expected behavior, not current behavior."}), None, 0),
+        (52, "state", "mode", None, json.dumps(["explore"]),        json.dumps({"writable": "", "strategy": "Map the territory before making changes."}), None, 0),
+        (53, "state", "mode", None, json.dumps(["implement", "tdd"]), json.dumps({"writable": "src/, tests/", "strategy": ""}), None, 0),
+        (54, "state", "mode", None, json.dumps(["review"]),         json.dumps({"writable": "", "strategy": "Read everything, then verify with tests."}), None, 0),
+        # principal
+        (60, "principal", "principal", "Teague", None, json.dumps({"name": "Teague"}), None, 0),
+        # audit
+        (70, "audit", "observation", "coach",   None, json.dumps({"name": "coach"}), None, 0),
+    ]
+    db.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+    # Hierarchy: src/ contains files 1, 2, 5; tests/ contains file 3
+    db.execute("UPDATE entities SET parent_id = 10 WHERE id IN (1, 2, 5)")
+    db.execute("UPDATE entities SET parent_id = 11 WHERE id = 3")
+    # Rebuild closure table
+    db.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure
+        WITH RECURSIVE closure(ancestor_id, descendant_id, depth) AS (
+            SELECT id, id, 0 FROM entities
+            UNION ALL
+            SELECT c.ancestor_id, e.id, c.depth + 1
+            FROM closure c
+            JOIN entities e ON e.parent_id = c.descendant_id
+        )
+        SELECT DISTINCT * FROM closure;
+    """)
+    db.commit()
+    return db
+
+
+def parse_selector(css_text: str):
+    """Parse a CSS selector string via umwelt's parser."""
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+    try:
+        register_sandbox_vocabulary()
+    except Exception:
+        pass
+    from umwelt.parser import parse
+    view = parse(css_text + " { _test: true; }", validate=False)
+    assert view.rules, f"no rules parsed from: {css_text}"
+    return view.rules[0].selectors[0]
+
+
+def parse_view(css_text: str):
+    """Parse a full .umw view string."""
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+    try:
+        register_sandbox_vocabulary()
+    except Exception:
+        pass
+    from umwelt.parser import parse
+    return parse(css_text, validate=False)
+
+
+def query_ids(con, sql: str) -> set[int]:
+    """Execute a compiled selector SQL and return matched entity IDs."""
+    result = con.execute(f"SELECT e.id FROM entities e WHERE {sql}").fetchall()
+    return {row[0] for row in result}

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -13,7 +13,6 @@ from tests.test_compilers_sql.conftest import parse_selector, parse_view, query_
 from umwelt.compilers.sql.compiler import compile_selector, compile_view
 from umwelt.compilers.sql.dialects import SQLiteDialect
 
-
 DIALECT = SQLiteDialect()
 
 

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -120,3 +120,83 @@ class TestClassSelectors:
     def test_class_not_present_matches_nothing(self, populated_db):
         sql = compile_selector(parse_selector("mode.deploy"), DIALECT)
         assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# Level 5: Compound selectors — cross-axis
+# ============================================================================
+
+class TestCompoundSelectors:
+    def test_two_axis_mode_tool(self, populated_db):
+        sql = compile_selector(parse_selector("mode.implement tool"), DIALECT)
+        assert query_ids(populated_db, sql) == {40, 41, 42, 43, 44, 45, 46}
+
+    def test_two_axis_mode_tool_with_attr(self, populated_db):
+        sql = compile_selector(parse_selector('mode.implement tool[name="Bash"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {42}
+
+    def test_context_qualifier_nonexistent_mode_produces_nothing(self, populated_db):
+        sql = compile_selector(parse_selector("mode.deploy tool"), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+    def test_two_axis_principal_tool(self, populated_db):
+        sql = compile_selector(parse_selector("principal#Teague tool"), DIALECT)
+        assert query_ids(populated_db, sql) == {40, 41, 42, 43, 44, 45, 46}
+
+    def test_two_axis_principal_nonexistent(self, populated_db):
+        sql = compile_selector(parse_selector("principal#Nobody tool"), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# Level 6: Three-axis compounds
+# ============================================================================
+
+class TestThreeAxisCompounds:
+    def test_principal_mode_tool(self, populated_db):
+        sql = compile_selector(parse_selector('principal#Teague mode.implement tool[name="Bash"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {42}
+
+    def test_three_axis_one_qualifier_fails(self, populated_db):
+        sql = compile_selector(parse_selector('principal#Nobody mode.implement tool[name="Bash"]'), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+    def test_three_axis_different_qualifier_fails(self, populated_db):
+        sql = compile_selector(parse_selector('principal#Teague mode.deploy tool[name="Bash"]'), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# Level 7: Structural descendants
+# ============================================================================
+
+class TestStructuralDescendants:
+    def test_dir_file_descendant(self, populated_db):
+        sql = compile_selector(parse_selector('dir[name="src"] file'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2, 5}
+
+    def test_dir_file_other_dir(self, populated_db):
+        sql = compile_selector(parse_selector('dir[name="tests"] file'), DIALECT)
+        assert query_ids(populated_db, sql) == {3}
+
+    def test_dir_file_nonexistent_dir(self, populated_db):
+        sql = compile_selector(parse_selector('dir[name="lib"] file'), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# Level 8: Pseudo-classes
+# ============================================================================
+
+class TestPseudoClasses:
+    def test_glob_pseudo(self, populated_db):
+        sql = compile_selector(parse_selector('file:glob("src/*.py")'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2}
+
+    def test_glob_recursive(self, populated_db):
+        sql = compile_selector(parse_selector('file:glob("**/*.py")'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2, 3}
+
+    def test_glob_no_match(self, populated_db):
+        sql = compile_selector(parse_selector('file:glob("*.rs")'), DIALECT)
+        assert query_ids(populated_db, sql) == set()

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -9,8 +9,8 @@ Organized from atoms to molecules:
 """
 from __future__ import annotations
 
-from tests.test_compilers_sql.conftest import parse_selector, query_ids
-from umwelt.compilers.sql.compiler import compile_selector
+from tests.test_compilers_sql.conftest import parse_selector, parse_view, query_ids
+from umwelt.compilers.sql.compiler import compile_selector, compile_view
 from umwelt.compilers.sql.dialects import SQLiteDialect
 
 
@@ -200,3 +200,37 @@ class TestPseudoClasses:
     def test_glob_no_match(self, populated_db):
         sql = compile_selector(parse_selector('file:glob("*.rs")'), DIALECT)
         assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# compile_view — full View AST to cascade candidates
+# ============================================================================
+
+class TestCompileView:
+    def test_compile_view_populates_candidates(self, populated_db):
+        view = parse_view('file[path^="src/"] { editable: true; }')
+        compile_view(populated_db, view, DIALECT, source_file="test.umw")
+        count = populated_db.execute("SELECT COUNT(*) FROM cascade_candidates").fetchone()[0]
+        assert count > 0
+
+    def test_compile_view_creates_resolution_views(self, populated_db):
+        view = parse_view('file { editable: false; }')
+        compile_view(populated_db, view, DIALECT, source_file="test.umw")
+        row = populated_db.execute("SELECT COUNT(*) FROM resolved_properties").fetchone()
+        assert row[0] > 0
+
+    def test_compile_view_comparison_inference(self, populated_db):
+        view = parse_view('tool { max-level: 5; }')
+        compile_view(populated_db, view, DIALECT, source_file="test.umw")
+        row = populated_db.execute(
+            "SELECT comparison FROM cascade_candidates WHERE property_name = 'max-level'"
+        ).fetchone()
+        assert row[0] == "<="
+
+    def test_compile_view_pattern_comparison(self, populated_db):
+        view = parse_view('tool[name="Bash"] { allow-pattern: "git *"; }')
+        compile_view(populated_db, view, DIALECT, source_file="test.umw")
+        row = populated_db.execute(
+            "SELECT comparison FROM cascade_candidates WHERE property_name = 'allow-pattern'"
+        ).fetchone()
+        assert row[0] == "pattern-in"

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -1,0 +1,122 @@
+"""Selector-to-SQL compiler tests.
+
+Organized from atoms to molecules:
+  Level 1: Type selectors (file, tool, mode)
+  Level 2: ID selectors (file#README.md, tool#Bash)
+  Level 3: Attribute selectors ([path="..."], [path^="..."])
+  Level 4: Class selectors (mode.implement, mode.implement.tdd)
+  Levels 5-8: see Task 5
+"""
+from __future__ import annotations
+
+from tests.test_compilers_sql.conftest import parse_selector, query_ids
+from umwelt.compilers.sql.compiler import compile_selector
+from umwelt.compilers.sql.dialects import SQLiteDialect
+
+
+DIALECT = SQLiteDialect()
+
+
+# ============================================================================
+# Level 1: Bare type selectors
+# ============================================================================
+
+class TestTypeSelectors:
+    def test_bare_file_matches_all_files(self, populated_db):
+        sql = compile_selector(parse_selector("file"), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2, 3, 4, 5}
+
+    def test_bare_tool_matches_all_tools(self, populated_db):
+        sql = compile_selector(parse_selector("tool"), DIALECT)
+        assert query_ids(populated_db, sql) == {40, 41, 42, 43, 44, 45, 46}
+
+    def test_bare_mode_matches_all_modes(self, populated_db):
+        sql = compile_selector(parse_selector("mode"), DIALECT)
+        assert query_ids(populated_db, sql) == {50, 51, 52, 53, 54}
+
+    def test_bare_resource_matches_all_resources(self, populated_db):
+        sql = compile_selector(parse_selector("resource"), DIALECT)
+        assert query_ids(populated_db, sql) == {20, 21}
+
+    def test_type_selector_excludes_other_types(self, populated_db):
+        sql = compile_selector(parse_selector("tool"), DIALECT)
+        ids = query_ids(populated_db, sql)
+        assert all(40 <= i <= 46 for i in ids)
+
+
+# ============================================================================
+# Level 2: ID selectors
+# ============================================================================
+
+class TestIDSelectors:
+    def test_file_with_id(self, populated_db):
+        sql = compile_selector(parse_selector("file#README.md"), DIALECT)
+        assert query_ids(populated_db, sql) == {4}
+
+    def test_tool_with_id(self, populated_db):
+        sql = compile_selector(parse_selector("tool#Bash"), DIALECT)
+        assert query_ids(populated_db, sql) == {42}
+
+    def test_principal_with_id(self, populated_db):
+        sql = compile_selector(parse_selector("principal#Teague"), DIALECT)
+        assert query_ids(populated_db, sql) == {60}
+
+    def test_nonexistent_id_matches_nothing(self, populated_db):
+        sql = compile_selector(parse_selector("tool#NonExistent"), DIALECT)
+        assert query_ids(populated_db, sql) == set()
+
+
+# ============================================================================
+# Level 3: Attribute selectors
+# ============================================================================
+
+class TestAttributeSelectors:
+    def test_exact_match(self, populated_db):
+        sql = compile_selector(parse_selector('file[path="src/auth.py"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {1}
+
+    def test_prefix_match(self, populated_db):
+        sql = compile_selector(parse_selector('file[path^="src/"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2, 5}
+
+    def test_suffix_match(self, populated_db):
+        sql = compile_selector(parse_selector('file[path$=".py"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2, 3}
+
+    def test_contains_match(self, populated_db):
+        sql = compile_selector(parse_selector('file[path*="auth"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 3}
+
+    def test_multiple_attributes_conjoin(self, populated_db):
+        sql = compile_selector(parse_selector('file[path^="src/"][language="python"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {1, 2}
+
+    def test_attribute_on_tool(self, populated_db):
+        sql = compile_selector(parse_selector('tool[altitude="os"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {40, 41, 42, 43, 45, 46}
+
+    def test_resource_kind_attribute(self, populated_db):
+        sql = compile_selector(parse_selector('resource[kind="memory"]'), DIALECT)
+        assert query_ids(populated_db, sql) == {20}
+
+
+# ============================================================================
+# Level 4: Class selectors
+# ============================================================================
+
+class TestClassSelectors:
+    def test_single_class(self, populated_db):
+        sql = compile_selector(parse_selector("mode.implement"), DIALECT)
+        assert query_ids(populated_db, sql) == {50, 53}
+
+    def test_class_excludes_non_matching(self, populated_db):
+        sql = compile_selector(parse_selector("mode.explore"), DIALECT)
+        assert query_ids(populated_db, sql) == {52}
+
+    def test_multiple_classes_must_all_match(self, populated_db):
+        sql = compile_selector(parse_selector("mode.implement.tdd"), DIALECT)
+        assert query_ids(populated_db, sql) == {53}
+
+    def test_class_not_present_matches_nothing(self, populated_db):
+        sql = compile_selector(parse_selector("mode.deploy"), DIALECT)
+        assert query_ids(populated_db, sql) == set()

--- a/tests/test_compilers_sql/test_dialects.py
+++ b/tests/test_compilers_sql/test_dialects.py
@@ -1,8 +1,7 @@
 """Tests for SQL dialect abstraction layer."""
 from __future__ import annotations
 
-import pytest
-from umwelt.compilers.sql.dialects import SQLiteDialect, DuckDBDialect
+from umwelt.compilers.sql.dialects import DuckDBDialect, SQLiteDialect
 
 
 class TestSQLiteDialect:

--- a/tests/test_compilers_sql/test_dialects.py
+++ b/tests/test_compilers_sql/test_dialects.py
@@ -1,0 +1,65 @@
+"""Tests for SQL dialect abstraction layer."""
+from __future__ import annotations
+
+import pytest
+from umwelt.compilers.sql.dialects import SQLiteDialect, DuckDBDialect
+
+
+class TestSQLiteDialect:
+    def setup_method(self):
+        self.d = SQLiteDialect()
+
+    def test_json_attr(self):
+        result = self.d.json_attr("e", "path")
+        assert result == "json_extract(e.attributes, '$.path')"
+
+    def test_list_contains(self):
+        result = self.d.list_contains("e", "classes", "implement")
+        assert "json_each" in result
+        assert "implement" in result
+
+    def test_format_specificity(self):
+        spec = (2, 0, 10100, 0, 0, 100, 0, 0)
+        result = self.d.format_specificity(spec)
+        assert result == '["00002","00000","10100","00000","00000","00100","00000","00000"]'
+
+    def test_specificity_ordering(self):
+        """Higher specificity sorts after lower when compared as strings."""
+        high = self.d.format_specificity((2, 0, 10100, 0, 0, 100, 0, 0))
+        low = self.d.format_specificity((1, 0, 0, 0, 0, 100, 0, 0))
+        assert high > low
+
+    def test_array_literal(self):
+        result = self.d.array_literal(["implement", "tdd"])
+        assert result == '["implement","tdd"]'
+
+    def test_map_literal(self):
+        result = self.d.map_literal({"path": "src/auth.py", "language": "python"})
+        assert '"path":"src/auth.py"' in result
+        assert '"language":"python"' in result
+
+
+class TestDuckDBDialect:
+    def setup_method(self):
+        self.d = DuckDBDialect()
+
+    def test_json_attr(self):
+        result = self.d.json_attr("e", "path")
+        assert result == "e.attributes['path']"
+
+    def test_list_contains(self):
+        result = self.d.list_contains("e", "classes", "implement")
+        assert result == "list_contains(e.classes, 'implement')"
+
+    def test_format_specificity(self):
+        spec = (2, 0, 10100, 0, 0, 100, 0, 0)
+        result = self.d.format_specificity(spec)
+        assert result == "[2,0,10100,0,0,100,0,0]::INTEGER[]"
+
+    def test_array_literal(self):
+        result = self.d.array_literal(["implement", "tdd"])
+        assert result == "['implement','tdd']"
+
+    def test_map_literal(self):
+        result = self.d.map_literal({"path": "src/auth.py"})
+        assert result == "MAP{'path':'src/auth.py'}"

--- a/tests/test_compilers_sql/test_populate.py
+++ b/tests/test_compilers_sql/test_populate.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import pytest
 from pathlib import Path
+
 from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.populate import entity_to_row, populate_entities
 from umwelt.compilers.sql.schema import create_schema
-from umwelt.compilers.sql.populate import populate_entities, entity_to_row
 
 
 class TestEntityToRow:
@@ -55,8 +55,8 @@ class TestPopulateEntities:
         con = sqlite3.connect(":memory:")
         con.executescript(create_schema(dialect))
 
-        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
         from umwelt.registry.taxa import _ACTIVE_STATE, RegistryState
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
 
         # Use a fresh registry to avoid conflicts with other tests
         token = _ACTIVE_STATE.set(RegistryState())

--- a/tests/test_compilers_sql/test_populate.py
+++ b/tests/test_compilers_sql/test_populate.py
@@ -1,0 +1,88 @@
+"""Tests for entity population from the matcher registry."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import pytest
+from pathlib import Path
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.compilers.sql.populate import populate_entities, entity_to_row
+
+
+class TestEntityToRow:
+    def test_file_entity(self):
+        from umwelt.sandbox.entities import FileEntity
+        entity = FileEntity(path="src/auth.py", abs_path=Path("/tmp/src/auth.py"), name="auth.py", language="python")
+        row = entity_to_row("world", "file", entity)
+        assert row["taxon"] == "world"
+        assert row["type_name"] == "file"
+        assert row["entity_id"] == "src/auth.py"
+        attrs = json.loads(row["attributes"])
+        assert attrs["path"] == "src/auth.py"
+        assert attrs["language"] == "python"
+
+    def test_tool_entity(self):
+        from umwelt.sandbox.entities import ToolEntity
+        entity = ToolEntity(name="Bash", altitude="os", level=5)
+        row = entity_to_row("capability", "tool", entity)
+        assert row["entity_id"] == "Bash"
+        attrs = json.loads(row["attributes"])
+        assert attrs["name"] == "Bash"
+        assert attrs["altitude"] == "os"
+
+    def test_mode_entity(self):
+        from umwelt.sandbox.entities import ModeEntity
+        entity = ModeEntity(name="implement", classes=("implement", "tdd"))
+        row = entity_to_row("state", "mode", entity)
+        classes = json.loads(row["classes"])
+        assert classes == ["implement", "tdd"]
+
+    def test_network_entity(self):
+        from umwelt.sandbox.entities import NetworkEntity
+        entity = NetworkEntity()
+        row = entity_to_row("world", "network", entity)
+        assert row["entity_id"] is None
+
+
+class TestPopulateEntities:
+    def test_populates_from_matchers(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("# app")
+        (tmp_path / "README.md").write_text("# readme")
+
+        dialect = SQLiteDialect()
+        con = sqlite3.connect(":memory:")
+        con.executescript(create_schema(dialect))
+
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+        from umwelt.registry.taxa import _ACTIVE_STATE, RegistryState
+
+        # Use a fresh registry to avoid conflicts with other tests
+        token = _ACTIVE_STATE.set(RegistryState())
+        try:
+            register_sandbox_vocabulary()
+
+            # Register matchers
+            from umwelt.registry.matchers import register_matcher
+            from umwelt.sandbox.world_matcher import WorldMatcher
+            register_matcher(taxon="world", matcher=WorldMatcher(base_dir=tmp_path))
+
+            populate_entities(con, tmp_path)
+
+            count = con.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+            assert count > 0
+
+            # Check a file was populated
+            row = con.execute(
+                "SELECT json_extract(attributes, '$.path') FROM entities WHERE type_name = 'file' AND entity_id LIKE '%app.py'"
+            ).fetchone()
+            assert row is not None
+
+            # Check closure table was built
+            closure_count = con.execute("SELECT COUNT(*) FROM entity_closure").fetchone()[0]
+            assert closure_count > 0
+        finally:
+            _ACTIVE_STATE.reset(token)
+
+        con.close()

--- a/tests/test_compilers_sql/test_resolution.py
+++ b/tests/test_compilers_sql/test_resolution.py
@@ -1,0 +1,136 @@
+"""Tests for cascade resolution views.
+
+Verifies comparison-aware resolution: exact (highest specificity wins),
+<= (tightest bound / MIN), pattern-in (set union).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import pytest
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.compilers.sql.resolution import create_resolution_views
+
+
+@pytest.fixture
+def db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    return con
+
+
+def _insert_candidates(con, rows):
+    """Insert cascade candidate rows: (entity_id, prop, value, comparison, specificity, rule_index)."""
+    dialect = SQLiteDialect()
+    for entity_id, prop, value, comparison, spec, rule_idx in rows:
+        spec_str = dialect.format_specificity(spec)
+        con.execute(
+            "INSERT INTO cascade_candidates (entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'test.umw', 1)",
+            (entity_id, prop, value, comparison, spec_str, rule_idx),
+        )
+    con.commit()
+
+
+def _resolved(con, entity_id: int, prop: str) -> str | None:
+    row = con.execute(
+        "SELECT property_value FROM resolved_properties WHERE entity_id = ? AND property_name = ?",
+        (entity_id, prop),
+    ).fetchone()
+    return row[0] if row else None
+
+
+class TestExactResolution:
+    def test_higher_specificity_wins(self, db):
+        _insert_candidates(db, [
+            (1, "editable", "false", "exact", (1, 0, 0, 0, 0, 1, 0, 0), 0),
+            (1, "editable", "true",  "exact", (1, 0, 100, 0, 0, 1, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        assert _resolved(db, 1, "editable") == "true"
+
+    def test_document_order_breaks_ties(self, db):
+        _insert_candidates(db, [
+            (1, "editable", "false", "exact", (1, 0, 100, 0, 0, 0, 0, 0), 0),
+            (1, "editable", "true",  "exact", (1, 0, 100, 0, 0, 0, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        assert _resolved(db, 1, "editable") == "true"
+
+    def test_independent_entities(self, db):
+        _insert_candidates(db, [
+            (1, "editable", "true",  "exact", (1, 0, 100, 0, 0, 0, 0, 0), 0),
+            (2, "editable", "false", "exact", (1, 0, 0, 0, 0, 0, 0, 0), 0),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        assert _resolved(db, 1, "editable") == "true"
+        assert _resolved(db, 2, "editable") == "false"
+
+    def test_a1_unique_winners(self, db):
+        """Every (entity, property) pair has exactly one winner."""
+        _insert_candidates(db, [
+            (1, "editable", "true",  "exact", (1, 0, 100, 0, 0, 0, 0, 0), 0),
+            (1, "editable", "false", "exact", (1, 0, 0, 0, 0, 0, 0, 0), 1),
+            (1, "visible",  "true",  "exact", (1, 0, 0, 0, 0, 0, 0, 0), 0),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        dupes = db.execute("""
+            SELECT entity_id, property_name, COUNT(*) AS n
+            FROM resolved_properties GROUP BY entity_id, property_name HAVING n > 1
+        """).fetchall()
+        assert dupes == []
+
+
+class TestCapResolution:
+    def test_tightest_bound_wins(self, db):
+        _insert_candidates(db, [
+            (1, "max-level", "5", "<=", (1, 0, 0, 0, 0, 1, 0, 0), 0),
+            (1, "max-level", "3", "<=", (1, 0, 0, 0, 0, 101, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        assert _resolved(db, 1, "max-level") == "3"
+
+    def test_cap_independent_of_specificity(self, db):
+        """For <=, the minimum value wins regardless of specificity."""
+        _insert_candidates(db, [
+            (1, "max-level", "2", "<=", (1, 0, 0, 0, 0, 1, 0, 0), 0),
+            (1, "max-level", "5", "<=", (1, 0, 0, 0, 0, 10001, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        assert _resolved(db, 1, "max-level") == "2"
+
+
+class TestPatternResolution:
+    def test_patterns_aggregate(self, db):
+        _insert_candidates(db, [
+            (1, "allow-pattern", "git *",    "pattern-in", (1, 0, 0, 0, 0, 101, 0, 0), 0),
+            (1, "allow-pattern", "pytest *", "pattern-in", (1, 0, 0, 0, 0, 101, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        result = _resolved(db, 1, "allow-pattern")
+        assert result is not None
+        assert "git *" in result
+        assert "pytest *" in result
+
+    def test_patterns_deduplicate(self, db):
+        _insert_candidates(db, [
+            (1, "allow-pattern", "git *", "pattern-in", (1, 0, 0, 0, 0, 101, 0, 0), 0),
+            (1, "allow-pattern", "git *", "pattern-in", (1, 0, 0, 0, 0, 101, 0, 0), 1),
+        ])
+        create_resolution_views(db, SQLiteDialect())
+        result = _resolved(db, 1, "allow-pattern")
+        assert result == "git *"
+
+
+class TestSpecificityOrdering:
+    def test_json_specificity_ordering_is_correct(self, db):
+        """Higher axis_count wins over higher within-axis specificity."""
+        dialect = SQLiteDialect()
+        _insert_candidates(db, [
+            (1, "allow", "true",  "exact", (2, 0, 0, 0, 0, 101, 0, 0), 0),
+            (1, "allow", "false", "exact", (1, 0, 0, 0, 0, 10001, 0, 0), 1),
+        ])
+        create_resolution_views(db, dialect)
+        assert _resolved(db, 1, "allow") == "true"

--- a/tests/test_compilers_sql/test_resolution.py
+++ b/tests/test_compilers_sql/test_resolution.py
@@ -5,12 +5,13 @@ Verifies comparison-aware resolution: exact (highest specificity wins),
 """
 from __future__ import annotations
 
-import json
 import sqlite3
+
 import pytest
+
 from umwelt.compilers.sql.dialects import SQLiteDialect
-from umwelt.compilers.sql.schema import create_schema
 from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
 
 
 @pytest.fixture

--- a/tests/test_compilers_sql/test_roundtrip.py
+++ b/tests/test_compilers_sql/test_roundtrip.py
@@ -4,6 +4,11 @@ Port of ducklog's test_roundtrip.py adapted for SQLite.
 """
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from tests.test_compilers_sql.conftest import parse_view
 from umwelt.compilers.sql.compiler import compile_view
@@ -184,6 +189,42 @@ class TestStructuralDescendants:
         assert rv.property("src/auth.py", "editable") == "true"
         assert rv.property("tests/test_auth.py", "editable") == "false"
         rv.assert_a1()
+
+
+_SRC_DIR = str(Path(__file__).resolve().parents[2] / "src")
+
+
+class TestCLIIntegration:
+    def _run_cli(self, *args):
+        env = {**os.environ, "PYTHONPATH": _SRC_DIR}
+        return subprocess.run(
+            [sys.executable, "-m", "umwelt.cli", *args],
+            capture_output=True, text=True, env=env,
+        )
+
+    def test_compile_to_sqlite_db(self, tmp_path):
+        policy = tmp_path / "policy.umw"
+        policy.write_text('file { editable: false; }\nfile[path^="src/"] { editable: true; }')
+        db_path = tmp_path / "policy.db"
+        result = self._run_cli("compile", str(policy), "--target", "sqlite", "--db", str(db_path))
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert db_path.exists()
+
+    def test_compile_sql_to_stdout(self, tmp_path):
+        policy = tmp_path / "policy.umw"
+        policy.write_text('file { visible: true; }')
+        result = self._run_cli("compile", str(policy), "--target", "sqlite")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "CREATE TABLE" in result.stdout
+
+    def test_compile_sql_to_file(self, tmp_path):
+        policy = tmp_path / "policy.umw"
+        policy.write_text('file { visible: true; }')
+        sql_path = tmp_path / "policy.sql"
+        result = self._run_cli("compile", str(policy), "--target", "sqlite", "-o", str(sql_path))
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert sql_path.exists()
+        assert "CREATE TABLE" in sql_path.read_text()
 
 
 class TestFullPolicy:

--- a/tests/test_compilers_sql/test_roundtrip.py
+++ b/tests/test_compilers_sql/test_roundtrip.py
@@ -1,0 +1,219 @@
+"""Round-trip tests: parse .umw → compile → SQLite → resolve → verify.
+
+Port of ducklog's test_roundtrip.py adapted for SQLite.
+"""
+from __future__ import annotations
+
+import pytest
+from tests.test_compilers_sql.conftest import parse_view
+from umwelt.compilers.sql.compiler import compile_view
+from umwelt.compilers.sql.dialects import SQLiteDialect
+
+
+DIALECT = SQLiteDialect()
+
+
+@pytest.fixture
+def world(populated_db):
+    return populated_db
+
+
+def _resolve(world, umw_text: str):
+    view = parse_view(umw_text)
+    compile_view(world, view, DIALECT, source_file="test.umw")
+    return _Resolved(world)
+
+
+class _Resolved:
+    def __init__(self, con):
+        self.con = con
+
+    def property(self, entity_id: str, prop_name: str) -> str | None:
+        row = self.con.execute(
+            "SELECT rp.property_value FROM resolved_properties rp "
+            "JOIN entities e ON rp.entity_id = e.id "
+            "WHERE e.entity_id = ? AND rp.property_name = ?",
+            (entity_id, prop_name),
+        ).fetchone()
+        return row[0] if row else None
+
+    def property_by_id(self, entity_db_id: int, prop_name: str) -> str | None:
+        row = self.con.execute(
+            "SELECT property_value FROM resolved_properties "
+            "WHERE entity_id = ? AND property_name = ?",
+            (entity_db_id, prop_name),
+        ).fetchone()
+        return row[0] if row else None
+
+    def all_props(self, entity_id: str) -> dict[str, str]:
+        rows = self.con.execute(
+            "SELECT rp.property_name, rp.property_value FROM resolved_properties rp "
+            "JOIN entities e ON rp.entity_id = e.id WHERE e.entity_id = ?",
+            (entity_id,),
+        ).fetchall()
+        return dict(rows)
+
+    def assert_a1(self):
+        dupes = self.con.execute(
+            "SELECT entity_id, property_name, COUNT(*) AS n "
+            "FROM resolved_properties GROUP BY entity_id, property_name HAVING n > 1"
+        ).fetchall()
+        assert dupes == [], f"A1 violated: duplicate winners {dupes}"
+
+
+class TestFilePermissions:
+    def test_prefix_match_sets_editable(self, world):
+        rv = _resolve(world, '''
+            file[path^="src/"] { editable: true; }
+            file { editable: false; }
+        ''')
+        assert rv.property("src/auth.py", "editable") == "true"
+        assert rv.property("tests/test_auth.py", "editable") == "false"
+        assert rv.property("README.md", "editable") == "false"
+        rv.assert_a1()
+
+    def test_suffix_match_hides_pyc(self, world):
+        rv = _resolve(world, '''
+            file { visible: true; }
+            file[path$=".pyc"] { visible: false; }
+        ''')
+        assert rv.property("src/auth.py", "visible") == "true"
+        assert rv.property("src/main.pyc", "visible") == "false"
+        rv.assert_a1()
+
+    def test_specificity_ordering(self, world):
+        rv = _resolve(world, '''
+            file { editable: false; }
+            file[path^="src/"] { editable: true; }
+        ''')
+        assert rv.property("src/auth.py", "editable") == "true"
+        rv.assert_a1()
+
+    def test_document_order_breaks_ties(self, world):
+        rv = _resolve(world, '''
+            file[path^="src/"] { editable: false; }
+            file[path^="src/"] { editable: true; }
+        ''')
+        assert rv.property("src/auth.py", "editable") == "true"
+        rv.assert_a1()
+
+
+class TestToolPermissions:
+    def test_tool_allow_deny(self, world):
+        rv = _resolve(world, '''
+            tool { allow: true; }
+            tool[name="Bash"] { allow: false; }
+        ''')
+        assert rv.property("Read", "allow") == "true"
+        assert rv.property("Bash", "allow") == "false"
+        rv.assert_a1()
+
+    def test_max_level_tightest_wins(self, world):
+        rv = _resolve(world, '''
+            tool { max-level: 5; }
+            tool[name="Bash"] { max-level: 3; }
+        ''')
+        assert rv.property("Bash", "max-level") == "3"
+        assert rv.property("Read", "max-level") == "5"
+        rv.assert_a1()
+
+    def test_allow_pattern_aggregates(self, world):
+        rv = _resolve(world, '''
+            tool[name="Bash"] { allow-pattern: "git *"; }
+            tool[name="Bash"] { allow-pattern: "pytest *"; }
+        ''')
+        patterns = rv.property("Bash", "allow-pattern")
+        assert patterns is not None
+        assert "git *" in patterns
+        assert "pytest *" in patterns
+        rv.assert_a1()
+
+
+class TestModeGatedTools:
+    def test_mode_gates_tool(self, world):
+        rv = _resolve(world, '''
+            tool { allow: true; }
+            mode.explore tool { allow: false; }
+        ''')
+        assert rv.property("Read", "allow") == "false"
+        assert rv.property("Bash", "allow") == "false"
+        rv.assert_a1()
+
+    def test_mode_specific_tool_override(self, world):
+        rv = _resolve(world, '''
+            mode.explore tool { allow: false; }
+            mode.explore tool[name="Read"] { allow: true; }
+        ''')
+        assert rv.property("Read", "allow") == "true"
+        assert rv.property("Bash", "allow") == "false"
+        rv.assert_a1()
+
+    def test_nonexistent_mode_gates_nothing(self, world):
+        rv = _resolve(world, '''
+            tool { allow: true; }
+            mode.deploy tool { allow: false; }
+        ''')
+        assert rv.property("Read", "allow") == "true"
+        rv.assert_a1()
+
+
+class TestCrossAxis:
+    def test_three_axis_beats_two_axis(self, world):
+        rv = _resolve(world, '''
+            mode.implement tool[name="Bash"] { allow: false; }
+            principal#Teague mode.implement tool[name="Bash"] { allow: true; }
+        ''')
+        assert rv.property("Bash", "allow") == "true"
+        rv.assert_a1()
+
+    def test_two_axis_beats_one_axis(self, world):
+        rv = _resolve(world, '''
+            tool[name="Bash"] { allow: true; }
+            mode.implement tool[name="Bash"] { allow: false; }
+        ''')
+        assert rv.property("Bash", "allow") == "false"
+        rv.assert_a1()
+
+
+class TestStructuralDescendants:
+    def test_dir_file_descendant(self, world):
+        rv = _resolve(world, '''
+            file { editable: false; }
+            dir[name="src"] file { editable: true; }
+        ''')
+        assert rv.property("src/auth.py", "editable") == "true"
+        assert rv.property("tests/test_auth.py", "editable") == "false"
+        rv.assert_a1()
+
+
+class TestFullPolicy:
+    def test_realistic_policy(self, world):
+        rv = _resolve(world, '''
+            file { editable: false; visible: true; }
+            file[path^="src/"] { editable: true; }
+            file[path$=".pyc"] { visible: false; }
+
+            tool { allow: true; max-level: 3; }
+            tool[name="Bash"] { max-level: 2; }
+            tool[name="Agent"] { allow: false; }
+
+            tool[name="Bash"] { allow-pattern: "git *"; }
+            tool[name="Bash"] { allow-pattern: "pytest *"; }
+
+            network { deny: "*"; }
+            resource[kind="memory"] { limit: 512MB; }
+        ''')
+        assert rv.property("src/auth.py", "editable") == "true"
+        assert rv.property("README.md", "editable") == "false"
+        assert rv.property("src/main.pyc", "visible") == "false"
+        assert rv.property("Read", "allow") == "true"
+        assert rv.property("Agent", "allow") == "false"
+        assert rv.property("Bash", "max-level") == "2"
+
+        patterns = rv.property("Bash", "allow-pattern")
+        assert "git *" in patterns
+        assert "pytest *" in patterns
+
+        assert rv.property_by_id(25, "deny") == "*"
+        assert rv.property("memory", "limit") == "512MB"
+        rv.assert_a1()

--- a/tests/test_compilers_sql/test_roundtrip.py
+++ b/tests/test_compilers_sql/test_roundtrip.py
@@ -10,10 +10,10 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from tests.test_compilers_sql.conftest import parse_view
 from umwelt.compilers.sql.compiler import compile_view
 from umwelt.compilers.sql.dialects import SQLiteDialect
-
 
 DIALECT = SQLiteDialect()
 

--- a/tests/test_compilers_sql/test_schema.py
+++ b/tests/test_compilers_sql/test_schema.py
@@ -1,0 +1,67 @@
+"""Tests for SQL schema DDL generation."""
+from __future__ import annotations
+
+import sqlite3
+import pytest
+from umwelt.compilers.sql.schema import create_schema, EXPECTED_TABLES
+from umwelt.compilers.sql.dialects import SQLiteDialect
+
+
+@pytest.fixture
+def db():
+    con = sqlite3.connect(":memory:")
+    yield con
+    con.close()
+
+
+class TestSchemaCreation:
+    def test_ddl_executes_without_error(self, db):
+        dialect = SQLiteDialect()
+        ddl = create_schema(dialect)
+        db.executescript(ddl)
+
+    def test_all_tables_exist(self, db):
+        dialect = SQLiteDialect()
+        db.executescript(create_schema(dialect))
+        cursor = db.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        tables = {row[0] for row in cursor}
+        for expected in EXPECTED_TABLES:
+            assert expected in tables, f"missing table: {expected}"
+
+    def test_entities_table_columns(self, db):
+        dialect = SQLiteDialect()
+        db.executescript(create_schema(dialect))
+        cursor = db.execute("PRAGMA table_info(entities)")
+        columns = {row[1] for row in cursor}
+        assert {"id", "taxon", "type_name", "entity_id", "classes", "attributes", "parent_id", "depth"} <= columns
+
+    def test_cascade_candidates_columns(self, db):
+        dialect = SQLiteDialect()
+        db.executescript(create_schema(dialect))
+        cursor = db.execute("PRAGMA table_info(cascade_candidates)")
+        columns = {row[1] for row in cursor}
+        assert {"entity_id", "property_name", "property_value", "comparison",
+                "specificity", "rule_index", "source_file", "source_line"} <= columns
+
+    def test_entity_closure_columns(self, db):
+        dialect = SQLiteDialect()
+        db.executescript(create_schema(dialect))
+        cursor = db.execute("PRAGMA table_info(entity_closure)")
+        columns = {row[1] for row in cursor}
+        assert {"ancestor_id", "descendant_id", "depth"} <= columns
+
+    def test_insert_entity_with_json(self, db):
+        """Verify JSON columns accept and return valid data."""
+        import json
+        dialect = SQLiteDialect()
+        db.executescript(create_schema(dialect))
+        db.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("world", "file", "src/auth.py",
+             json.dumps(["python"]),
+             json.dumps({"path": "src/auth.py", "language": "python"}),
+             0),
+        )
+        row = db.execute("SELECT json_extract(attributes, '$.path') FROM entities WHERE entity_id = 'src/auth.py'").fetchone()
+        assert row[0] == "src/auth.py"

--- a/tests/test_compilers_sql/test_schema.py
+++ b/tests/test_compilers_sql/test_schema.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import sqlite3
+
 import pytest
-from umwelt.compilers.sql.schema import create_schema, EXPECTED_TABLES
+
 from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.schema import EXPECTED_TABLES, create_schema
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Adds `umwelt.compilers.sql` — a new SQLite-backed policy compiler that translates `.umw` views into queryable SQLite databases
- Implements dialect abstraction layer (SQLite + DuckDB), schema DDL generation, selector-to-SQL compilation (type/id/class/attr filters with 6 operators, pseudo-classes, structural descent, cross-axis qualifiers), comparison-aware cascade resolution (exact/cap/pattern-in), and entity population from the matcher registry
- Integrates with CLI: `umwelt compile policy.umw --target sqlite [--db path.db] [-o file.sql]`

## Details
- 12 commits, 86 new tests across 6 test files
- SQLite as canonical IR — DuckDB reads SQLite natively, no separate ducklog package needed
- JSON columns for attributes/classes, zero-padded specificity arrays for lexicographic ordering
- Materialized cascade_candidates (INSERT per entity) for SQLite performance
- No new runtime dependencies (removed pypika after switching to direct SQL generation)

## Test plan
- [x] 86 SQL compiler tests pass (dialect, schema, compiler, resolution, populate, roundtrip)
- [x] 528 existing tests pass with no regressions (34 pre-existing sandbox failures unchanged)
- [x] Ruff lint clean
- [x] Manual smoke test: `umwelt compile policy.umw --target sqlite --db out.db` produces 22,802 entities, 35,992 resolved properties
- [ ] Review A1 invariant (unique winners) holds across all round-trip test scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)