### PR TITLE
feat: world state layer + PolicyEngine API

### DIFF
--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -195,6 +195,58 @@ Each cycle moves a piece of the agent's behavior from "requires judgment" to "ha
 
 This is the [configuration ratchet](https://judgementalmonad.com/blog/ma/the-configuration-ratchet) from the Ma framework, applied to policy specification. The ratchet utility ships in v0.3.
 
+## World files: declaring the DOM
+
+The entity tree above can be declared in a `.world.yml` file — a YAML document that lists what exists in the agent's world:
+
+```yaml
+# env.world.yml
+tools: [Read, Edit, Bash]
+modes: [implement]
+principal: Teague
+
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+    attributes:
+      description: "Execute shell commands"
+
+projections:
+  - type: dir
+    id: node_modules
+    attributes:
+      path: "node_modules/"
+```
+
+Shorthand keys (`tools:`, `modes:`, `principal:`) expand via a vocabulary-driven registry — `tools: [Read, Edit]` becomes two `DeclaredEntity(type="tool", ...)` instances. Explicit `entities:` entries override shorthands on `(type, id)` collision.
+
+World files are parsed by `umwelt.world.load_world()` and can be materialized at three detail levels (summary, outline, full) via `umwelt materialize`.
+
+## PolicyEngine: querying resolved policy
+
+The **PolicyEngine** is the consumer-facing API. It compiles a world file + stylesheet into an in-memory SQLite database, resolves cascade, and answers queries:
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine.from_files(world="env.world.yml", stylesheet="policy.umw")
+
+# What's the resolved value?
+engine.resolve(type="tool", id="Bash", property="visible")  # → "false"
+
+# Why did that value win?
+trace = engine.trace(type="tool", id="Bash", property="visible")
+
+# Are there policy smells?
+warnings = engine.lint()  # narrow_win, shadowed_rule, conflicting_intent, ...
+
+# Enforce a constraint
+engine.require(type="tool", id="Bash", visible="false")  # raises PolicyDenied on mismatch
+```
+
+Consumers like Kibitzer and Lackpy use PolicyEngine instead of raw SQL — umwelt declares, consumers enforce.
+
 ## Where to go from here
 
 - **[Vision: Policy Layer](../vision/policy-layer.md)** — the full theoretical framing: why umwelt exists, how it fits the specified-band regulation strategy, the three-layer model.

--- a/docs/superpowers/plans/2026-04-20-policy-engine.md
+++ b/docs/superpowers/plans/2026-04-20-policy-engine.md
@@ -1,0 +1,2557 @@
+# PolicyEngine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `umwelt.policy.PolicyEngine` — a consumer-facing Python API that wraps a compiled SQLite database, providing knowledge queries (resolve, trace), lint analysis, typed projection views, world file entity population, and COW extend semantics.
+
+**Architecture:** New `src/umwelt/policy/` subpackage layered on top of `compilers/sql/`. PolicyEngine manages an in-memory SQLite database. Three constructors (from_files, from_db, programmatic) all produce the same schema. Knowledge queries run SQL against `resolved_properties` and `cascade_candidates`. Lint analysis detects cascade smell patterns in Python. Projection views are vocabulary-driven SQL pivots embedded at compile time.
+
+**Tech Stack:** sqlite3 (stdlib), existing `compilers/sql/` (schema, compiler, populate, resolution, dialects), existing `world/` layer (parser, model), existing `parser` (CSS parsing). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-policy-engine-design.md`
+
+---
+
+## Design Decisions
+
+**D1: PolicyEngine wraps an in-memory SQLite connection.** All three constructors ultimately produce a `sqlite3.Connection` in memory. `from_db()` copies the file into memory (COW). `from_files()` builds in memory from scratch. Programmatic builds lazily on first query.
+
+**D2: Queries module is pure SQL against sqlite3.** `policy/queries.py` takes a `sqlite3.Connection` and returns dicts/lists. No dependency on `compilers/sql/` at query time — the compiled database is self-contained. CSS selector string parsing at query time uses `umwelt.selector.parse` + `umwelt.compilers.sql.compiler.compile_selector`.
+
+**D3: Lint runs in Python over SQL results.** Each smell detector queries `cascade_candidates` and/or `resolved_properties` and applies pattern detection. Returns `LintWarning` dataclasses.
+
+**D4: Projection views are generated from the registry's property_types table.** At compile time, `projections.py` reads the property_types table from the DB and generates `CREATE VIEW` DDL for each entity type that has registered properties.
+
+**D5: World file population is a separate function in `compilers/sql/populate.py`.** `populate_from_world()` inserts `DeclaredEntity` instances as rows. It runs after matcher population; world file entities win on (type, id) collision.
+
+**D6: Error hierarchy.** `PolicyError(UmweltError)` is the base. `PolicyDenied(PolicyError)` for `require()` failures. `PolicyCompilationError(PolicyError)` for build failures.
+
+**D7: Structured logging via `logging.getLogger("umwelt.policy")`.** Events emitted at INFO/DEBUG/WARNING levels with structured `extra` dicts. Zero overhead when no handlers are attached.
+
+---
+
+## Files
+
+### New files
+| File | Purpose |
+|---|---|
+| `src/umwelt/policy/__init__.py` | Public API: `PolicyEngine`, `LintWarning`, `TraceResult`, `Candidate` |
+| `src/umwelt/policy/engine.py` | `PolicyEngine` class with constructors, query dispatch, COW extend, save/export |
+| `src/umwelt/policy/queries.py` | Structured query builders: `resolve_entity`, `resolve_all`, `trace_entity`, `select_entities` |
+| `src/umwelt/policy/lint.py` | Smell detection: `run_lint()` returning `list[LintWarning]` |
+| `src/umwelt/policy/projections.py` | Vocabulary-driven typed projection view DDL + `compilation_meta` table |
+| `tests/policy/__init__.py` | Package marker |
+| `tests/policy/conftest.py` | Shared fixtures (compiled DBs, sample worlds + stylesheets) |
+| `tests/policy/test_queries.py` | Query method tests |
+| `tests/policy/test_engine.py` | PolicyEngine lifecycle, COW, save/load tests |
+| `tests/policy/test_lint.py` | Lint smell detection tests |
+| `tests/policy/test_projections.py` | Typed projection view tests |
+| `tests/policy/test_populate_world.py` | World file entity population tests |
+| `tests/policy/test_integration.py` | End-to-end: from_files → resolve → trace → lint |
+
+### Modified files
+| File | Change |
+|---|---|
+| `src/umwelt/errors.py` | Add `PolicyError`, `PolicyDenied`, `PolicyCompilationError` |
+| `src/umwelt/compilers/sql/populate.py` | Add `populate_from_world()` function |
+
+---
+
+## Tasks
+
+### Task 1: Error classes + data models
+
+**Files:**
+- Modify: `src/umwelt/errors.py`
+- Create: `src/umwelt/policy/__init__.py`, `src/umwelt/policy/engine.py` (stub)
+- Create: `tests/policy/__init__.py`, `tests/policy/test_engine.py` (model tests only)
+
+- [ ] **Step 1: Write tests for error classes and data models**
+
+```python
+# tests/policy/test_engine.py
+import pytest
+from umwelt.errors import PolicyDenied, PolicyError, PolicyCompilationError, UmweltError
+
+
+class TestErrorHierarchy:
+    def test_policy_error_is_umwelt_error(self):
+        assert issubclass(PolicyError, UmweltError)
+
+    def test_policy_denied_is_policy_error(self):
+        assert issubclass(PolicyDenied, PolicyError)
+
+    def test_policy_compilation_error_is_policy_error(self):
+        assert issubclass(PolicyCompilationError, PolicyError)
+
+    def test_policy_denied_fields(self):
+        exc = PolicyDenied(
+            entity="tool#Bash",
+            property="editable",
+            expected="true",
+            actual="false",
+        )
+        assert exc.entity == "tool#Bash"
+        assert exc.property == "editable"
+        assert exc.expected == "true"
+        assert exc.actual == "false"
+        assert "tool#Bash" in str(exc)
+        assert "editable" in str(exc)
+
+
+class TestDataModels:
+    def test_lint_warning_construction(self):
+        from umwelt.policy import LintWarning
+        w = LintWarning(
+            smell="narrow_win",
+            severity="warning",
+            description="Winner won by 1 specificity point",
+            entities=("tool#Bash",),
+            property="max-level",
+        )
+        assert w.smell == "narrow_win"
+        assert w.severity == "warning"
+
+    def test_trace_result_construction(self):
+        from umwelt.policy import TraceResult, Candidate
+        c = Candidate(
+            value="3",
+            specificity="00001,00000,00001",
+            rule_index=2,
+            source_file="policy.umw",
+            source_line=10,
+            won=True,
+        )
+        tr = TraceResult(
+            entity="tool#Bash",
+            property="max-level",
+            value="3",
+            candidates=(c,),
+        )
+        assert tr.value == "3"
+        assert len(tr.candidates) == 1
+        assert tr.candidates[0].won is True
+
+    def test_lint_warning_frozen(self):
+        from umwelt.policy import LintWarning
+        w = LintWarning(smell="narrow_win", severity="warning", description="test", entities=(), property=None)
+        with pytest.raises(AttributeError):
+            w.smell = "other"
+
+    def test_candidate_frozen(self):
+        from umwelt.policy import Candidate
+        c = Candidate(value="3", specificity="x", rule_index=0, source_file="", source_line=0, won=True)
+        with pytest.raises(AttributeError):
+            c.value = "5"
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_engine.py -v
+```
+
+- [ ] **Step 3: Implement error classes and data models**
+
+Add to `src/umwelt/errors.py`:
+
+```python
+class PolicyError(UmweltError):
+    """Base class for policy engine errors."""
+
+
+class PolicyDenied(PolicyError):
+    """Raised when a require() check fails."""
+
+    def __init__(
+        self,
+        entity: str,
+        property: str,
+        expected: str,
+        actual: str | None,
+    ) -> None:
+        self.entity = entity
+        self.property = property
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"policy denied: {entity} {property}={actual!r} (expected {expected!r})"
+        )
+
+
+class PolicyCompilationError(PolicyError):
+    """Raised when compilation of policy sources fails."""
+```
+
+Create `src/umwelt/policy/__init__.py`:
+
+```python
+from umwelt.policy.engine import Candidate, LintWarning, TraceResult
+
+__all__ = [
+    "Candidate",
+    "LintWarning",
+    "TraceResult",
+]
+```
+
+Create `src/umwelt/policy/engine.py` (data models only for now):
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Candidate:
+    value: str
+    specificity: str
+    rule_index: int
+    source_file: str
+    source_line: int
+    won: bool
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    entity: str
+    property: str
+    value: str | None
+    candidates: tuple[Candidate, ...]
+
+
+@dataclass(frozen=True)
+class LintWarning:
+    smell: str
+    severity: str
+    description: str
+    entities: tuple[str, ...]
+    property: str | None
+```
+
+Create `tests/policy/__init__.py` (empty).
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_engine.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/umwelt/policy/ src/umwelt/errors.py tests/policy/
+git commit -m "feat(policy): error hierarchy + data models for PolicyEngine"
+```
+
+---
+
+### Task 2: Query functions (`queries.py`)
+
+**Files:**
+- Create: `src/umwelt/policy/queries.py`
+- Create: `tests/policy/conftest.py`, `tests/policy/test_queries.py`
+
+These functions operate on a raw `sqlite3.Connection` — no PolicyEngine yet. They are the SQL query layer.
+
+- [ ] **Step 1: Write conftest fixtures**
+
+```python
+# tests/policy/conftest.py
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+
+
+@pytest.fixture
+def dialect():
+    return SQLiteDialect()
+
+
+@pytest.fixture
+def policy_db(dialect):
+    """In-memory SQLite with schema, entities, cascade_candidates, and resolution views.
+
+    Entities:
+      - tool#Read (id=1)
+      - tool#Edit (id=2, classes=["edit"])
+      - tool#Bash (id=3, classes=["dangerous", "shell"])
+      - mode#implement (id=4)
+      - mode#review (id=5)
+
+    Cascade candidates (rules):
+      Rule 0: tool { allow: true; max-level: 5; }         specificity (0,0,0,1,0,0,0,0)
+      Rule 1: tool.dangerous { max-level: 3; }             specificity (0,0,0,1,0,1,0,0)
+      Rule 2: tool#Bash { risk-note: "Prefer structured"; } specificity (0,0,1,1,0,0,0,0)
+      Rule 3: mode { allow: true; }                        specificity (0,0,0,1,0,0,0,0)
+      Rule 4: tool.dangerous { allow: false; }             specificity (0,0,0,1,0,1,0,0) [same spec as rule 1, higher index]
+    """
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Edit", json.dumps(["edit"]), json.dumps({"name": "Edit"}), None, 0),
+        (3, "capability", "tool", "Bash", json.dumps(["dangerous", "shell"]), json.dumps({"name": "Bash"}), None, 0),
+        (4, "state", "mode", "implement", None, json.dumps({"name": "implement"}), None, 0),
+        (5, "state", "mode", "review", None, json.dumps({"name": "review"}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+
+    # Self-closure entries
+    con.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure (ancestor_id, descendant_id, depth)
+        SELECT id, id, 0 FROM entities;
+    """)
+
+    spec_tool = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+    spec_tool_class = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+    spec_tool_id = '["00000","00000","00001","00001","00000","00000","00000","00000"]'
+    spec_mode = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+    candidates = [
+        # Rule 0: tool { allow: true; max-level: 5; }
+        (1, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (2, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (3, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (1, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        (2, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        (3, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        # Rule 1: tool.dangerous { max-level: 3; }
+        (3, "max-level", "3", "<=", spec_tool_class, 1, "policy.umw", 3),
+        # Rule 2: tool#Bash { risk-note: "Prefer structured"; }
+        (3, "risk-note", "Prefer structured", "exact", spec_tool_id, 2, "policy.umw", 5),
+        # Rule 3: mode { allow: true; }
+        (4, "allow", "true", "exact", spec_mode, 3, "policy.umw", 7),
+        (5, "allow", "true", "exact", spec_mode, 3, "policy.umw", 7),
+        # Rule 4: tool.dangerous { allow: false; } — same specificity as rule 0 for Bash, higher index
+        (3, "allow", "false", "exact", spec_tool_class, 4, "policy.umw", 9),
+    ]
+    con.executemany(
+        "INSERT INTO cascade_candidates "
+        "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        candidates,
+    )
+    con.commit()
+
+    create_resolution_views(con, dialect)
+    return con
+```
+
+- [ ] **Step 2: Write query tests**
+
+```python
+# tests/policy/test_queries.py
+import pytest
+
+from umwelt.policy.queries import resolve_entity, resolve_all_entities, trace_entity, select_entities
+
+
+class TestResolveEntity:
+    def test_resolve_single_property(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_resolve_all_properties(self, policy_db):
+        props = resolve_entity(policy_db, type="tool", id="Bash")
+        assert props["risk-note"] == "Prefer structured"
+        assert props["allow"] == "false"  # rule 4 wins (higher specificity class selector)
+
+    def test_resolve_cap_comparison(self, policy_db):
+        props = resolve_entity(policy_db, type="tool", id="Bash")
+        assert props["max-level"] == "3"  # cap: MIN wins
+
+    def test_resolve_nonexistent_entity(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="NonExistent", property="allow")
+        assert val is None
+
+    def test_resolve_nonexistent_property(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="Read", property="nonexistent")
+        assert val is None
+
+    def test_resolve_mode_entity(self, policy_db):
+        val = resolve_entity(policy_db, type="mode", id="implement", property="allow")
+        assert val == "true"
+
+
+class TestResolveAll:
+    def test_resolve_all_tools(self, policy_db):
+        results = resolve_all_entities(policy_db, type="tool")
+        assert len(results) == 3
+        ids = {r["entity_id"] for r in results}
+        assert ids == {"Read", "Edit", "Bash"}
+
+    def test_resolve_all_includes_properties(self, policy_db):
+        results = resolve_all_entities(policy_db, type="tool")
+        bash = next(r for r in results if r["entity_id"] == "Bash")
+        assert bash["properties"]["allow"] == "false"
+        assert bash["properties"]["max-level"] == "3"
+
+    def test_resolve_all_modes(self, policy_db):
+        results = resolve_all_entities(policy_db, type="mode")
+        assert len(results) == 2
+
+    def test_resolve_all_unknown_type(self, policy_db):
+        results = resolve_all_entities(policy_db, type="nonexistent")
+        assert results == []
+
+
+class TestTraceEntity:
+    def test_trace_returns_all_candidates(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        assert len(result.candidates) >= 2  # rule 0 and rule 4
+
+    def test_trace_marks_winner(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        winners = [c for c in result.candidates if c.won]
+        assert len(winners) == 1
+        assert winners[0].value == "false"
+
+    def test_trace_value_matches_resolve(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        resolved = resolve_entity(policy_db, type="tool", id="Bash", property="allow")
+        assert result.value == resolved
+
+    def test_trace_nonexistent(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="NonExistent", property="allow")
+        assert result.value is None
+        assert result.candidates == ()
+
+    def test_trace_candidates_ordered_by_specificity(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="max-level")
+        specs = [c.specificity for c in result.candidates]
+        assert specs == sorted(specs, reverse=True)
+
+
+class TestSelectEntities:
+    def test_select_by_type(self, policy_db):
+        entities = select_entities(policy_db, type="tool")
+        assert len(entities) == 3
+
+    def test_select_by_type_and_id(self, policy_db):
+        entities = select_entities(policy_db, type="tool", id="Bash")
+        assert len(entities) == 1
+        assert entities[0]["entity_id"] == "Bash"
+
+    def test_select_by_classes(self, policy_db):
+        entities = select_entities(policy_db, type="tool", classes=["dangerous"])
+        assert len(entities) == 1
+        assert entities[0]["entity_id"] == "Bash"
+
+    def test_select_returns_entity_fields(self, policy_db):
+        entities = select_entities(policy_db, type="tool", id="Read")
+        e = entities[0]
+        assert "entity_id" in e
+        assert "type_name" in e
+        assert "classes" in e
+        assert "attributes" in e
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_queries.py -v
+```
+
+- [ ] **Step 4: Implement queries.py**
+
+```python
+# src/umwelt/policy/queries.py
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from umwelt.policy.engine import Candidate, TraceResult
+
+
+def resolve_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+    property: str | None = None,
+) -> str | dict[str, str] | None:
+    """Resolve properties for a single entity.
+
+    If *property* is given, returns that property's value (or None).
+    If *property* is omitted, returns a dict of all resolved properties.
+    """
+    entity_row = _find_entity(con, type=type, id=id)
+    if entity_row is None:
+        return None if property else {}
+
+    entity_pk = entity_row[0]
+
+    if property is not None:
+        row = con.execute(
+            "SELECT property_value FROM resolved_properties "
+            "WHERE entity_id = ? AND property_name = ?",
+            (entity_pk, property),
+        ).fetchone()
+        return row[0] if row else None
+
+    rows = con.execute(
+        "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+        (entity_pk,),
+    ).fetchall()
+    return {name: value for name, value in rows}
+
+
+def resolve_all_entities(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+) -> list[dict]:
+    """Resolve all entities of a type with their properties."""
+    entities = con.execute(
+        "SELECT id, entity_id, classes, attributes FROM entities WHERE type_name = ?",
+        (type,),
+    ).fetchall()
+
+    results = []
+    for eid, entity_id, classes_json, attrs_json in entities:
+        props_rows = con.execute(
+            "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+            (eid,),
+        ).fetchall()
+        props = {name: value for name, value in props_rows}
+        results.append({
+            "entity_id": entity_id,
+            "type_name": type,
+            "classes": json.loads(classes_json) if classes_json else [],
+            "attributes": json.loads(attrs_json) if attrs_json else {},
+            "properties": props,
+        })
+    return results
+
+
+def trace_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+    property: str,
+) -> TraceResult:
+    """Trace all cascade candidates for an (entity, property) pair."""
+    entity_row = _find_entity(con, type=type, id=id)
+    if entity_row is None:
+        return TraceResult(
+            entity=f"{type}#{id}",
+            property=property,
+            value=None,
+            candidates=(),
+        )
+
+    entity_pk = entity_row[0]
+
+    # Get winning value
+    winner_row = con.execute(
+        "SELECT property_value FROM resolved_properties "
+        "WHERE entity_id = ? AND property_name = ?",
+        (entity_pk, property),
+    ).fetchone()
+    winning_value = winner_row[0] if winner_row else None
+
+    # Get all candidates
+    rows = con.execute(
+        "SELECT property_value, specificity, rule_index, source_file, source_line "
+        "FROM cascade_candidates "
+        "WHERE entity_id = ? AND property_name = ? "
+        "ORDER BY specificity DESC, rule_index DESC",
+        (entity_pk, property),
+    ).fetchall()
+
+    candidates = []
+    for value, spec, rule_idx, src_file, src_line in rows:
+        candidates.append(Candidate(
+            value=value,
+            specificity=spec,
+            rule_index=rule_idx,
+            source_file=src_file or "",
+            source_line=src_line or 0,
+            won=(value == winning_value and not any(c.won for c in candidates)),
+        ))
+
+    return TraceResult(
+        entity=f"{type}#{id}",
+        property=property,
+        value=winning_value,
+        candidates=tuple(candidates),
+    )
+
+
+def select_entities(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str | None = None,
+    classes: list[str] | None = None,
+) -> list[dict]:
+    """Select entities matching type, optional id, and optional classes."""
+    sql = "SELECT id, entity_id, type_name, classes, attributes FROM entities WHERE type_name = ?"
+    params: list = [type]
+
+    if id is not None:
+        sql += " AND entity_id = ?"
+        params.append(id)
+
+    rows = con.execute(sql, params).fetchall()
+
+    results = []
+    for eid, entity_id, type_name, classes_json, attrs_json in rows:
+        entity_classes = json.loads(classes_json) if classes_json else []
+        if classes and not all(c in entity_classes for c in classes):
+            continue
+        results.append({
+            "id": eid,
+            "entity_id": entity_id,
+            "type_name": type_name,
+            "classes": entity_classes,
+            "attributes": json.loads(attrs_json) if attrs_json else {},
+        })
+    return results
+
+
+def _find_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+) -> tuple | None:
+    """Find an entity by (type, id). Returns the row or None."""
+    return con.execute(
+        "SELECT id, entity_id, type_name, classes, attributes FROM entities "
+        "WHERE type_name = ? AND entity_id = ?",
+        (type, id),
+    ).fetchone()
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_queries.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/umwelt/policy/queries.py tests/policy/conftest.py tests/policy/test_queries.py
+git commit -m "feat(policy): query functions — resolve, trace, select"
+```
+
+---
+
+### Task 3: World file entity population
+
+**Files:**
+- Modify: `src/umwelt/compilers/sql/populate.py`
+- Create: `tests/policy/test_populate_world.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/policy/test_populate_world.py
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.populate import populate_from_world
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.world.model import DeclaredEntity, Projection, Provenance, WorldFile
+
+
+@pytest.fixture
+def empty_db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    yield con
+    con.close()
+
+
+class TestPopulateFromWorld:
+    def test_basic_entity_insertion(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read"),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT type_name, entity_id FROM entities WHERE entity_id = 'Read'"
+        ).fetchone()
+        assert row == ("tool", "Read")
+
+    def test_classes_stored_as_json(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Bash", classes=("dangerous", "shell")),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT classes FROM entities WHERE entity_id = 'Bash'"
+        ).fetchone()
+        assert json.loads(row[0]) == ["dangerous", "shell"]
+
+    def test_attributes_stored_as_json(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read", attributes={"description": "read files"}),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT attributes FROM entities WHERE entity_id = 'Read'"
+        ).fetchone()
+        assert json.loads(row[0])["description"] == "read files"
+
+    def test_multiple_entities(self, empty_db):
+        wf = WorldFile(
+            entities=(
+                DeclaredEntity(type="tool", id="Read"),
+                DeclaredEntity(type="tool", id="Edit"),
+                DeclaredEntity(type="mode", id="implement"),
+            ),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        count = empty_db.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+        assert count == 3
+
+    def test_projection_inserted_as_entity(self, empty_db):
+        wf = WorldFile(
+            entities=(),
+            projections=(Projection(type="dir", id="node_modules", attributes={"path": "node_modules/"}),),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT type_name, entity_id FROM entities WHERE entity_id = 'node_modules'"
+        ).fetchone()
+        assert row == ("dir", "node_modules")
+
+    def test_world_entity_wins_on_collision(self, empty_db):
+        # Pre-insert a matcher-discovered entity
+        empty_db.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+            "VALUES ('capability', 'tool', 'Bash', NULL, NULL, 0)"
+        )
+        empty_db.commit()
+
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Bash", classes=("dangerous",)),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+
+        rows = empty_db.execute(
+            "SELECT classes FROM entities WHERE entity_id = 'Bash'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert json.loads(rows[0][0]) == ["dangerous"]
+
+    def test_closure_table_rebuilt(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read"),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        closure = empty_db.execute(
+            "SELECT COUNT(*) FROM entity_closure"
+        ).fetchone()[0]
+        assert closure >= 1  # at least self-closure
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_populate_world.py -v
+```
+
+- [ ] **Step 3: Implement populate_from_world**
+
+Add to `src/umwelt/compilers/sql/populate.py`:
+
+```python
+def populate_from_world(con: Any, world: WorldFile) -> None:
+    """Insert DeclaredEntity instances from a WorldFile into the entities table.
+
+    World file entities win on (type_name, entity_id) collision with
+    existing matcher-discovered entities.
+    """
+    from umwelt.world.model import WorldFile  # deferred to avoid circular
+
+    for entity in world.entities:
+        _upsert_declared_entity(con, entity)
+
+    for proj in world.projections:
+        _upsert_projection(con, proj)
+
+    con.commit()
+    _rebuild_closure(con)
+
+
+def _upsert_declared_entity(con: Any, entity: Any) -> None:
+    """Insert or replace a DeclaredEntity into the entities table."""
+    import json as _json
+
+    classes_json = _json.dumps(list(entity.classes)) if entity.classes else None
+    attrs_json = _json.dumps(entity.attributes) if entity.attributes else None
+
+    existing = con.execute(
+        "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+        (entity.type, entity.id),
+    ).fetchone()
+
+    if existing:
+        con.execute(
+            "UPDATE entities SET classes = ?, attributes = ? WHERE id = ?",
+            (classes_json, attrs_json, existing[0]),
+        )
+    else:
+        taxon = _guess_taxon(entity.type)
+        con.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+            "VALUES (?, ?, ?, ?, ?, 0)",
+            (taxon, entity.type, entity.id, classes_json, attrs_json),
+        )
+
+
+def _upsert_projection(con: Any, proj: Any) -> None:
+    """Insert a Projection as an entity."""
+    import json as _json
+
+    attrs_json = _json.dumps(proj.attributes) if proj.attributes else None
+
+    existing = con.execute(
+        "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+        (proj.type, proj.id),
+    ).fetchone()
+
+    if existing:
+        con.execute(
+            "UPDATE entities SET attributes = ? WHERE id = ?",
+            (attrs_json, existing[0]),
+        )
+    else:
+        taxon = _guess_taxon(proj.type)
+        con.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, attributes, depth) "
+            "VALUES (?, ?, ?, ?, 0)",
+            (taxon, proj.type, proj.id, attrs_json),
+        )
+
+
+def _guess_taxon(type_name: str) -> str:
+    """Look up the taxon for an entity type from the registry, or default."""
+    try:
+        from umwelt.registry.entities import resolve_entity_type
+        taxa = resolve_entity_type(type_name)
+        if taxa:
+            return taxa[0]
+    except Exception:
+        pass
+    return type_name
+```
+
+The import of `WorldFile` in the type annotation uses a string to avoid circular imports. The function signature uses `Any` for the `world` parameter but documents that it expects a `WorldFile`.
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_populate_world.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/umwelt/compilers/sql/populate.py tests/policy/test_populate_world.py
+git commit -m "feat(policy): world file entity population via populate_from_world()"
+```
+
+---
+
+### Task 4: Typed projection views (`projections.py`)
+
+**Files:**
+- Create: `src/umwelt/policy/projections.py`
+- Create: `tests/policy/test_projections.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/policy/test_projections.py
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.policy.projections import create_projection_views, create_compilation_meta
+
+
+@pytest.fixture
+def projection_db():
+    """DB with entities, candidates, resolution views, and property_types."""
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    # Register property types
+    prop_types = [
+        ("capability", "tool", "allow", "str", "exact", ""),
+        ("capability", "tool", "visible", "str", "exact", ""),
+        ("capability", "tool", "max-level", "int", "<=", ""),
+        ("state", "mode", "writable", "str", "exact", ""),
+        ("state", "mode", "strategy", "str", "exact", ""),
+    ]
+    con.executemany(
+        "INSERT INTO property_types (taxon, entity_type, name, value_type, comparison, description) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        prop_types,
+    )
+
+    # Entities
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Bash", json.dumps(["dangerous"]), json.dumps({"name": "Bash"}), None, 0),
+        (3, "state", "mode", "implement", None, json.dumps({}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+
+    # Cascade candidates + resolution views
+    spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+    candidates = [
+        (1, "allow", "true", "exact", spec, 0, "", 0),
+        (2, "allow", "true", "exact", spec, 0, "", 0),
+        (2, "max-level", "3", "<=", spec, 0, "", 0),
+        (3, "writable", "src/", "exact", spec, 0, "", 0),
+    ]
+    con.executemany(
+        "INSERT INTO cascade_candidates "
+        "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        candidates,
+    )
+    con.commit()
+    create_resolution_views(con, dialect)
+    return con
+
+
+class TestProjectionViews:
+    def test_creates_tools_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM tools").fetchall()
+        assert len(rows) == 2  # Read and Bash
+
+    def test_tools_view_has_pivoted_columns(self, projection_db):
+        create_projection_views(projection_db)
+        row = projection_db.execute(
+            "SELECT name, allow, max_level FROM tools WHERE name = 'Bash'"
+        ).fetchone()
+        assert row is not None
+        assert row[1] == "true"  # allow
+        assert row[2] == "3"    # max_level
+
+    def test_creates_modes_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM modes").fetchall()
+        assert len(rows) == 1
+
+    def test_modes_view_columns(self, projection_db):
+        create_projection_views(projection_db)
+        row = projection_db.execute(
+            "SELECT name, writable FROM modes WHERE name = 'implement'"
+        ).fetchone()
+        assert row is not None
+        assert row[1] == "src/"
+
+    def test_creates_resolved_entities_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM resolved_entities").fetchall()
+        assert len(rows) >= 2  # at least the entities with resolved properties
+
+    def test_no_property_types_still_works(self):
+        dialect = SQLiteDialect()
+        con = sqlite3.connect(":memory:")
+        con.executescript(create_schema(dialect))
+        create_resolution_views(con, dialect)
+        create_projection_views(con)
+        # No views to create, but should not error
+
+
+class TestCompilationMeta:
+    def test_creates_meta_table(self, projection_db):
+        create_compilation_meta(projection_db, source_world="test.world.yml", source_stylesheet="policy.umw")
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'source_world'"
+        ).fetchone()
+        assert row[0] == "test.world.yml"
+
+    def test_meta_has_entity_count(self, projection_db):
+        create_compilation_meta(projection_db)
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'entity_count'"
+        ).fetchone()
+        assert int(row[0]) == 3
+
+    def test_meta_has_compiled_at(self, projection_db):
+        create_compilation_meta(projection_db)
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'compiled_at'"
+        ).fetchone()
+        assert row[0]  # non-empty ISO timestamp
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_projections.py -v
+```
+
+- [ ] **Step 3: Implement projections.py**
+
+```python
+# src/umwelt/policy/projections.py
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+
+def create_projection_views(con: sqlite3.Connection) -> None:
+    """Create vocabulary-driven typed projection views.
+
+    Reads entity types and their properties from property_types table,
+    generates a pivot view for each entity type.
+    """
+    _create_resolved_entities_view(con)
+
+    type_props = _get_type_properties(con)
+    for entity_type, props in type_props.items():
+        _create_typed_view(con, entity_type, props)
+
+
+def create_compilation_meta(
+    con: sqlite3.Connection,
+    *,
+    source_world: str | None = None,
+    source_stylesheet: str | None = None,
+) -> None:
+    """Create and populate the compilation_meta table."""
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS compilation_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+
+    entity_count = con.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+
+    resolved_count_row = con.execute(
+        "SELECT COUNT(*) FROM resolved_properties"
+    ).fetchone()
+    resolved_count = resolved_count_row[0] if resolved_count_row else 0
+
+    meta = {
+        "compiled_at": datetime.now(timezone.utc).isoformat(),
+        "entity_count": str(entity_count),
+        "resolved_count": str(resolved_count),
+        "dialect": "sqlite",
+    }
+    if source_world:
+        meta["source_world"] = source_world
+    if source_stylesheet:
+        meta["source_stylesheet"] = source_stylesheet
+
+    for key, value in meta.items():
+        con.execute(
+            "INSERT OR REPLACE INTO compilation_meta (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+    con.commit()
+
+
+def _get_type_properties(con: sqlite3.Connection) -> dict[str, list[str]]:
+    """Read property_types and group property names by entity_type."""
+    rows = con.execute(
+        "SELECT entity_type, name FROM property_types ORDER BY entity_type, name"
+    ).fetchall()
+    result: dict[str, list[str]] = {}
+    for entity_type, prop_name in rows:
+        result.setdefault(entity_type, []).append(prop_name)
+    return result
+
+
+def _create_typed_view(
+    con: sqlite3.Connection,
+    entity_type: str,
+    properties: list[str],
+) -> None:
+    """Create a typed projection view for one entity type."""
+    view_name = entity_type + "s"  # tool -> tools, mode -> modes
+    safe_view = view_name.replace('"', '""')
+
+    pivot_cols = []
+    for prop in properties:
+        col_name = prop.replace("-", "_")
+        safe_col = col_name.replace('"', '""')
+        safe_prop = prop.replace("'", "''")
+        pivot_cols.append(
+            f'    MAX(CASE WHEN rp.property_name = \'{safe_prop}\' '
+            f'THEN rp.property_value END) AS "{safe_col}"'
+        )
+
+    pivot_sql = ",\n".join(pivot_cols)
+    safe_type = entity_type.replace("'", "''")
+
+    ddl = f"""
+CREATE VIEW IF NOT EXISTS "{safe_view}" AS
+SELECT e.entity_id AS name, e.classes, e.attributes,
+{pivot_sql}
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+WHERE e.type_name = '{safe_type}'
+GROUP BY e.id, e.entity_id, e.classes, e.attributes;
+"""
+    con.executescript(ddl)
+
+
+def _create_resolved_entities_view(con: sqlite3.Connection) -> None:
+    """Create the generic resolved_entities view with JSON property map."""
+    con.executescript("""
+CREATE VIEW IF NOT EXISTS resolved_entities AS
+SELECT e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes,
+    json_group_object(rp.property_name, rp.property_value) AS properties
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+GROUP BY e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes;
+""")
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_projections.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/umwelt/policy/projections.py tests/policy/test_projections.py
+git commit -m "feat(policy): typed projection views + compilation_meta"
+```
+
+---
+
+### Task 5: Lint analysis (`lint.py`)
+
+**Files:**
+- Create: `src/umwelt/policy/lint.py`
+- Create: `tests/policy/test_lint.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/policy/test_lint.py
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.policy.engine import LintWarning
+from umwelt.policy.lint import run_lint
+
+
+@pytest.fixture
+def lint_db():
+    """DB set up for lint testing with various smell scenarios."""
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Bash", json.dumps(["dangerous"]), json.dumps({"name": "Bash"}), None, 0),
+        (3, "capability", "tool", "Orphan", None, json.dumps({"name": "Orphan"}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+    con.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure (ancestor_id, descendant_id, depth)
+        SELECT id, id, 0 FROM entities;
+    """)
+    return con
+
+
+class TestNarrowWin:
+    def test_detects_narrow_win(self, lint_db):
+        dialect = SQLiteDialect()
+        spec_low = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec_high = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+
+        # Two rules for same entity/property, specificity differs by one position
+        candidates = [
+            (2, "allow", "true", "exact", spec_low, 0, "a.umw", 1),
+            (2, "allow", "false", "exact", spec_high, 1, "a.umw", 3),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        narrow = [w for w in warnings if w.smell == "narrow_win"]
+        assert len(narrow) >= 1
+
+
+class TestShadowedRule:
+    def test_detects_shadowed_rule(self, lint_db):
+        dialect = SQLiteDialect()
+        spec_low = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec_high = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+
+        # Rule at a.umw:5 sets allow for entity 2, but higher-spec rule always wins
+        candidates = [
+            (2, "allow", "true", "exact", spec_low, 0, "a.umw", 5),
+            (2, "allow", "false", "exact", spec_high, 1, "a.umw", 10),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        shadowed = [w for w in warnings if w.smell == "shadowed_rule"]
+        assert len(shadowed) >= 1
+
+
+class TestUncoveredEntity:
+    def test_detects_uncovered_entity(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        # Rules for entities 1 and 2 only — entity 3 (Orphan) has no candidates
+        candidates = [
+            (1, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        uncovered = [w for w in warnings if w.smell == "uncovered_entity"]
+        assert len(uncovered) >= 1
+        assert any("Orphan" in w.description for w in uncovered)
+
+
+class TestConflictingIntent:
+    def test_detects_conflicting_intent(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        # Same specificity, opposite values — winner decided by source order alone
+        candidates = [
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "false", "exact", spec, 1, "a.umw", 5),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        conflicting = [w for w in warnings if w.smell == "conflicting_intent"]
+        assert len(conflicting) >= 1
+
+
+class TestSpecificityEscalation:
+    def test_detects_escalation(self, lint_db):
+        dialect = SQLiteDialect()
+        spec1 = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec2 = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+        spec3 = '["00000","00000","00001","00001","00000","00001","00000","00000"]'
+
+        # 3+ candidates with strictly increasing specificity
+        candidates = [
+            (2, "max-level", "5", "<=", spec1, 0, "a.umw", 1),
+            (2, "max-level", "3", "<=", spec2, 1, "a.umw", 3),
+            (2, "max-level", "1", "<=", spec3, 2, "a.umw", 5),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        escalation = [w for w in warnings if w.smell == "specificity_escalation"]
+        assert len(escalation) >= 1
+
+
+class TestNoSmells:
+    def test_clean_db_no_warnings(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        # Simple, non-overlapping rules
+        candidates = [
+            (1, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (3, "allow", "true", "exact", spec, 0, "a.umw", 1),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        # No narrow_win, conflicting_intent, or escalation — possibly uncovered if no candidates match all
+        serious = [w for w in warnings if w.severity == "warning"]
+        assert len(serious) == 0
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_lint.py -v
+```
+
+- [ ] **Step 3: Implement lint.py**
+
+```python
+# src/umwelt/policy/lint.py
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+from umwelt.policy.engine import LintWarning
+
+logger = logging.getLogger("umwelt.policy")
+
+
+def run_lint(con: sqlite3.Connection) -> list[LintWarning]:
+    """Run all lint smell detectors and return warnings."""
+    warnings: list[LintWarning] = []
+    warnings.extend(_detect_narrow_win(con))
+    warnings.extend(_detect_shadowed_rule(con))
+    warnings.extend(_detect_conflicting_intent(con))
+    warnings.extend(_detect_uncovered_entity(con))
+    warnings.extend(_detect_specificity_escalation(con))
+
+    for w in warnings:
+        logger.warning(
+            "lint: %s — %s",
+            w.smell,
+            w.description,
+            extra={"smell": w.smell, "entities": w.entities, "severity": w.severity},
+        )
+    return warnings
+
+
+def _detect_narrow_win(con: sqlite3.Connection) -> list[LintWarning]:
+    """Detect cases where the winner's specificity is barely higher than the runner-up."""
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT cc.entity_id, cc.property_name, cc.property_value, cc.specificity, cc.rule_index
+        FROM cascade_candidates cc
+        WHERE cc.comparison = 'exact'
+        ORDER BY cc.entity_id, cc.property_name, cc.specificity DESC, cc.rule_index DESC
+    """).fetchall()
+
+    groups: dict[tuple[int, str], list[tuple]] = {}
+    for row in rows:
+        key = (row[0], row[1])
+        groups.setdefault(key, []).append(row)
+
+    for (entity_id, prop_name), candidates in groups.items():
+        if len(candidates) < 2:
+            continue
+        winner_spec = _parse_specificity(candidates[0][3])
+        runner_spec = _parse_specificity(candidates[1][3])
+        if winner_spec is None or runner_spec is None:
+            continue
+        diff = sum(w - r for w, r in zip(winner_spec, runner_spec))
+        if 0 < diff <= 1:
+            entity_name = _entity_name(con, entity_id)
+            warnings.append(LintWarning(
+                smell="narrow_win",
+                severity="warning",
+                description=f"{entity_name} '{prop_name}' won by specificity margin of {diff}",
+                entities=(entity_name,),
+                property=prop_name,
+            ))
+    return warnings
+
+
+def _detect_shadowed_rule(con: sqlite3.Connection) -> list[LintWarning]:
+    """Detect rules that never win for any entity."""
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT cc.source_file, cc.source_line, cc.property_name, cc.entity_id
+        FROM cascade_candidates cc
+        LEFT JOIN resolved_properties rp
+            ON cc.entity_id = rp.entity_id
+            AND cc.property_name = rp.property_name
+            AND cc.property_value = rp.property_value
+            AND cc.specificity = rp.specificity
+            AND cc.rule_index = rp.rule_index
+        WHERE rp.entity_id IS NULL
+          AND cc.source_file IS NOT NULL
+          AND cc.source_file != ''
+    """).fetchall()
+
+    shadowed_rules: dict[tuple[str, int], set[str]] = {}
+    for src_file, src_line, prop_name, entity_id in rows:
+        key = (src_file, src_line)
+        shadowed_rules.setdefault(key, set()).add(prop_name)
+
+    for (src_file, src_line), props in shadowed_rules.items():
+        warnings.append(LintWarning(
+            smell="shadowed_rule",
+            severity="info",
+            description=f"Rule at {src_file}:{src_line} never wins for properties: {', '.join(sorted(props))}",
+            entities=(),
+            property=None,
+        ))
+    return warnings
+
+
+def _detect_conflicting_intent(con: sqlite3.Connection) -> list[LintWarning]:
+    """Detect same-specificity candidates with opposite values."""
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT c1.entity_id, c1.property_name,
+               c1.property_value, c2.property_value,
+               c1.specificity
+        FROM cascade_candidates c1
+        JOIN cascade_candidates c2
+            ON c1.entity_id = c2.entity_id
+            AND c1.property_name = c2.property_name
+            AND c1.specificity = c2.specificity
+            AND c1.rule_index < c2.rule_index
+        WHERE c1.property_value != c2.property_value
+          AND c1.comparison = 'exact'
+          AND c2.comparison = 'exact'
+    """).fetchall()
+
+    seen: set[tuple[int, str]] = set()
+    for entity_id, prop_name, val1, val2, spec in rows:
+        key = (entity_id, prop_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        entity_name = _entity_name(con, entity_id)
+        warnings.append(LintWarning(
+            smell="conflicting_intent",
+            severity="warning",
+            description=f"{entity_name} '{prop_name}': '{val1}' vs '{val2}' at same specificity — winner decided by source order",
+            entities=(entity_name,),
+            property=prop_name,
+        ))
+    return warnings
+
+
+def _detect_uncovered_entity(con: sqlite3.Connection) -> list[LintWarning]:
+    """Detect entities with no resolved properties."""
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT e.id, e.type_name, e.entity_id
+        FROM entities e
+        LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+        WHERE rp.entity_id IS NULL
+    """).fetchall()
+
+    for eid, type_name, entity_id in rows:
+        name = f"{type_name}#{entity_id}" if entity_id else f"{type_name}(id={eid})"
+        warnings.append(LintWarning(
+            smell="uncovered_entity",
+            severity="info",
+            description=f"{name} has no resolved properties",
+            entities=(name,),
+            property=None,
+        ))
+    return warnings
+
+
+def _detect_specificity_escalation(con: sqlite3.Connection) -> list[LintWarning]:
+    """Detect 3+ candidates with strictly increasing specificity."""
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT entity_id, property_name, specificity
+        FROM cascade_candidates
+        ORDER BY entity_id, property_name, specificity ASC
+    """).fetchall()
+
+    groups: dict[tuple[int, str], list[str]] = {}
+    for entity_id, prop_name, spec in rows:
+        key = (entity_id, prop_name)
+        groups.setdefault(key, []).append(spec)
+
+    for (entity_id, prop_name), specs in groups.items():
+        unique_specs = sorted(set(specs))
+        if len(unique_specs) >= 3:
+            entity_name = _entity_name(con, entity_id)
+            warnings.append(LintWarning(
+                smell="specificity_escalation",
+                severity="warning",
+                description=f"{entity_name} '{prop_name}' has {len(unique_specs)} specificity levels — possible escalation war",
+                entities=(entity_name,),
+                property=prop_name,
+            ))
+    return warnings
+
+
+def _parse_specificity(spec_str: str) -> list[int] | None:
+    """Parse a JSON-encoded specificity array."""
+    try:
+        parts = json.loads(spec_str)
+        return [int(p) for p in parts]
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+
+
+def _entity_name(con: sqlite3.Connection, entity_id: int) -> str:
+    """Look up a human-readable entity name by PK."""
+    row = con.execute(
+        "SELECT type_name, entity_id FROM entities WHERE id = ?",
+        (entity_id,),
+    ).fetchone()
+    if row is None:
+        return f"entity({entity_id})"
+    type_name, eid = row
+    return f"{type_name}#{eid}" if eid else f"{type_name}(id={entity_id})"
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_lint.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/umwelt/policy/lint.py tests/policy/test_lint.py
+git commit -m "feat(policy): lint analysis — five cascade smell detectors"
+```
+
+---
+
+### Task 6: PolicyEngine class (`engine.py`)
+
+**Files:**
+- Modify: `src/umwelt/policy/engine.py`
+- Modify: `tests/policy/test_engine.py`
+
+This task adds the full `PolicyEngine` class — three constructors, query dispatch, COW extend, save/export, logging.
+
+- [ ] **Step 1: Write tests**
+
+```python
+# Add to tests/policy/test_engine.py (after existing TestErrorHierarchy and TestDataModels)
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from umwelt.errors import PolicyDenied
+from umwelt.policy.engine import PolicyEngine
+
+
+@pytest.fixture
+def sample_world_yml(tmp_path):
+    p = tmp_path / "test.world.yml"
+    p.write_text("""
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+  - type: mode
+    id: implement
+""")
+    return p
+
+
+@pytest.fixture
+def sample_stylesheet(tmp_path):
+    p = tmp_path / "policy.umw"
+    p.write_text("""
+tool { allow: true; max-level: 5; }
+tool.dangerous { max-level: 3; allow: false; }
+mode { allow: true; }
+""")
+    return p
+
+
+class TestFromFiles:
+    def test_creates_engine(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine is not None
+
+    def test_resolve_after_from_files(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        val = engine.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_resolve_all_properties(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        props = engine.resolve(type="tool", id="Bash")
+        assert isinstance(props, dict)
+        assert "allow" in props
+        assert "max-level" in props
+
+
+class TestFromDb:
+    def test_roundtrip_save_load(self, sample_world_yml, sample_stylesheet, tmp_path):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        db_path = tmp_path / "policy.db"
+        engine1.save(str(db_path))
+
+        engine2 = PolicyEngine.from_db(str(db_path))
+        val = engine2.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_from_db_is_cow(self, sample_world_yml, sample_stylesheet, tmp_path):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        db_path = tmp_path / "policy.db"
+        engine1.save(str(db_path))
+
+        engine2 = PolicyEngine.from_db(str(db_path))
+        # Modifying engine2 should not affect the file
+        # (We can't easily test this without extend, but from_db copies to memory)
+        assert engine2.resolve(type="tool", id="Read", property="allow") == "true"
+
+
+class TestProgrammatic:
+    def test_programmatic_build(self):
+        engine = PolicyEngine()
+        engine.add_entities([
+            {"type": "tool", "id": "Read"},
+            {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+        ])
+        engine.add_stylesheet("tool { allow: true; }\ntool.dangerous { allow: false; }")
+
+        val = engine.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+        val = engine.resolve(type="tool", id="Bash", property="allow")
+        assert val == "false"
+
+
+class TestExtend:
+    def test_extend_produces_new_engine(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        assert engine2 is not engine1
+
+    def test_extend_preserves_original(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        # Original should still have only implement
+        modes = engine1.resolve_all(type="mode")
+        assert len(modes) == 1
+
+    def test_extend_adds_entities(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        modes = engine2.resolve_all(type="mode")
+        assert len(modes) == 2
+
+    def test_extend_with_stylesheet(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            stylesheet="tool#Read { visible: false; }",
+        )
+        val = engine2.resolve(type="tool", id="Read", property="visible")
+        assert val == "false"
+
+
+class TestConvenience:
+    def test_check_true(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine.check(type="tool", id="Read", allow="true") is True
+
+    def test_check_false(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine.check(type="tool", id="Bash", allow="true") is False
+
+    def test_require_passes(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine.require(type="tool", id="Read", allow="true")  # should not raise
+
+    def test_require_raises_policy_denied(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        with pytest.raises(PolicyDenied) as exc_info:
+            engine.require(type="tool", id="Bash", allow="true")
+        assert exc_info.value.actual == "false"
+
+
+class TestTrace:
+    def test_trace_returns_candidates(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        result = engine.trace(type="tool", id="Bash", property="allow")
+        assert result.value is not None
+        assert len(result.candidates) >= 1
+
+
+class TestLint:
+    def test_lint_returns_list(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        warnings = engine.lint()
+        assert isinstance(warnings, list)
+
+
+class TestExecute:
+    def test_raw_sql(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        rows = engine.execute("SELECT COUNT(*) FROM entities")
+        assert rows[0][0] >= 3
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+pytest tests/policy/test_engine.py -v
+```
+
+- [ ] **Step 3: Implement PolicyEngine class**
+
+Replace `src/umwelt/policy/engine.py` with the full implementation:
+
+```python
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from umwelt.errors import PolicyCompilationError, PolicyDenied
+
+logger = logging.getLogger("umwelt.policy")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    value: str
+    specificity: str
+    rule_index: int
+    source_file: str
+    source_line: int
+    won: bool
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    entity: str
+    property: str
+    value: str | None
+    candidates: tuple[Candidate, ...]
+
+
+@dataclass(frozen=True)
+class LintWarning:
+    smell: str
+    severity: str
+    description: str
+    entities: tuple[str, ...]
+    property: str | None
+
+
+class PolicyEngine:
+    """Consumer-facing API for querying resolved world knowledge."""
+
+    def __init__(self) -> None:
+        self._con: sqlite3.Connection | None = None
+        self._pending_entities: list[dict[str, Any]] = []
+        self._pending_stylesheets: list[str] = []
+        self._compiled = False
+
+    @classmethod
+    def from_files(
+        cls,
+        *,
+        world: str | Path,
+        stylesheet: str | Path,
+    ) -> PolicyEngine:
+        """Build a PolicyEngine from source files."""
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import populate_from_world
+        from umwelt.compilers.sql.schema import create_schema
+        from umwelt.parser import parse
+        from umwelt.policy.projections import create_compilation_meta, create_projection_views
+        from umwelt.world.parser import load_world
+
+        world_path = Path(world)
+        stylesheet_path = Path(stylesheet)
+
+        try:
+            _load_default_vocabulary()
+        except Exception:
+            pass
+
+        world_file = load_world(world_path)
+
+        view = parse(stylesheet_path)
+
+        dialect = SQLiteDialect()
+        con = sqlite3.connect(":memory:")
+        con.executescript(create_schema(dialect))
+
+        populate_from_world(con, world_file)
+        compile_view(con, view, dialect, source_file=str(stylesheet_path))
+
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+        try:
+            create_compilation_meta(
+                con,
+                source_world=str(world_path),
+                source_stylesheet=str(stylesheet_path),
+            )
+        except Exception:
+            pass
+
+        engine = cls.__new__(cls)
+        engine._con = con
+        engine._pending_entities = []
+        engine._pending_stylesheets = []
+        engine._compiled = True
+
+        logger.info(
+            "compile",
+            extra={
+                "source_files": [str(world_path), str(stylesheet_path)],
+                "entity_count": con.execute("SELECT COUNT(*) FROM entities").fetchone()[0],
+            },
+        )
+        return engine
+
+    @classmethod
+    def from_db(cls, path: str | Path) -> PolicyEngine:
+        """Open a compiled database (copied into memory for COW safety)."""
+        source = sqlite3.connect(str(path))
+        con = sqlite3.connect(":memory:")
+        source.backup(con)
+        source.close()
+
+        engine = cls.__new__(cls)
+        engine._con = con
+        engine._pending_entities = []
+        engine._pending_stylesheets = []
+        engine._compiled = True
+        return engine
+
+    def add_entities(self, entities: list[dict[str, Any]]) -> None:
+        """Add entities for programmatic construction."""
+        self._pending_entities.extend(entities)
+        self._compiled = False
+
+    def add_stylesheet(self, css: str) -> None:
+        """Add CSS stylesheet text for programmatic construction."""
+        self._pending_stylesheets.append(css)
+        self._compiled = False
+
+    def register_vocabulary(self, registrar: Any) -> None:
+        """Register vocabulary via a callable (e.g., register_sandbox_vocabulary)."""
+        registrar()
+
+    def _ensure_compiled(self) -> sqlite3.Connection:
+        """Lazily compile on first query for programmatic construction."""
+        if self._con is not None and self._compiled:
+            return self._con
+
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import populate_from_world
+        from umwelt.compilers.sql.schema import create_schema
+        from umwelt.parser import parse as parse_css
+        from umwelt.policy.projections import create_projection_views
+        from umwelt.world.model import DeclaredEntity, WorldFile
+
+        dialect = SQLiteDialect()
+        con = self._con or sqlite3.connect(":memory:")
+        if not self._compiled:
+            con.executescript(create_schema(dialect))
+
+        if self._pending_entities:
+            declared = []
+            for e in self._pending_entities:
+                classes = tuple(e.get("classes", ()))
+                declared.append(DeclaredEntity(
+                    type=e["type"],
+                    id=e["id"],
+                    classes=classes,
+                    attributes=e.get("attributes", {}),
+                    parent=e.get("parent"),
+                ))
+            wf = WorldFile(entities=tuple(declared), projections=(), warnings=())
+            populate_from_world(con, wf)
+            self._pending_entities = []
+
+        for css_text in self._pending_stylesheets:
+            view = parse_css(css_text, validate=False)
+            compile_view(con, view, dialect)
+        self._pending_stylesheets = []
+
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+
+        self._con = con
+        self._compiled = True
+        return con
+
+    def resolve(
+        self,
+        *,
+        type: str,
+        id: str,
+        property: str | None = None,
+    ) -> str | dict[str, str] | None:
+        """Resolve properties for a single entity."""
+        from umwelt.policy.queries import resolve_entity
+
+        con = self._ensure_compiled()
+        result = resolve_entity(con, type=type, id=id, property=property)
+        logger.info(
+            "resolve",
+            extra={"entity": f"{type}#{id}", "property": property, "value": result},
+        )
+        return result
+
+    def resolve_all(self, *, type: str) -> list[dict]:
+        """Resolve all entities of a type with their properties."""
+        from umwelt.policy.queries import resolve_all_entities
+
+        con = self._ensure_compiled()
+        results = resolve_all_entities(con, type=type)
+        logger.info(
+            "resolve_all",
+            extra={"type": type, "result_count": len(results)},
+        )
+        return results
+
+    def trace(
+        self,
+        *,
+        type: str,
+        id: str,
+        property: str,
+    ) -> TraceResult:
+        """Trace all cascade candidates for an (entity, property) pair."""
+        from umwelt.policy.queries import trace_entity
+
+        con = self._ensure_compiled()
+        result = trace_entity(con, type=type, id=id, property=property)
+        logger.debug(
+            "trace",
+            extra={"entity": f"{type}#{id}", "property": property, "candidates": len(result.candidates)},
+        )
+        return result
+
+    def lint(self) -> list[LintWarning]:
+        """Run lint analysis on the compiled database."""
+        from umwelt.policy.lint import run_lint
+
+        con = self._ensure_compiled()
+        return run_lint(con)
+
+    def check(self, *, type: str, id: str, **expected: str) -> bool:
+        """Check whether resolved properties match expected values."""
+        for prop_name, expected_val in expected.items():
+            actual = self.resolve(type=type, id=id, property=prop_name)
+            if actual != expected_val:
+                return False
+        return True
+
+    def require(self, *, type: str, id: str, **expected: str) -> None:
+        """Raise PolicyDenied if resolved properties don't match."""
+        for prop_name, expected_val in expected.items():
+            actual = self.resolve(type=type, id=id, property=prop_name)
+            if actual != expected_val:
+                logger.warning(
+                    "require_denied",
+                    extra={"entity": f"{type}#{id}", "property": prop_name, "expected": expected_val, "actual": actual},
+                )
+                raise PolicyDenied(
+                    entity=f"{type}#{id}",
+                    property=prop_name,
+                    expected=expected_val,
+                    actual=actual or "(none)",
+                )
+
+    def extend(
+        self,
+        *,
+        entities: list[dict[str, Any]] | None = None,
+        stylesheet: str | None = None,
+    ) -> PolicyEngine:
+        """Create a new engine with additional entities and/or stylesheet rules."""
+        con = self._ensure_compiled()
+
+        new_con = sqlite3.connect(":memory:")
+        con.backup(new_con)
+
+        new_engine = PolicyEngine.__new__(PolicyEngine)
+        new_engine._con = new_con
+        new_engine._pending_entities = list(entities) if entities else []
+        new_engine._pending_stylesheets = [stylesheet] if stylesheet else []
+        new_engine._compiled = False
+
+        if new_engine._pending_entities or new_engine._pending_stylesheets:
+            new_engine._recompile_incremental()
+
+        logger.info(
+            "extend",
+            extra={
+                "entities_added": len(entities) if entities else 0,
+                "stylesheet_added": bool(stylesheet),
+            },
+        )
+        return new_engine
+
+    def _recompile_incremental(self) -> None:
+        """Recompile after extend — add new entities/rules to existing DB."""
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import _rebuild_closure, populate_from_world
+        from umwelt.compilers.sql.resolution import create_resolution_views
+        from umwelt.parser import parse as parse_css
+        from umwelt.policy.projections import create_projection_views
+        from umwelt.world.model import DeclaredEntity, WorldFile
+
+        con = self._con
+        dialect = SQLiteDialect()
+
+        if self._pending_entities:
+            declared = []
+            for e in self._pending_entities:
+                classes = tuple(e.get("classes", ()))
+                declared.append(DeclaredEntity(
+                    type=e["type"],
+                    id=e["id"],
+                    classes=classes,
+                    attributes=e.get("attributes", {}),
+                    parent=e.get("parent"),
+                ))
+            wf = WorldFile(entities=tuple(declared), projections=(), warnings=())
+            populate_from_world(con, wf)
+            self._pending_entities = []
+
+        # Drop and recreate resolution views before adding new rules
+        for view_name in ("resolved_properties", "_resolved_exact", "_resolved_cap", "_resolved_pattern"):
+            con.execute(f"DROP VIEW IF EXISTS {view_name}")
+
+        for css_text in self._pending_stylesheets:
+            view = parse_css(css_text, validate=False)
+            compile_view(con, view, dialect)
+        self._pending_stylesheets = []
+
+        if not self._pending_stylesheets:
+            # Resolution views were recreated by compile_view if we had stylesheets.
+            # If we only added entities (no new stylesheet), recreate them now.
+            try:
+                con.execute("SELECT 1 FROM resolved_properties LIMIT 1")
+            except sqlite3.OperationalError:
+                create_resolution_views(con, dialect)
+
+        # Recreate projection views
+        for view_name in ("resolved_entities", "tools", "modes"):
+            con.execute(f"DROP VIEW IF EXISTS {view_name}")
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+
+        self._compiled = True
+
+    def save(self, path: str | Path) -> None:
+        """Save the compiled database to a file."""
+        con = self._ensure_compiled()
+        target = sqlite3.connect(str(path))
+        con.backup(target)
+        target.close()
+
+    def to_files(
+        self,
+        *,
+        world: str | Path,
+        stylesheet: str | Path,
+    ) -> None:
+        """Export the engine state back to source files (best-effort round-trip)."""
+        con = self._ensure_compiled()
+
+        # Export entities as world YAML
+        entities = con.execute(
+            "SELECT type_name, entity_id, classes, attributes FROM entities ORDER BY type_name, entity_id"
+        ).fetchall()
+
+        import json
+
+        import yaml
+
+        entity_dicts = []
+        for type_name, entity_id, classes_json, attrs_json in entities:
+            d: dict[str, Any] = {"type": type_name, "id": entity_id}
+            if classes_json:
+                classes = json.loads(classes_json)
+                if classes:
+                    d["classes"] = classes
+            if attrs_json:
+                attrs = json.loads(attrs_json)
+                if attrs:
+                    d["attributes"] = attrs
+            entity_dicts.append(d)
+
+        world_data = {"entities": entity_dicts}
+        Path(world).write_text(yaml.dump(world_data, default_flow_style=False, sort_keys=False))
+
+        # Export cascade candidates as CSS (best-effort)
+        rules = con.execute(
+            "SELECT DISTINCT source_file, source_line FROM cascade_candidates "
+            "WHERE source_file IS NOT NULL AND source_file != '' "
+            "ORDER BY source_file, source_line"
+        ).fetchall()
+
+        css_lines: list[str] = []
+        seen_rules: set[tuple] = set()
+        candidates = con.execute(
+            "SELECT cc.entity_id, e.type_name, e.entity_id, e.classes, "
+            "cc.property_name, cc.property_value, cc.source_file, cc.source_line "
+            "FROM cascade_candidates cc "
+            "JOIN entities e ON cc.entity_id = e.id "
+            "ORDER BY cc.source_file, cc.source_line, cc.rule_index"
+        ).fetchall()
+
+        current_rule: tuple | None = None
+        current_decls: list[str] = []
+        current_selector: str = ""
+
+        for eid, type_name, entity_id_str, classes_json, prop_name, prop_value, src_file, src_line in candidates:
+            rule_key = (src_file, src_line)
+            selector = type_name
+            if entity_id_str:
+                selector += f"#{entity_id_str}"
+
+            if rule_key != current_rule:
+                if current_rule is not None and current_decls:
+                    css_lines.append(f"{current_selector} {{ {'; '.join(current_decls)}; }}")
+                current_rule = rule_key
+                current_selector = selector
+                current_decls = []
+
+            decl = f"{prop_name}: {prop_value}"
+            if decl not in current_decls:
+                current_decls.append(decl)
+
+        if current_rule is not None and current_decls:
+            css_lines.append(f"{current_selector} {{ {'; '.join(current_decls)}; }}")
+
+        Path(stylesheet).write_text("\n".join(css_lines) + "\n")
+
+    def execute(self, sql: str, params: tuple = ()) -> list[tuple]:
+        """Execute raw SQL against the compiled database."""
+        con = self._ensure_compiled()
+        return con.execute(sql, params).fetchall()
+
+
+def _load_default_vocabulary() -> None:
+    """Auto-load the sandbox vocabulary if available."""
+    try:
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+        register_sandbox_vocabulary()
+    except ImportError:
+        pass
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+pytest tests/policy/test_engine.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/umwelt/policy/engine.py tests/policy/test_engine.py
+git commit -m "feat(policy): PolicyEngine class — constructors, queries, COW extend, save/export"
+```
+
+---
+
+### Task 7: Update `__init__.py` public API
+
+**Files:**
+- Modify: `src/umwelt/policy/__init__.py`
+
+- [ ] **Step 1: Update exports**
+
+```python
+# src/umwelt/policy/__init__.py
+from umwelt.policy.engine import Candidate, LintWarning, PolicyEngine, TraceResult
+
+__all__ = [
+    "Candidate",
+    "LintWarning",
+    "PolicyEngine",
+    "TraceResult",
+]
+```
+
+- [ ] **Step 2: Verify import works**
+
+```bash
+python -c "from umwelt.policy import PolicyEngine, LintWarning, TraceResult, Candidate; print('OK')"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/umwelt/policy/__init__.py
+git commit -m "feat(policy): public API exports"
+```
+
+---
+
+### Task 8: Integration test
+
+**Files:**
+- Create: `tests/policy/test_integration.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+# tests/policy/test_integration.py
+import yaml
+from pathlib import Path
+
+from umwelt.errors import PolicyDenied
+from umwelt.policy import PolicyEngine
+
+
+def test_full_pipeline(tmp_path):
+    """End-to-end: from_files → resolve → trace → lint → save → from_db → resolve."""
+    world_path = tmp_path / "delegate.world.yml"
+    world_path.write_text("""
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Edit
+    classes: [edit]
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell]
+  - type: mode
+    id: implement
+""")
+    style_path = tmp_path / "policy.umw"
+    style_path.write_text("""
+tool { allow: true; max-level: 5; }
+tool.dangerous { max-level: 3; allow: false; }
+tool#Bash { risk-note: Prefer structured tools; }
+mode { allow: true; }
+""")
+
+    # Build from files
+    engine = PolicyEngine.from_files(world=world_path, stylesheet=style_path)
+
+    # Resolve
+    assert engine.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine.resolve(type="tool", id="Bash", property="allow") == "false"
+    assert engine.resolve(type="tool", id="Bash", property="max-level") == "3"
+
+    bash_props = engine.resolve(type="tool", id="Bash")
+    assert isinstance(bash_props, dict)
+    assert "risk-note" in bash_props
+
+    # Resolve all
+    tools = engine.resolve_all(type="tool")
+    assert len(tools) == 3
+
+    # Trace
+    trace = engine.trace(type="tool", id="Bash", property="allow")
+    assert trace.value == "false"
+    assert len(trace.candidates) >= 2
+
+    # Lint
+    warnings = engine.lint()
+    assert isinstance(warnings, list)
+
+    # Check / require
+    assert engine.check(type="tool", id="Read", allow="true") is True
+    assert engine.check(type="tool", id="Bash", allow="true") is False
+
+    import pytest
+    with pytest.raises(PolicyDenied):
+        engine.require(type="tool", id="Bash", allow="true")
+
+    # Save and reload
+    db_path = tmp_path / "policy.db"
+    engine.save(str(db_path))
+    assert db_path.exists()
+
+    engine2 = PolicyEngine.from_db(str(db_path))
+    assert engine2.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine2.resolve(type="tool", id="Bash", property="allow") == "false"
+
+    # Raw SQL
+    rows = engine2.execute("SELECT COUNT(*) FROM entities")
+    assert rows[0][0] >= 4
+
+
+def test_extend_cow_semantics(tmp_path):
+    """Extend produces a new engine; original is unchanged."""
+    world_path = tmp_path / "w.world.yml"
+    world_path.write_text("entities:\n  - type: tool\n    id: Read\n")
+    style_path = tmp_path / "p.umw"
+    style_path.write_text("tool { allow: true; }\n")
+
+    engine1 = PolicyEngine.from_files(world=world_path, stylesheet=style_path)
+    engine2 = engine1.extend(
+        entities=[{"type": "tool", "id": "Bash", "classes": ["dangerous"]}],
+        stylesheet="tool.dangerous { allow: false; }",
+    )
+
+    # Original unchanged
+    tools1 = engine1.resolve_all(type="tool")
+    assert len(tools1) == 1
+
+    # Extended has both
+    tools2 = engine2.resolve_all(type="tool")
+    assert len(tools2) == 2
+    assert engine2.resolve(type="tool", id="Bash", property="allow") == "false"
+
+
+def test_programmatic_construction():
+    """Build engine entirely in code."""
+    engine = PolicyEngine()
+    engine.add_entities([
+        {"type": "tool", "id": "Read"},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    engine.add_stylesheet("tool { allow: true; }\ntool.dangerous { allow: false; }")
+
+    assert engine.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine.resolve(type="tool", id="Bash", property="allow") == "false"
+
+
+def test_to_files_roundtrip(tmp_path):
+    """Export to files and verify they contain expected data."""
+    engine = PolicyEngine()
+    engine.add_entities([
+        {"type": "tool", "id": "Read"},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    engine.add_stylesheet("tool { allow: true; }")
+
+    world_out = tmp_path / "out.world.yml"
+    style_out = tmp_path / "out.umw"
+    engine.to_files(world=world_out, stylesheet=style_out)
+
+    assert world_out.exists()
+    assert style_out.exists()
+
+    world_data = yaml.safe_load(world_out.read_text())
+    assert len(world_data["entities"]) >= 2
+    ids = {e["id"] for e in world_data["entities"]}
+    assert "Read" in ids
+    assert "Bash" in ids
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+pytest tests/policy/test_integration.py -v
+```
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+```bash
+pytest tests/ -v
+```
+
+- [ ] **Step 4: Run lint**
+
+```bash
+ruff check src/umwelt/policy/ tests/policy/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/policy/test_integration.py
+git commit -m "feat(policy): integration tests for full PolicyEngine pipeline"
+```
+
+---
+
+## Verification
+
+After all tasks:
+
+1. **Unit tests pass:** `pytest tests/policy/ -v` — all green
+2. **Full suite passes:** `pytest tests/ -v` — no regressions in `compilers/sql/`, `world/`, etc.
+3. **Lint passes:** `ruff check src/umwelt/policy/ tests/policy/`
+4. **Python API works:**
+   ```python
+   from umwelt.policy import PolicyEngine
+
+   # Programmatic
+   engine = PolicyEngine()
+   engine.add_entities([{"type": "tool", "id": "Read"}, {"type": "tool", "id": "Bash", "classes": ["dangerous"]}])
+   engine.add_stylesheet("tool { allow: true; }\ntool.dangerous { allow: false; }")
+   print(engine.resolve(type="tool", id="Read", property="allow"))  # "true"
+   print(engine.resolve(type="tool", id="Bash", property="allow"))  # "false"
+   print(engine.trace(type="tool", id="Bash", property="allow"))
+   print(engine.lint())
+
+   # From files
+   engine2 = PolicyEngine.from_files(world="delegate.world.yml", stylesheet="policy.umw")
+   engine2.save("policy.db")
+
+   # From compiled DB
+   engine3 = PolicyEngine.from_db("policy.db")
+   print(engine3.resolve_all(type="tool"))
+
+   # COW extend
+   engine4 = engine3.extend(entities=[{"type": "mode", "id": "review"}])
+   ```
+5. **Compiled DB is self-contained:**
+   ```bash
+   sqlite3 policy.db "SELECT * FROM tools"
+   sqlite3 policy.db "SELECT * FROM resolved_entities"
+   sqlite3 policy.db "SELECT * FROM compilation_meta"
+   ```

--- a/docs/superpowers/specs/2026-04-20-policy-engine-design.md
+++ b/docs/superpowers/specs/2026-04-20-policy-engine-design.md
@@ -1,0 +1,610 @@
+# PolicyEngine Design — Knowledge Query API + SQL Compiler Extensions
+
+*Extends umwelt's existing `compilers/sql/` module with a consumer-facing Python API (`umwelt.policy`) for querying resolved world knowledge, adds typed projection views, lint analysis, structured logging for audit, and integrates world file entity population. Replaces the standalone ducklog package.*
+
+**Status:** draft, pre-implementation.
+**Date:** 2026-04-20.
+**Depends on:** `compilers/sql/` (merged, PR #4), `world/` layer (merged, PR #7), `docs/vision/world-state.md`.
+**Prerequisite:** Phase 1 world state layer complete (YAML parser, materializer, validator, CLI).
+**Next step after approval:** invoke `writing-plans` to produce a concrete implementation plan.
+
+---
+
+## 1. Motivation and scope
+
+Umwelt's SQL compiler (`compilers/sql/`) already compiles CSS selectors to SQL WHERE clauses, populates entities from matchers, and resolves cascade properties in SQLite. But there is no consumer-facing API — the only way to read results is via CLI output or raw SQL queries against the compiled database.
+
+Meanwhile, ducklog exists as a separate package doing largely the same compilation for DuckDB, plus consumer packages for Kibitzer and Lackpy that translate SQL views into tool-specific config dicts. This duplication is unnecessary now that umwelt has its own SQL compiler.
+
+This design introduces:
+
+1. **`umwelt.policy.PolicyEngine`** — the consumer-facing Python API. Wraps a compiled SQLite database. Provides knowledge queries (resolve entity properties), trace (explain why a value won), and lint (detect knowledge quality issues).
+2. **Typed projection views** — vocabulary-driven SQL views (tools, files, modes, kibitzer_modes) embedded in the compiled database, making it self-contained and queryable without Python.
+3. **World file entity population** — entities from `.world.yml` files feed into the SQL database alongside matcher-discovered entities.
+4. **Structured logging** — audit observability via stdlib `logging`, not a custom audit module. Consumers attach handlers.
+5. **Lint analysis** — Python module that detects fragile or surprising cascade resolutions.
+
+### Deliverables
+
+1. **`umwelt.policy` subpackage** (§3) — PolicyEngine class with three constructors, knowledge query methods, COW extend semantics.
+2. **Knowledge query model** (§4) — entity path queries, bulk resolution, trace.
+3. **Typed projection views** (§5) — vocabulary-driven pivot views in the compiled database.
+4. **Lint module** (§6) — smell detection over cascade_candidates.
+5. **World file population path** (§7) — DeclaredEntity → entities table.
+6. **Observability** (§8) — structured logging via `umwelt.policy` logger.
+7. **Compilation pipeline** (§9) — three paths into a PolicyEngine.
+8. **Round-trip** (§10) — `to_files()` for exporting back to source format.
+
+### Explicit non-goals
+
+- **Generator plugin protocol.** The three-tier generator protocol (enumerate/define_query/query) is a future design. This spec builds the infrastructure generators will plug into, but does not define the plugin interface.
+- **Full ancestor/depth vocabulary extension.** The ancestor/depth model for entity hierarchy (§11) is documented here as a design direction. Implementation is deferred — the existing parent_id/entity_closure mechanism continues to work.
+- **CSS selector parsing at query time.** CSS is the authoring language for policy. The SQL engine evaluates compiled selectors. The PolicyEngine accepts CSS selector strings as a convenience (parsed in Python, compiled to structured queries), but no CSS parsing happens in SQL.
+- **DuckDB parity.** SQLite is the default and primary target. DuckDB support continues via the dialect abstraction but is not extended in this spec.
+- **Kibitzer/Lackpy adapter packages.** Those live in each tool's repo. This spec defines the API they consume, not their adapters.
+
+---
+
+## 2. Architecture
+
+### Layering
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Consumers: Kibitzer, Lackpy, CLI, custom tools             │
+│  (import umwelt.policy or query .db directly with SQL)      │
+└──────────────────────────┬─────────��────────────────────────┘
+                           │
+┌──────────────────────────▼──────────────��─────────────────���─┐
+│  umwelt.policy  (this spec)                                  │
+│  PolicyEngine: constructors, resolve, trace, lint, extend    │
+│  Structured logging via stdlib logging                       │
+└──────────────────────────┬─────────────────────────────────���┘
+                           │
+┌──────────────────────────▼──────��──────────────────���────────┐
+│  umwelt.compilers.sql  (existing, unchanged)                 │
+│  Schema DDL, selector→SQL, entity population, resolution     │
+│  Dialect abstraction (SQLite, DuckDB)                        │
+└─────────────��────────────┬──────��───────────────────────────┘
+                           │
+┌──────���───────────────────▼─────���────────────────────────────┐
+│  SQLite database                                             │
+│  entities, cascade_candidates, resolved_properties,          │
+│  typed projection views                                      │
+└──────────────��────────────────────────────────────────���─────┘
+```
+
+### Key boundaries
+
+| Component | Responsibility | Depends on |
+|---|---|---|
+| `compilers/sql/` | CSS → SQL compilation, schema DDL, entity population, resolution views | `ast`, `selector`, `registry` |
+| `policy/engine.py` | Lifecycle management, COW semantics, query dispatch | `compilers/sql/`, `world/` |
+| `policy/queries.py` | Structured entity/resolution queries → SQL | `sqlite3` only |
+| `policy/lint.py` | Smell detection over cascade_candidates | `sqlite3`, `json` |
+| `policy/projections.py` | Vocabulary-driven typed projection view DDL | `compilers/sql/dialects` |
+
+### File layout
+
+```
+src/umwelt/policy/
+├── __init__.py          # Public API: PolicyEngine, LintWarning
+├── engine.py            # PolicyEngine class
+├── queries.py           # Structured query builders
+├── lint.py              # Cascade smell detection
+└── projections.py       # Typed projection view DDL generation
+```
+
+### What stays in `compilers/sql/`
+
+Everything that exists today — schema, selector compilation, dialect abstraction, entity population, resolution views. No changes needed. The `policy/` package is a layer on top.
+
+---
+
+## 3. PolicyEngine class
+
+### Constructors
+
+**From source files (author time):**
+
+```python
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+```
+
+Pipeline: parse world YAML → register vocabulary → populate entities → parse CSS → compile selectors to cascade_candidates → create resolution views → create projection views → ready to query.
+
+**From compiled database (consumer time):**
+
+```python
+engine = PolicyEngine.from_db("policy.db")
+```
+
+Opens existing compiled database. The database is copied into memory on open (COW safety — the source file is never modified). No compilation needed. Immediate query access. For v1, all engines operate on in-memory SQLite databases; large-database support (memory-mapped or file-backed COW) is a future optimization.
+
+**Programmatic (runtime):**
+
+```python
+engine = PolicyEngine()
+engine.register_vocabulary(register_sandbox_vocabulary)
+engine.add_entities([
+    {"type": "tool", "id": "Read"},
+    {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    {"type": "mode", "id": "implement"},
+])
+engine.add_stylesheet("tool.dangerous { max-level: 2; }")
+```
+
+### COW extend
+
+Mutations produce a new engine. The original is unchanged.
+
+```python
+engine2 = engine.extend(
+    entities=[{"type": "mode", "id": "review"}],
+    stylesheet='mode#review tool.dangerous { allow: false; }',
+)
+# engine is unchanged — engine2 has the new state
+```
+
+Implementation: `extend()` copies the SQLite database (in-memory or to a temp file), applies mutations to the copy, recompiles cascade_candidates and resolution views, returns a new PolicyEngine wrapping the copy.
+
+### Save and export
+
+```python
+# Save compiled database
+engine.save("policy.db")
+
+# Export back to source files
+engine.to_files(world="delegate.world.yml", stylesheet="policy.umw")
+```
+
+### Raw SQL escape hatch
+
+```python
+# Direct database access for custom queries
+rows = engine.execute("SELECT * FROM resolved_properties WHERE property_name = 'allow'")
+```
+
+The compiled database is always accessible. The convenience methods handle the common cases; raw SQL handles everything else.
+
+---
+
+## 4. Knowledge query model
+
+**Core principle: the engine resolves knowledge. Consumers interpret values and decide what to enforce.**
+
+The cascade doesn't just resolve allow/deny — it resolves any property to any value. Permission properties (`allow`, `editable`), constraints (`max-level`, `limit`), behavioral guidance (`strategy`, `risk-note`), and informational metadata (`description`, `convention`) all resolve the same way through the CSS cascade.
+
+A consumer asking `engine.resolve('tool#Bash', "risk-note")` gets back `"Prefer structured tools"` — that is knowledge, not enforcement. The consumer decides what to do with it.
+
+### Query as entity path
+
+A query describes a position in the entity hierarchy — a path from ancestor to target entity. The engine resolves properties at the deepest matching entity.
+
+**CSS selector string (parsed in Python):**
+
+```python
+engine.resolve('file[path="src/foo.py"] ast .fn#special', "editable")
+```
+
+**Structured path (list of dicts — what gets sent to SQL):**
+
+```python
+engine.resolve([
+    {"type": "file", "attributes": {"path": "src/foo.py"}},
+    {"type": "ast"},
+    {"classes": ["fn"], "id": "special"}
+], "editable")
+```
+
+**Simple case — type + id:**
+
+```python
+engine.resolve(type="tool", id="Bash", property="max-level")
+```
+
+All three forms are equivalent. The CSS string is parsed in Python and converted to the structured path, which is compiled to a SQL query with entity_closure JOINs.
+
+### API methods
+
+**resolve — single entity, single or all properties:**
+
+```python
+# Single property
+engine.resolve('tool#Bash', "max-level")  # → "3"
+
+# All properties for an entity
+engine.resolve('tool#Bash')
+# → {"allow": "true", "max-level": "3", "effects-ceiling": "filesystem",
+#     "description": "Shell execution", "risk-note": "Prefer structured tools"}
+```
+
+**resolve_all — bulk query:**
+
+```python
+# All entities of a type with resolved properties
+engine.resolve_all(type="tool")
+# → [{"entity": {...}, "properties": {"allow": "true", ...}}, ...]
+
+# With structured filters
+engine.resolve_all(type="file", attributes={"path": ("^=", "src/")})
+```
+
+**trace — explain a resolution:**
+
+```python
+result = engine.trace('tool#Bash', "max-level")
+# result.value = "3"
+# result.candidates = [
+#   Candidate(value="5", rule="tool { max-level: 5; }", specificity=(...), won=False),
+#   Candidate(value="3", rule="tool#Bash { max-level: 3; }", specificity=(...), won=True),
+# ]
+```
+
+Trace reads from `cascade_candidates` (the pre-aggregation table) rather than `resolved_properties` (the post-aggregation view). This shows all competing rules, not just the winner.
+
+### Convenience methods for common consumer patterns
+
+```python
+# Check — returns True/False for a specific expected value
+engine.check('file[path="src/foo.py"]', editable=True)  # → False
+
+# Require — raises PolicyDenied if check fails
+engine.require('file[path="src/foo.py"]', editable=True)
+# → raises PolicyDenied(entity=..., property="editable", expected="true", actual="false", trace=[...])
+```
+
+These are thin wrappers over `resolve()`. The engine provides them as conveniences; consumers can also implement their own enforcement logic using `resolve()` directly.
+
+### Consumer enforcement examples
+
+```python
+# Kibitzer — reads knowledge, enforces in its path guard
+props = engine.resolve('file[path="src/foo.py"]')
+if props.get("editable") == "false":
+    deny_write(reason="policy says not editable")
+
+# Lackpy — reads constraints, caps its own grade
+max_level = int(engine.resolve('tool#Bash', "max-level") or "5")
+toolspec.grade_w = min(toolspec.grade_w, max_level)
+
+# Kibitzer coach — reads guidance, surfaces to agent
+note = engine.resolve('tool#Bash', "risk-note")
+if note:
+    suggest(f"Consider: {note}")
+```
+
+---
+
+## 5. Typed projection views
+
+Consumer-friendly SQL views created at compile time and embedded in the database. These make the compiled database self-contained — any SQLite client can query `SELECT * FROM tools` without importing umwelt.
+
+### Vocabulary-driven generation
+
+Projection views are generated from the registered property schemas. When a vocabulary defines properties for entity type `tool`, the compiler generates:
+
+```sql
+CREATE VIEW tools AS
+SELECT e.id, e.entity_id AS name, e.classes, e.attributes,
+    MAX(CASE WHEN rp.property_name = 'allow' THEN rp.property_value END) AS allow,
+    MAX(CASE WHEN rp.property_name = 'visible' THEN rp.property_value END) AS visible,
+    MAX(CASE WHEN rp.property_name = 'max-level' THEN rp.property_value END) AS max_level,
+    MAX(CASE WHEN rp.property_name = 'allow-pattern' THEN rp.property_value END) AS allow_pattern,
+    MAX(CASE WHEN rp.property_name = 'deny-pattern' THEN rp.property_value END) AS deny_pattern
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+WHERE e.type_name = 'tool'
+GROUP BY e.id, e.entity_id, e.classes, e.attributes;
+```
+
+Similarly for `files`, `modes`, `resources`. The column list comes from the property_types table — each registered property becomes a pivoted column.
+
+Custom vocabularies get custom views. A plugin that registers entity type `ast` with properties `complexity` and `test-coverage` would get a `CREATE VIEW ast_entities AS ...` with those columns.
+
+### Consumer-specific views
+
+Views tailored to specific consumers, also vocabulary-driven:
+
+```sql
+-- Kibitzer: mode definitions with writable paths and strategy
+CREATE VIEW kibitzer_modes AS
+SELECT e.entity_id AS mode_name,
+    MAX(CASE WHEN rp.property_name = 'writable' THEN rp.property_value END) AS writable,
+    MAX(CASE WHEN rp.property_name = 'strategy' THEN rp.property_value END) AS strategy
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+WHERE e.type_name = 'mode'
+GROUP BY e.entity_id;
+```
+
+These can be registered by consumers via the vocabulary system or generated from a projection schema. The compiled database includes all registered projection views.
+
+### Generic resolved_entities view
+
+For consumers that want all entities with all resolved properties as a single map:
+
+```sql
+CREATE VIEW resolved_entities AS
+SELECT e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes,
+    json_group_object(rp.property_name, rp.property_value) AS properties
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+GROUP BY e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes;
+```
+
+### Compilation metadata
+
+```sql
+CREATE TABLE compilation_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+-- Populated at compile time:
+-- umwelt_version, compiled_at, source_world, source_stylesheet,
+-- entity_count, resolved_count, dialect
+```
+
+---
+
+## 6. Lint analysis
+
+Lint detects knowledge quality issues by analyzing cascade_candidates and resolved_properties. It runs in Python, not SQL — it needs to compare candidates across entities and detect patterns.
+
+### API
+
+```python
+warnings = engine.lint()
+# �� list[LintWarning]
+```
+
+Each `LintWarning` has: `type` (string), `severity` ("info" | "warning"), `description` (human-readable), `entities` (affected entity IDs), `candidates` (relevant cascade_candidates rows).
+
+### Smell catalog
+
+| Smell | Detection | Severity |
+|---|---|---|
+| **narrow_win** | Winner's specificity minus runner-up's specificity ≤ 1 position | warning |
+| **shadowed_rule** | A (source_file, source_line) pair appears in cascade_candidates but never appears in resolved_properties | info |
+| **conflicting_intent** | Two candidates for same (entity, property) have opposite values (e.g., "true" vs "false") and the winner won by source order alone (equal specificity) | warning |
+| **uncovered_entity** | Entity exists in entities table but has zero rows in resolved_properties | info |
+| **specificity_escalation** | 3+ candidates for same (entity, property) with strictly increasing specificity | warning |
+
+### Implementation
+
+`policy/lint.py` queries cascade_candidates and resolved_properties, joins them, and applies each smell detector. Results are returned as `LintWarning` objects and also emitted as log events at WARNING level via the `umwelt.policy` logger.
+
+---
+
+## 7. World file entity population
+
+The existing `compilers/sql/populate.py` populates entities from registered matchers. This spec adds a parallel path: entities from parsed `.world.yml` files.
+
+### DeclaredEntity → entities table
+
+A `DeclaredEntity` from the world layer maps directly to an entities row:
+
+| DeclaredEntity field | entities column | Notes |
+|---|---|---|
+| `type` | `type_name` | Direct mapping |
+| `id` | `entity_id` | Direct mapping |
+| `classes` | `classes` | Tuple → JSON array |
+| `attributes` | `attributes` | Dict �� JSON object |
+| `parent` | `parent_id` | Resolved via entity_id lookup |
+| `provenance` | (metadata) | Stored in compilation_meta or a provenance column |
+
+### Population function
+
+```python
+def populate_from_world(con: sqlite3.Connection, world: WorldFile) -> None:
+    """Insert DeclaredEntity instances from a WorldFile into the entities table."""
+```
+
+Called during `PolicyEngine.from_files()` after `populate_entities()` (matcher population). World file entities and matcher entities coexist — if both sources produce the same (type, id) entity, the world file version wins (explicit > discovered, per the world layer's merge semantics).
+
+### Projection population
+
+Projections from the world file (`Projection` instances) are inserted as entities with `provenance=PROJECTED`. They participate in cascade resolution like any other entity.
+
+---
+
+## 8. Observability
+
+The engine emits structured log events via Python's stdlib `logging` module. No custom audit module. Consumers attach handlers to capture what they need.
+
+### Logger
+
+```python
+logger = logging.getLogger("umwelt.policy")
+```
+
+### Events
+
+| Event | Level | Extra data |
+|---|---|---|
+| `resolve` | INFO | entity_path, property, resolved_value |
+| `resolve_all` | INFO | type, filter, result_count |
+| `extend` | INFO | entities_added, stylesheet_added |
+| `trace` | DEBUG | entity_path, property, all candidates |
+| `lint_warning` | WARNING | warning_type, entities, description |
+| `compile` | INFO | source_files, entity_count, resolved_count |
+| `require_denied` | WARNING | entity_path, property, expected, actual |
+
+### Consumer handler examples
+
+```python
+# Kibitzer routes to its existing event store
+handler = KibitzerStoreHandler(store)
+logging.getLogger("umwelt.policy").addHandler(handler)
+
+# CLI user writes to a file
+logging.getLogger("umwelt.policy").addHandler(logging.FileHandler("audit.log"))
+
+# No handler attached = no logging overhead
+```
+
+Consumers who want structured audit trails write a handler that captures the `extra` dict from log records. Consumers who do not care attach nothing — zero overhead.
+
+---
+
+## 9. Compilation pipeline
+
+### Three paths, one database format
+
+All three constructors produce the same SQLite database schema. The database is the universal interchange format.
+
+**Path 1: from_files (author time)**
+
+```
+.world.yml + .umw
+    ↓ parse world YAML
+    ↓ register vocabulary
+    ↓ create schema DDL
+    ↓ populate entities (matchers + world file)
+    ↓ parse CSS
+    ↓ compile selectors → cascade_candidates
+    ↓ create resolution views
+    ↓ create projection views
+    ↓ create compilation_meta
+    ↓
+PolicyEngine (wrapping in-memory SQLite)
+```
+
+**Path 2: from_db (consumer time)**
+
+```
+policy.db
+    ↓ copy to in-memory SQLite (COW)
+    ↓
+PolicyEngine (wrapping in-memory copy)
+```
+
+**Path 3: programmatic (runtime)**
+
+```
+PolicyEngine()
+    ↓ register_vocabulary()
+    ↓ add_entities()
+    �� add_stylesheet()
+    ↓ (internally: compile on first query)
+    ���
+PolicyEngine (wrapping in-memory SQLite)
+```
+
+### Saving
+
+```python
+engine.save("policy.db")
+```
+
+Writes the in-memory database to a file. This is the "reference database" — the frozen, portable artifact. Any SQLite client can read it.
+
+### The compiled database is self-contained
+
+The saved `.db` file contains everything a consumer needs:
+
+- `entities` — all entities with type, id, classes, attributes
+- `entity_closure` — ancestor/descendant hierarchy
+- `cascade_candidates` — all selector matches with specificity
+- `resolved_properties` — winning value per (entity, property)
+- Typed projection views — `tools`, `files`, `modes`, etc.
+- `compilation_meta` — provenance (source files, timestamps, version)
+
+A consumer can `sqlite3 policy.db "SELECT * FROM tools"` with no Python, no umwelt, no dependencies.
+
+---
+
+## 10. Round-trip: to_files()
+
+The PolicyEngine can export its current state back to source files:
+
+```python
+engine.to_files(world="delegate.world.yml", stylesheet="policy.umw")
+```
+
+This produces:
+- A `.world.yml` file with entities serialized as YAML (using shorthand syntax where applicable)
+- A `.umw` file with the CSS policy declarations
+
+This is useful for:
+- Debugging ("show me what this engine actually contains")
+- Migration ("I built this programmatically, now I want to version-control it")
+- Diffing ("what changed between two snapshots?" — diff the YAML/CSS, not the SQL)
+
+The round-trip is best-effort — programmatically constructed engines may not produce the same CSS that was originally authored. Entity ordering, selector formatting, and shorthand expansion may differ. The semantic content is preserved.
+
+---
+
+## 11. Future: ancestor/depth entity hierarchy
+
+*This section documents a design direction. Implementation is deferred.*
+
+The current entity hierarchy uses `parent_id` on the entities table and `entity_closure` for transitive ancestry. Parent relationships are set by matchers (filesystem convention: file's parent is its containing directory).
+
+A more general model would let entity types declare their position in the hierarchy via vocabulary definitions:
+
+```css
+@entity mode {
+    ancestor: world;
+    depth: 1;           /* direct child of world — scopes everything below */
+}
+
+@entity system {
+    ancestor: world;
+    depth: 5;           /* default — peers with other high-level types */
+}
+
+@entity file {
+    ancestor: system;
+    depth: 5;           /* files live inside systems */
+}
+
+@entity ast {
+    ancestor: file;
+    depth: 5;           /* AST nodes live inside files */
+}
+```
+
+Key properties:
+- **ancestor** declares which entity type this type nests under (not necessarily direct parent).
+- **depth** is relative to the ancestor — lower numbers are closer to the ancestor. Default depth (e.g., 5) leaves room for other types to be inserted between.
+- A depth of 1 means tight coupling — nothing can be inserted between this type and its ancestor.
+- The depth gap enables pluggable hierarchies — a new entity type can slot in at depth 3 between two types at depths 1 and 5 without restructuring.
+
+This makes structural selectors like `world mode#edit filesystem file` work correctly even with plugin-contributed entity types, because the depth ordering validates the structural descent path.
+
+---
+
+## 12. Ducklog replacement path
+
+This spec, once implemented, replaces the standalone ducklog package entirely:
+
+| Ducklog component | Replacement |
+|---|---|
+| `ducklog/compiler.py` (selector→SQL) | `umwelt.compilers.sql.compiler` (already merged) |
+| `ducklog/schema/policy.sql` | `umwelt.compilers.sql.schema` + `umwelt.policy.projections` |
+| `ducklog/consumers/kibitzer.py` | Kibitzer's own adapter using `PolicyEngine.resolve_all(type="mode")` |
+| `ducklog/consumers/lackpy.py` | Lackpy's own adapter using `PolicyEngine.resolve_all(type="tool")` |
+| Live provider views (glob, read_json) | Future: generator plugin protocol (`define_query` tier) |
+
+Consumer packages move into each tool's repository as thin adapters over the PolicyEngine API. The ducklog package can be archived once all consumers have migrated.
+
+---
+
+## 13. Success criteria
+
+1. `PolicyEngine.from_files()` produces a queryable database from `.world.yml` + `.umw` source files.
+2. `PolicyEngine.from_db()` opens a compiled database for immediate querying.
+3. `engine.resolve()` returns correct resolved values matching the existing cascade resolver output.
+4. `engine.trace()` returns all competing candidates with specificity for any (entity, property).
+5. `engine.lint()` detects at least: narrow_win, shadowed_rule, uncovered_entity.
+6. `engine.extend()` produces a new engine with COW semantics — original unchanged.
+7. `engine.save()` produces a self-contained SQLite file queryable without Python.
+8. Typed projection views are vocabulary-driven and present in the compiled database.
+9. `engine.to_files()` round-trips back to `.world.yml` + `.umw`.
+10. Structured log events emitted via `logging.getLogger("umwelt.policy")` for all query and mutation operations.
+11. Existing `compilers/sql/` tests continue to pass unchanged.
+12. Kibitzer's `load_config_from_duckdb()` can be reimplemented against the PolicyEngine API with equivalent output.

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -125,7 +125,14 @@ privileged; all are regular consumers of the common-language contract.
 
 ## Status
 
-**v0.5.2 shipped.** VSM-aligned taxa (principal, audit, operation, coordination, control, intelligence), `use[of=...]` action-axis permission primitive, cross-axis cascade specificity, mode entity with class selectors, `tool.visible` property, `@audit { ... }` at-rule. Evaluation framework with ~35 falsifiable claims. DuckDB compile target (`umwelt compile --target duckdb`) via [ducklog](https://github.com/teaguesterling/ducklog). Kibitzer consumes ducklog policy databases. 562 tests. See [`docs/superpowers/plans/`](../superpowers/plans/) for the active implementation plans and [`docs/vision/evaluation-framework.md`](./evaluation-framework.md) for the claim ledger.
+**v0.6 in progress.** Building on v0.5.2 (VSM-aligned taxa, `use[of=...]`, cross-axis cascade, DuckDB compile target). Two new subsystems landed:
+
+- **World State Layer** (`umwelt.world`): YAML-based world file parser with shorthand expansion, vocabulary validation, and three-level materialization (summary/outline/full). `umwelt materialize` CLI command. PyYAML dependency.
+- **PolicyEngine** (`umwelt.policy`): Consumer-facing Python API wrapping a compiled SQLite database. Three constructors (`from_files`, `from_db`, programmatic builder). Four query modes: resolve (cascade resolution), trace (explain why), lint (smell detection), select (entity filtering). COW `extend()` for immutable fork-and-specialize. World file entities populate the same SQL schema as matchers. Typed projection views (tools, modes, etc.) embedded in compiled databases. 70 new tests.
+
+PolicyEngine replaces the separate ducklog package for consumers like Kibitzer and Lackpy — they query resolved policy via `engine.resolve()` instead of raw SQL. See [`docs/superpowers/specs/2026-04-20-policy-engine-design.md`](../superpowers/specs/2026-04-20-policy-engine-design.md) for the full design spec.
+
+632+ tests total. See [`docs/superpowers/plans/`](../superpowers/plans/) for the active implementation plans and [`docs/vision/evaluation-framework.md`](./evaluation-framework.md) for the claim ledger.
 
 ## Document map
 
@@ -144,6 +151,7 @@ privileged; all are regular consumers of the common-language contract.
 | [`notes/vsm-alignment.md`](./notes/vsm-alignment.md) | Beer's VSM as the organizing principle for umwelt's taxa. |
 | [`notes/logic-semantics.md`](./notes/logic-semantics.md) | umwelt views as Datalog programs. Landscape: OPA, Cedar, Polar, Binder. What's novel. |
 | [`notes/v05-retrospective.md`](./notes/v05-retrospective.md) | Honest assessment: what emerged, what's right, what's missing. |
+| [`../superpowers/specs/2026-04-20-policy-engine-design.md`](../superpowers/specs/2026-04-20-policy-engine-design.md) | **PolicyEngine design spec.** Knowledge query API, SQL compiler extensions, world file population, projections, lint, observability. |
 
 Future documents (not yet written):
 
@@ -168,8 +176,8 @@ umwelt is one piece of a larger specified-band regulation tool suite. Each piece
 
 - **[Ma of Multi-Agent Systems](https://judgementalmonad.com/blog/ma/00-intro)** — the theoretical framework. Specified band, grade lattice, four actors, layered regulation, configuration ratchet. umwelt is a concrete instantiation of the policy layer of this framework.
 - **[Ratchet Fuel](https://judgementalmonad.com/blog/fuel/)** — the practitioner companion. Failures as product roadmap, the two-stage turn, sandbox specs as type signatures. umwelt's ratchet utility implements the crystallization stage for multi-dimension views.
-- **[ducklog](https://github.com/teaguesterling/ducklog)** — the relational backend. Compiles umwelt views to DuckDB policy databases. Consumers query resolved policy with plain SQL. Includes the selector-to-SQL compiler, comparison-aware cascade resolution, provider views (filesystem, tools, modes), and consumer modules for kibitzer and lackpy. `umwelt compile --target duckdb` uses ducklog.
-- **[kibitzer](https://github.com/teaguesterling/kibitzer)** — observation and coaching at the semantic altitude. Reads mode definitions and tool surfaces from ducklog policy databases (optional) or its own TOML config. First real consumer of the umwelt→ducklog pipeline.
+- **[ducklog](https://github.com/teaguesterling/ducklog)** — the original relational backend (being replaced by `umwelt.policy`). Compiled views to DuckDB policy databases. The selector-to-SQL compiler and cascade resolution have been absorbed into `umwelt.compilers.sql`; the consumer-facing query layer is now `umwelt.policy.PolicyEngine`. `umwelt compile --target duckdb` still works for the DuckDB dialect. ducklog remains for backwards compatibility but new consumers should use PolicyEngine directly.
+- **[kibitzer](https://github.com/teaguesterling/kibitzer)** — observation and coaching at the semantic altitude. Migrating from `ducklog.consumers.kibitzer` to `umwelt.policy.PolicyEngine` for mode definitions and tool surfaces.
 - **[lackpy](https://github.com/teaguesterling/lackpy)** — language-altitude sandbox. Primary umwelt consumer for delegate orchestration. Consumes the `compilers/lackpy-namespace` compiler or ducklog's `lackpy_tool_config` view.
 - **[blq](https://github.com/teaguesterling/lq)** — build log query. Captures observations (resource usage, command traces, strace output) that the ratchet utility consumes. DuckDB-native — shares the database substrate with ducklog.
 - **[ratchet-detect](https://github.com/teaguesterling/judgementalmonad.com/blob/main/tools/ratchet-detect/)** — observation tool for Claude Code conversation logs. Another observation source for the ratchet utility.

--- a/docs/vision/package-design.md
+++ b/docs/vision/package-design.md
@@ -78,7 +78,29 @@ umwelt/                                      # repository / PyPI package root
         │
         ├── compilers/                       # compiler protocol + registry
         │   ├── __init__.py
-        │   └── protocol.py                  # Compiler protocol, registry, altitude declaration
+        │   ├── protocol.py                  # Compiler protocol, registry, altitude declaration
+        │   └── sql/                         # SQL-backed compilation pipeline
+        │       ├── __init__.py              # compile_to_db, compile_to_sql
+        │       ├── schema.py                # 6-table DDL (entities, selectors, etc.)
+        │       ├── compiler.py              # compile_selector, compile_view
+        │       ├── resolution.py            # cascade resolution views (exact/cap/pattern)
+        │       ├── dialects.py              # Dialect ABC, SQLiteDialect, DuckDBDialect
+        │       └── populate.py              # world file entity → SQL population
+        │
+        ├── world/                           # world state layer — YAML world files
+        │   ├── __init__.py                  # public API: load_world, materialize, etc.
+        │   ├── model.py                     # DeclaredEntity, WorldFile, MaterializedWorld, enums
+        │   ├── parser.py                    # YAML parsing + shorthand expansion → WorldFile
+        │   ├── shorthands.py                # ShorthandDef, register_shorthand, get_shorthand
+        │   ├── validate.py                  # vocabulary validation → appends warnings
+        │   └── materialize.py               # materialize() at 3 levels + render_yaml()
+        │
+        ├── policy/                          # consumer-facing PolicyEngine
+        │   ├── __init__.py                  # exports: PolicyEngine, Candidate, TraceResult, LintWarning
+        │   ├── engine.py                    # PolicyEngine class — constructors, queries, COW extend
+        │   ├── queries.py                   # resolve, trace, select — pure SQL query layer
+        │   ├── lint.py                      # 5 smell detectors (narrow_win, shadowed_rule, etc.)
+        │   └── projections.py               # typed projection views + compilation_meta
         │
         ├── validate.py                      # runs registered validators over a parsed View
         ├── cli.py                           # umwelt parse | inspect | compile | dry-run | ratchet | check | diff
@@ -163,6 +185,7 @@ Core umwelt (~1,600 lines) is now smaller than the original monolithic plan sugg
 
 - Python 3.10+
 - `tinycss2` — CSS-3 tokenizer. Used for view file parsing. See [`implementation-language.md`](./implementation-language.md) for the rationale.
+- `pyyaml` — YAML parser. Used for `.world.yml` file parsing in `umwelt.world`.
 
 **Runtime (optional):**
 
@@ -230,6 +253,53 @@ register_property(
 ```
 
 This is what `umwelt.sandbox` calls at import time. Third-party consumers follow the same pattern. See [`entity-model.md`](./entity-model.md) §6 for the full API reference.
+
+### PolicyEngine — consumer-facing query API
+
+```python
+from umwelt.policy import PolicyEngine
+
+# Author time: compile from source files
+engine = PolicyEngine.from_files(world="env.world.yml", stylesheet="policy.umw")
+
+# Consumer time: load a pre-compiled database
+engine = PolicyEngine.from_db("world.duckdb")
+
+# Runtime: programmatic builder
+engine = PolicyEngine()
+engine.add_entities([{"type": "tool", "id": "Read", "classes": ["safe"]}])
+engine.add_stylesheet("tool.safe { visible: true; }")
+
+# Query resolved policy
+engine.resolve(type="tool", id="Read", property="visible")     # → "true"
+engine.resolve(type="tool", id="Read")                          # → {"visible": "true"}
+engine.resolve_all(type="tool")                                 # → [{"type": "tool", "id": "Read", ...}]
+
+# Explain why a value won
+trace = engine.trace(type="tool", id="Read", property="visible")
+for c in trace.candidates:
+    print(f"  {c.value} spec={c.specificity} {'✓' if c.won else '✗'}")
+
+# Check and enforce
+engine.check(type="tool", id="Read", visible="true")           # → True
+engine.require(type="tool", id="Read", visible="true")         # raises PolicyDenied if mismatch
+
+# Detect policy smells
+warnings = engine.lint()                                        # → list[LintWarning]
+
+# COW fork — immutable extend
+child = engine.extend(
+    entities=[{"type": "tool", "id": "Bash", "classes": ["dangerous"]}],
+    stylesheet="tool.dangerous { visible: false; }",
+)
+
+# Persist
+engine.save("compiled.duckdb")
+```
+
+PolicyEngine wraps a compiled SQLite database. The three constructors cover the full lifecycle: `from_files()` for authoring, `from_db()` for consumers loading pre-compiled policy, and the programmatic builder for runtime composition. `extend()` produces a new engine via SQLite backup — the original is never mutated.
+
+See [`docs/superpowers/specs/2026-04-20-policy-engine-design.md`](../superpowers/specs/2026-04-20-policy-engine-design.md) for the full design spec.
 
 ### Compiler protocol and registry
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "tinycss2>=1.2",
+  "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/umwelt/cli.py
+++ b/src/umwelt/cli.py
@@ -227,6 +227,36 @@ def _cmd_compile_sql(args: argparse.Namespace, view) -> int:
     return 0
 
 
+def _cmd_materialize(args: argparse.Namespace) -> int:
+    _load_default_vocabulary()
+    from umwelt.errors import WorldParseError
+    from umwelt.world.materialize import materialize, render_yaml
+    from umwelt.world.model import DetailLevel
+    from umwelt.world.parser import load_world
+    from umwelt.world.validate import validate_world
+
+    try:
+        world = load_world(Path(args.file))
+    except FileNotFoundError as exc:
+        print(f"error: No such file: {exc.filename}", file=sys.stderr)
+        return 2
+    except WorldParseError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    world = validate_world(world)
+    level = DetailLevel(args.level)
+    result = materialize(world, level=level)
+    output = render_yaml(result)
+
+    if args.output:
+        Path(args.output).write_text(output)
+        print(f"Materialized to {args.output}")
+    else:
+        print(output, end="")
+    return 0
+
+
 def _cmd_diff(args: argparse.Namespace) -> int:
     _load_default_vocabulary()
     try:
@@ -378,6 +408,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="database connection string or file path (executes SQL)",
     )
     p_compile.set_defaults(func=_cmd_compile)
+
+    p_mat = subparsers.add_parser("materialize", help="materialize a .world.yml file")
+    p_mat.add_argument("file", help="path to a .world.yml file")
+    p_mat.add_argument("--level", choices=["summary", "outline", "full"], default="full",
+                       help="detail level (default: full)")
+    p_mat.add_argument("-o", "--output", default=None, help="output file path")
+    p_mat.set_defaults(func=_cmd_materialize)
 
     p_diff = subparsers.add_parser(
         "diff", help="compare two view files and show rule-level differences"

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -137,3 +137,75 @@ def _rebuild_closure(con: Any) -> None:
         )
         SELECT DISTINCT * FROM closure;
     """)
+
+
+def populate_from_world(con: Any, world: Any) -> None:
+    """Insert DeclaredEntity instances from a WorldFile into the entities table.
+
+    World file entities win on (type_name, entity_id) collision with
+    existing matcher-discovered entities.
+    """
+    for entity in world.entities:
+        _upsert_declared_entity(con, entity)
+
+    for proj in world.projections:
+        _upsert_projection(con, proj)
+
+    con.commit()
+    _rebuild_closure(con)
+
+
+def _upsert_declared_entity(con: Any, entity: Any) -> None:
+    classes_json = json.dumps(list(entity.classes)) if entity.classes else None
+    attrs_json = json.dumps(entity.attributes) if entity.attributes else None
+
+    existing = con.execute(
+        "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+        (entity.type, entity.id),
+    ).fetchone()
+
+    if existing:
+        con.execute(
+            "UPDATE entities SET classes = ?, attributes = ? WHERE id = ?",
+            (classes_json, attrs_json, existing[0]),
+        )
+    else:
+        taxon = _guess_taxon(entity.type)
+        con.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+            "VALUES (?, ?, ?, ?, ?, 0)",
+            (taxon, entity.type, entity.id, classes_json, attrs_json),
+        )
+
+
+def _upsert_projection(con: Any, proj: Any) -> None:
+    attrs_json = json.dumps(proj.attributes) if proj.attributes else None
+
+    existing = con.execute(
+        "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+        (proj.type, proj.id),
+    ).fetchone()
+
+    if existing:
+        con.execute(
+            "UPDATE entities SET attributes = ? WHERE id = ?",
+            (attrs_json, existing[0]),
+        )
+    else:
+        taxon = _guess_taxon(proj.type)
+        con.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, attributes, depth) "
+            "VALUES (?, ?, ?, ?, 0)",
+            (taxon, proj.type, proj.id, attrs_json),
+        )
+
+
+def _guess_taxon(type_name: str) -> str:
+    try:
+        from umwelt.registry.entities import resolve_entity_type
+        taxa = resolve_entity_type(type_name)
+        if taxa:
+            return taxa[0]
+    except Exception:
+        pass
+    return type_name

--- a/src/umwelt/errors.py
+++ b/src/umwelt/errors.py
@@ -40,3 +40,11 @@ class ViewValidationError(ViewError):
 
 class RegistryError(UmweltError):
     """Raised on plugin-registry collisions or lookup failures."""
+
+
+class WorldError(UmweltError):
+    """Base class for world file errors."""
+
+
+class WorldParseError(WorldError):
+    """Raised when a .world.yml file has structural problems."""

--- a/src/umwelt/errors.py
+++ b/src/umwelt/errors.py
@@ -48,3 +48,30 @@ class WorldError(UmweltError):
 
 class WorldParseError(WorldError):
     """Raised when a .world.yml file has structural problems."""
+
+
+class PolicyError(UmweltError):
+    """Base class for policy engine errors."""
+
+
+class PolicyDenied(PolicyError):
+    """Raised when a require() check fails."""
+
+    def __init__(
+        self,
+        entity: str,
+        property: str,
+        expected: str,
+        actual: str | None,
+    ) -> None:
+        self.entity = entity
+        self.property = property
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"policy denied: {entity} {property}={actual!r} (expected {expected!r})"
+        )
+
+
+class PolicyCompilationError(PolicyError):
+    """Raised when compilation of policy sources fails."""

--- a/src/umwelt/policy/__init__.py
+++ b/src/umwelt/policy/__init__.py
@@ -1,0 +1,7 @@
+from umwelt.policy.engine import Candidate, LintWarning, TraceResult
+
+__all__ = [
+    "Candidate",
+    "LintWarning",
+    "TraceResult",
+]

--- a/src/umwelt/policy/__init__.py
+++ b/src/umwelt/policy/__init__.py
@@ -1,7 +1,8 @@
-from umwelt.policy.engine import Candidate, LintWarning, TraceResult
+from umwelt.policy.engine import Candidate, LintWarning, PolicyEngine, TraceResult
 
 __all__ = [
     "Candidate",
     "LintWarning",
+    "PolicyEngine",
     "TraceResult",
 ]

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -68,7 +68,7 @@ class PolicyEngine:
         try:
             _load_default_vocabulary()
         except Exception:
-            pass
+            logger.debug("vocabulary registration skipped", exc_info=True)
 
         world_file = load_world(world_path)
         view = parse(stylesheet_path)
@@ -82,7 +82,7 @@ class PolicyEngine:
         try:
             create_projection_views(con)
         except Exception:
-            pass
+            logger.debug("projection views skipped", exc_info=True)
         try:
             create_compilation_meta(
                 con,
@@ -90,7 +90,7 @@ class PolicyEngine:
                 source_stylesheet=str(stylesheet_path),
             )
         except Exception:
-            pass
+            logger.debug("compilation meta skipped", exc_info=True)
 
         engine = cls.__new__(cls)
         engine._con = con
@@ -147,7 +147,7 @@ class PolicyEngine:
         try:
             _load_default_vocabulary()
         except Exception:
-            pass
+            logger.debug("vocabulary registration skipped", exc_info=True)
 
         dialect = SQLiteDialect()
         con = self._con or sqlite3.connect(":memory:")
@@ -177,7 +177,7 @@ class PolicyEngine:
         try:
             create_projection_views(con)
         except Exception:
-            pass
+            logger.debug("projection views skipped", exc_info=True)
 
         self._con = con
         self._compiled = True
@@ -306,7 +306,7 @@ class PolicyEngine:
         try:
             _load_default_vocabulary()
         except Exception:
-            pass
+            logger.debug("vocabulary registration skipped", exc_info=True)
 
         con = self._con
         dialect = SQLiteDialect()
@@ -326,39 +326,37 @@ class PolicyEngine:
             populate_from_world(con, wf)
             self._pending_entities = []
 
-        # Drop and recreate resolution views before adding new rules
         _resolution_views = (
             "resolved_properties", "_resolved_exact",
             "_resolved_cap", "_resolved_pattern",
         )
         for view_name in _resolution_views:
-            con.execute(f"DROP VIEW IF EXISTS {view_name}")
+            con.execute(f'DROP VIEW IF EXISTS "{view_name}"')
 
+        had_stylesheets = bool(self._pending_stylesheets)
         for css_text in self._pending_stylesheets:
             view = parse_css(css_text, validate=False)
             compile_view(con, view, dialect)
         self._pending_stylesheets = []
 
-        if not self._pending_stylesheets:
+        if not had_stylesheets:
             try:
                 con.execute("SELECT 1 FROM resolved_properties LIMIT 1")
             except sqlite3.OperationalError:
                 create_resolution_views(con, dialect)
 
-        # Recreate projection views
         for view_name in ("resolved_entities",):
-            con.execute(f"DROP VIEW IF EXISTS {view_name}")
-        # Also drop any typed views that might exist
+            con.execute(f'DROP VIEW IF EXISTS "{view_name}"')
         existing_views = con.execute(
             "SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE '_%'"
         ).fetchall()
         for (vname,) in existing_views:
             if vname != "resolved_properties":
-                con.execute(f"DROP VIEW IF EXISTS \"{vname}\"")
+                con.execute(f'DROP VIEW IF EXISTS "{vname}"')
         try:
             create_projection_views(con)
         except Exception:
-            pass
+            logger.debug("projection views skipped", exc_info=True)
 
         self._compiled = True
 

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Candidate:
+    value: str
+    specificity: str
+    rule_index: int
+    source_file: str
+    source_line: int
+    won: bool
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    entity: str
+    property: str
+    value: str | None
+    candidates: tuple[Candidate, ...]
+
+
+@dataclass(frozen=True)
+class LintWarning:
+    smell: str
+    severity: str
+    description: str
+    entities: tuple[str, ...]
+    property: str | None

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -355,6 +355,73 @@ class PolicyEngine:
         con.backup(target)
         target.close()
 
+    def to_files(
+        self,
+        *,
+        world: str | Path,
+        stylesheet: str | Path,
+    ) -> None:
+        import json
+
+        import yaml
+
+        con = self._ensure_compiled()
+
+        # Export entities to world YAML
+        rows = con.execute(
+            "SELECT entity_id, type_name, classes, attributes FROM entities ORDER BY type_name, entity_id"
+        ).fetchall()
+        entities_out = []
+        for entity_id, type_name, classes_json, attrs_json in rows:
+            entry: dict[str, Any] = {"type": type_name, "id": entity_id}
+            classes = json.loads(classes_json) if classes_json else []
+            if classes:
+                entry["classes"] = classes
+            attrs = json.loads(attrs_json) if attrs_json else {}
+            if attrs:
+                entry["attributes"] = attrs
+            entities_out.append(entry)
+
+        world_path = Path(world)
+        world_path.write_text(yaml.dump({"entities": entities_out}, default_flow_style=False, sort_keys=False))
+
+        # Export stylesheet: copy original if tracked, otherwise emit a comment
+        stylesheet_path = Path(stylesheet)
+        source_stylesheet: str | None = None
+        try:
+            row = con.execute(
+                "SELECT value FROM compilation_meta WHERE key = 'source_stylesheet'"
+            ).fetchone()
+            if row:
+                source_stylesheet = row[0]
+        except Exception:
+            pass
+
+        if source_stylesheet and Path(source_stylesheet).exists():
+            stylesheet_path.write_bytes(Path(source_stylesheet).read_bytes())
+        else:
+            # Best-effort: emit each distinct (property_name, property_value) combination
+            # grouped by source_file and rule_index as a comment block.
+            rule_rows = con.execute(
+                "SELECT property_name, property_value, source_file, rule_index "
+                "FROM cascade_candidates ORDER BY source_file, rule_index, property_name"
+            ).fetchall()
+            by_rule: dict[tuple[str, int], list[tuple[str, str]]] = {}
+            for prop_name, prop_value, src_file, rule_idx in rule_rows:
+                key = (src_file or "", rule_idx)
+                by_rule.setdefault(key, []).append((prop_name, prop_value))
+
+            lines = ["/* exported from compiled policy */"]
+            for (src_file, rule_idx), props in by_rule.items():
+                if src_file:
+                    lines.append(f"/* rule {rule_idx} from {src_file} */")
+                lines.append("* {")
+                for name, value in props:
+                    lines.append(f"  {name}: {value};")
+                lines.append("}")
+                lines.append("")
+            stylesheet_path.write_text("\n".join(lines))
+
     def execute(self, sql: str, params: tuple = ()) -> list[tuple]:
         con = self._ensure_compiled()
         return con.execute(sql, params).fetchall()

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import logging
+import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from umwelt.errors import PolicyCompilationError, PolicyDenied
+
+logger = logging.getLogger("umwelt.policy")
 
 
 @dataclass(frozen=True)
@@ -28,3 +36,333 @@ class LintWarning:
     description: str
     entities: tuple[str, ...]
     property: str | None
+
+
+class PolicyEngine:
+    """Consumer-facing API for querying resolved world knowledge."""
+
+    def __init__(self) -> None:
+        self._con: sqlite3.Connection | None = None
+        self._pending_entities: list[dict[str, Any]] = []
+        self._pending_stylesheets: list[str] = []
+        self._compiled = False
+
+    @classmethod
+    def from_files(
+        cls,
+        *,
+        world: str | Path,
+        stylesheet: str | Path,
+    ) -> PolicyEngine:
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import populate_from_world
+        from umwelt.compilers.sql.schema import create_schema
+        from umwelt.parser import parse
+        from umwelt.policy.projections import create_compilation_meta, create_projection_views
+        from umwelt.world.parser import load_world
+
+        world_path = Path(world)
+        stylesheet_path = Path(stylesheet)
+
+        try:
+            _load_default_vocabulary()
+        except Exception:
+            pass
+
+        world_file = load_world(world_path)
+        view = parse(stylesheet_path)
+
+        dialect = SQLiteDialect()
+        con = sqlite3.connect(":memory:")
+        con.executescript(create_schema(dialect))
+        populate_from_world(con, world_file)
+        compile_view(con, view, dialect, source_file=str(stylesheet_path))
+
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+        try:
+            create_compilation_meta(
+                con,
+                source_world=str(world_path),
+                source_stylesheet=str(stylesheet_path),
+            )
+        except Exception:
+            pass
+
+        engine = cls.__new__(cls)
+        engine._con = con
+        engine._pending_entities = []
+        engine._pending_stylesheets = []
+        engine._compiled = True
+
+        logger.info(
+            "compile",
+            extra={
+                "source_files": [str(world_path), str(stylesheet_path)],
+                "entity_count": con.execute("SELECT COUNT(*) FROM entities").fetchone()[0],
+            },
+        )
+        return engine
+
+    @classmethod
+    def from_db(cls, path: str | Path) -> PolicyEngine:
+        source = sqlite3.connect(str(path))
+        con = sqlite3.connect(":memory:")
+        source.backup(con)
+        source.close()
+
+        engine = cls.__new__(cls)
+        engine._con = con
+        engine._pending_entities = []
+        engine._pending_stylesheets = []
+        engine._compiled = True
+        return engine
+
+    def add_entities(self, entities: list[dict[str, Any]]) -> None:
+        self._pending_entities.extend(entities)
+        self._compiled = False
+
+    def add_stylesheet(self, css: str) -> None:
+        self._pending_stylesheets.append(css)
+        self._compiled = False
+
+    def register_vocabulary(self, registrar: Any) -> None:
+        registrar()
+
+    def _ensure_compiled(self) -> sqlite3.Connection:
+        if self._con is not None and self._compiled:
+            return self._con
+
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import populate_from_world
+        from umwelt.compilers.sql.schema import create_schema
+        from umwelt.parser import parse as parse_css
+        from umwelt.policy.projections import create_projection_views
+        from umwelt.world.model import DeclaredEntity, WorldFile
+
+        try:
+            _load_default_vocabulary()
+        except Exception:
+            pass
+
+        dialect = SQLiteDialect()
+        con = self._con or sqlite3.connect(":memory:")
+        if not self._compiled:
+            con.executescript(create_schema(dialect))
+
+        if self._pending_entities:
+            declared = []
+            for e in self._pending_entities:
+                classes = tuple(e.get("classes", ()))
+                declared.append(DeclaredEntity(
+                    type=e["type"],
+                    id=e["id"],
+                    classes=classes,
+                    attributes=e.get("attributes", {}),
+                    parent=e.get("parent"),
+                ))
+            wf = WorldFile(entities=tuple(declared), projections=(), warnings=())
+            populate_from_world(con, wf)
+            self._pending_entities = []
+
+        for css_text in self._pending_stylesheets:
+            view = parse_css(css_text, validate=False)
+            compile_view(con, view, dialect)
+        self._pending_stylesheets = []
+
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+
+        self._con = con
+        self._compiled = True
+        return con
+
+    def resolve(
+        self,
+        *,
+        type: str,
+        id: str,
+        property: str | None = None,
+    ) -> str | dict[str, str] | None:
+        from umwelt.policy.queries import resolve_entity
+
+        con = self._ensure_compiled()
+        result = resolve_entity(con, type=type, id=id, property=property)
+        logger.info(
+            "resolve",
+            extra={"entity": f"{type}#{id}", "property": property, "value": result},
+        )
+        return result
+
+    def resolve_all(self, *, type: str) -> list[dict]:
+        from umwelt.policy.queries import resolve_all_entities
+
+        con = self._ensure_compiled()
+        results = resolve_all_entities(con, type=type)
+        logger.info(
+            "resolve_all",
+            extra={"type": type, "result_count": len(results)},
+        )
+        return results
+
+    def trace(
+        self,
+        *,
+        type: str,
+        id: str,
+        property: str,
+    ) -> TraceResult:
+        from umwelt.policy.queries import trace_entity
+
+        con = self._ensure_compiled()
+        result = trace_entity(con, type=type, id=id, property=property)
+        logger.debug(
+            "trace",
+            extra={"entity": f"{type}#{id}", "property": property, "candidates": len(result.candidates)},
+        )
+        return result
+
+    def lint(self) -> list[LintWarning]:
+        from umwelt.policy.lint import run_lint
+
+        con = self._ensure_compiled()
+        return run_lint(con)
+
+    def check(self, *, type: str, id: str, **expected: str) -> bool:
+        for prop_name, expected_val in expected.items():
+            actual = self.resolve(type=type, id=id, property=prop_name)
+            if actual != expected_val:
+                return False
+        return True
+
+    def require(self, *, type: str, id: str, **expected: str) -> None:
+        for prop_name, expected_val in expected.items():
+            actual = self.resolve(type=type, id=id, property=prop_name)
+            if actual != expected_val:
+                logger.warning(
+                    "require_denied",
+                    extra={"entity": f"{type}#{id}", "property": prop_name, "expected": expected_val, "actual": actual},
+                )
+                raise PolicyDenied(
+                    entity=f"{type}#{id}",
+                    property=prop_name,
+                    expected=expected_val,
+                    actual=actual or "(none)",
+                )
+
+    def extend(
+        self,
+        *,
+        entities: list[dict[str, Any]] | None = None,
+        stylesheet: str | None = None,
+    ) -> PolicyEngine:
+        con = self._ensure_compiled()
+
+        new_con = sqlite3.connect(":memory:")
+        con.backup(new_con)
+
+        new_engine = PolicyEngine.__new__(PolicyEngine)
+        new_engine._con = new_con
+        new_engine._pending_entities = list(entities) if entities else []
+        new_engine._pending_stylesheets = [stylesheet] if stylesheet else []
+        new_engine._compiled = False
+
+        if new_engine._pending_entities or new_engine._pending_stylesheets:
+            new_engine._recompile_incremental()
+
+        logger.info(
+            "extend",
+            extra={
+                "entities_added": len(entities) if entities else 0,
+                "stylesheet_added": bool(stylesheet),
+            },
+        )
+        return new_engine
+
+    def _recompile_incremental(self) -> None:
+        from umwelt.compilers.sql.compiler import compile_view
+        from umwelt.compilers.sql.dialects import SQLiteDialect
+        from umwelt.compilers.sql.populate import populate_from_world
+        from umwelt.compilers.sql.resolution import create_resolution_views
+        from umwelt.parser import parse as parse_css
+        from umwelt.policy.projections import create_projection_views
+        from umwelt.world.model import DeclaredEntity, WorldFile
+
+        try:
+            _load_default_vocabulary()
+        except Exception:
+            pass
+
+        con = self._con
+        dialect = SQLiteDialect()
+
+        if self._pending_entities:
+            declared = []
+            for e in self._pending_entities:
+                classes = tuple(e.get("classes", ()))
+                declared.append(DeclaredEntity(
+                    type=e["type"],
+                    id=e["id"],
+                    classes=classes,
+                    attributes=e.get("attributes", {}),
+                    parent=e.get("parent"),
+                ))
+            wf = WorldFile(entities=tuple(declared), projections=(), warnings=())
+            populate_from_world(con, wf)
+            self._pending_entities = []
+
+        # Drop and recreate resolution views before adding new rules
+        for view_name in ("resolved_properties", "_resolved_exact", "_resolved_cap", "_resolved_pattern"):
+            con.execute(f"DROP VIEW IF EXISTS {view_name}")
+
+        for css_text in self._pending_stylesheets:
+            view = parse_css(css_text, validate=False)
+            compile_view(con, view, dialect)
+        self._pending_stylesheets = []
+
+        if not self._pending_stylesheets:
+            try:
+                con.execute("SELECT 1 FROM resolved_properties LIMIT 1")
+            except sqlite3.OperationalError:
+                create_resolution_views(con, dialect)
+
+        # Recreate projection views
+        for view_name in ("resolved_entities",):
+            con.execute(f"DROP VIEW IF EXISTS {view_name}")
+        # Also drop any typed views that might exist
+        existing_views = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE '_%'"
+        ).fetchall()
+        for (vname,) in existing_views:
+            if vname != "resolved_properties":
+                con.execute(f"DROP VIEW IF EXISTS \"{vname}\"")
+        try:
+            create_projection_views(con)
+        except Exception:
+            pass
+
+        self._compiled = True
+
+    def save(self, path: str | Path) -> None:
+        con = self._ensure_compiled()
+        target = sqlite3.connect(str(path))
+        con.backup(target)
+        target.close()
+
+    def execute(self, sql: str, params: tuple = ()) -> list[tuple]:
+        con = self._ensure_compiled()
+        return con.execute(sql, params).fetchall()
+
+
+def _load_default_vocabulary() -> None:
+    try:
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+        register_sandbox_vocabulary()
+    except ImportError:
+        pass

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from umwelt.errors import PolicyCompilationError, PolicyDenied
+from umwelt.errors import PolicyDenied
 
 logger = logging.getLogger("umwelt.policy")
 
@@ -224,7 +224,11 @@ class PolicyEngine:
         result = trace_entity(con, type=type, id=id, property=property)
         logger.debug(
             "trace",
-            extra={"entity": f"{type}#{id}", "property": property, "candidates": len(result.candidates)},
+            extra={
+                "entity": f"{type}#{id}",
+                "property": property,
+                "candidates": len(result.candidates),
+            },
         )
         return result
 
@@ -247,7 +251,12 @@ class PolicyEngine:
             if actual != expected_val:
                 logger.warning(
                     "require_denied",
-                    extra={"entity": f"{type}#{id}", "property": prop_name, "expected": expected_val, "actual": actual},
+                    extra={
+                        "entity": f"{type}#{id}",
+                        "property": prop_name,
+                        "expected": expected_val,
+                        "actual": actual,
+                    },
                 )
                 raise PolicyDenied(
                     entity=f"{type}#{id}",
@@ -318,7 +327,11 @@ class PolicyEngine:
             self._pending_entities = []
 
         # Drop and recreate resolution views before adding new rules
-        for view_name in ("resolved_properties", "_resolved_exact", "_resolved_cap", "_resolved_pattern"):
+        _resolution_views = (
+            "resolved_properties", "_resolved_exact",
+            "_resolved_cap", "_resolved_pattern",
+        )
+        for view_name in _resolution_views:
             con.execute(f"DROP VIEW IF EXISTS {view_name}")
 
         for css_text in self._pending_stylesheets:
@@ -369,7 +382,8 @@ class PolicyEngine:
 
         # Export entities to world YAML
         rows = con.execute(
-            "SELECT entity_id, type_name, classes, attributes FROM entities ORDER BY type_name, entity_id"
+            "SELECT entity_id, type_name, classes, attributes "
+            "FROM entities ORDER BY type_name, entity_id"
         ).fetchall()
         entities_out = []
         for entity_id, type_name, classes_json, attrs_json in rows:
@@ -383,7 +397,10 @@ class PolicyEngine:
             entities_out.append(entry)
 
         world_path = Path(world)
-        world_path.write_text(yaml.dump({"entities": entities_out}, default_flow_style=False, sort_keys=False))
+        world_data = {"entities": entities_out}
+        world_path.write_text(
+            yaml.dump(world_data, default_flow_style=False, sort_keys=False)
+        )
 
         # Export stylesheet: copy original if tracked, otherwise emit a comment
         stylesheet_path = Path(stylesheet)

--- a/src/umwelt/policy/lint.py
+++ b/src/umwelt/policy/lint.py
@@ -1,0 +1,200 @@
+# src/umwelt/policy/lint.py
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+from umwelt.policy.engine import LintWarning
+
+logger = logging.getLogger("umwelt.policy")
+
+
+def run_lint(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+    warnings.extend(_detect_narrow_win(con))
+    warnings.extend(_detect_shadowed_rule(con))
+    warnings.extend(_detect_conflicting_intent(con))
+    warnings.extend(_detect_uncovered_entity(con))
+    warnings.extend(_detect_specificity_escalation(con))
+
+    for w in warnings:
+        logger.warning(
+            "lint: %s — %s",
+            w.smell,
+            w.description,
+            extra={"smell": w.smell, "entities": w.entities, "severity": w.severity},
+        )
+    return warnings
+
+
+def _detect_narrow_win(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT cc.entity_id, cc.property_name, cc.property_value, cc.specificity, cc.rule_index
+        FROM cascade_candidates cc
+        WHERE cc.comparison = 'exact'
+        ORDER BY cc.entity_id, cc.property_name, cc.specificity DESC, cc.rule_index DESC
+    """).fetchall()
+
+    groups: dict[tuple[int, str], list[tuple]] = {}
+    for row in rows:
+        key = (row[0], row[1])
+        groups.setdefault(key, []).append(row)
+
+    for (entity_id, prop_name), candidates in groups.items():
+        if len(candidates) < 2:
+            continue
+        winner_spec = _parse_specificity(candidates[0][3])
+        runner_spec = _parse_specificity(candidates[1][3])
+        if winner_spec is None or runner_spec is None:
+            continue
+        diff = sum(w - r for w, r in zip(winner_spec, runner_spec))
+        if 0 < diff <= 1:
+            entity_name = _entity_name(con, entity_id)
+            warnings.append(LintWarning(
+                smell="narrow_win",
+                severity="warning",
+                description=f"{entity_name} '{prop_name}' won by specificity margin of {diff}",
+                entities=(entity_name,),
+                property=prop_name,
+            ))
+    return warnings
+
+
+def _detect_shadowed_rule(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT cc.source_file, cc.source_line, cc.property_name, cc.entity_id
+        FROM cascade_candidates cc
+        LEFT JOIN resolved_properties rp
+            ON cc.entity_id = rp.entity_id
+            AND cc.property_name = rp.property_name
+            AND cc.property_value = rp.property_value
+            AND cc.specificity = rp.specificity
+            AND cc.rule_index = rp.rule_index
+        WHERE rp.entity_id IS NULL
+          AND cc.source_file IS NOT NULL
+          AND cc.source_file != ''
+    """).fetchall()
+
+    shadowed_rules: dict[tuple[str, int], set[str]] = {}
+    for src_file, src_line, prop_name, entity_id in rows:
+        key = (src_file, src_line)
+        shadowed_rules.setdefault(key, set()).add(prop_name)
+
+    for (src_file, src_line), props in shadowed_rules.items():
+        warnings.append(LintWarning(
+            smell="shadowed_rule",
+            severity="info",
+            description=f"Rule at {src_file}:{src_line} never wins for properties: {', '.join(sorted(props))}",
+            entities=(),
+            property=None,
+        ))
+    return warnings
+
+
+def _detect_conflicting_intent(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT c1.entity_id, c1.property_name,
+               c1.property_value, c2.property_value,
+               c1.specificity
+        FROM cascade_candidates c1
+        JOIN cascade_candidates c2
+            ON c1.entity_id = c2.entity_id
+            AND c1.property_name = c2.property_name
+            AND c1.specificity = c2.specificity
+            AND c1.rule_index < c2.rule_index
+        WHERE c1.property_value != c2.property_value
+          AND c1.comparison = 'exact'
+          AND c2.comparison = 'exact'
+    """).fetchall()
+
+    seen: set[tuple[int, str]] = set()
+    for entity_id, prop_name, val1, val2, spec in rows:
+        key = (entity_id, prop_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        entity_name = _entity_name(con, entity_id)
+        warnings.append(LintWarning(
+            smell="conflicting_intent",
+            severity="warning",
+            description=f"{entity_name} '{prop_name}': '{val1}' vs '{val2}' at same specificity — winner decided by source order",
+            entities=(entity_name,),
+            property=prop_name,
+        ))
+    return warnings
+
+
+def _detect_uncovered_entity(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT e.id, e.type_name, e.entity_id
+        FROM entities e
+        LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+        WHERE rp.entity_id IS NULL
+    """).fetchall()
+
+    for eid, type_name, entity_id in rows:
+        name = f"{type_name}#{entity_id}" if entity_id else f"{type_name}(id={eid})"
+        warnings.append(LintWarning(
+            smell="uncovered_entity",
+            severity="info",
+            description=f"{name} has no resolved properties",
+            entities=(name,),
+            property=None,
+        ))
+    return warnings
+
+
+def _detect_specificity_escalation(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    rows = con.execute("""
+        SELECT entity_id, property_name, specificity
+        FROM cascade_candidates
+        ORDER BY entity_id, property_name, specificity ASC
+    """).fetchall()
+
+    groups: dict[tuple[int, str], list[str]] = {}
+    for entity_id, prop_name, spec in rows:
+        key = (entity_id, prop_name)
+        groups.setdefault(key, []).append(spec)
+
+    for (entity_id, prop_name), specs in groups.items():
+        unique_specs = sorted(set(specs))
+        if len(unique_specs) >= 3:
+            entity_name = _entity_name(con, entity_id)
+            warnings.append(LintWarning(
+                smell="specificity_escalation",
+                severity="warning",
+                description=f"{entity_name} '{prop_name}' has {len(unique_specs)} specificity levels — possible escalation war",
+                entities=(entity_name,),
+                property=prop_name,
+            ))
+    return warnings
+
+
+def _parse_specificity(spec_str: str) -> list[int] | None:
+    try:
+        parts = json.loads(spec_str)
+        return [int(p) for p in parts]
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+
+
+def _entity_name(con: sqlite3.Connection, entity_id: int) -> str:
+    row = con.execute(
+        "SELECT type_name, entity_id FROM entities WHERE id = ?",
+        (entity_id,),
+    ).fetchone()
+    if row is None:
+        return f"entity({entity_id})"
+    type_name, eid = row
+    return f"{type_name}#{eid}" if eid else f"{type_name}(id={entity_id})"

--- a/src/umwelt/policy/lint.py
+++ b/src/umwelt/policy/lint.py
@@ -50,7 +50,7 @@ def _detect_narrow_win(con: sqlite3.Connection) -> list[LintWarning]:
         runner_spec = _parse_specificity(candidates[1][3])
         if winner_spec is None or runner_spec is None:
             continue
-        diff = sum(w - r for w, r in zip(winner_spec, runner_spec))
+        diff = sum(w - r for w, r in zip(winner_spec, runner_spec, strict=False))
         if 0 < diff <= 1:
             entity_name = _entity_name(con, entity_id)
             warnings.append(LintWarning(
@@ -81,7 +81,7 @@ def _detect_shadowed_rule(con: sqlite3.Connection) -> list[LintWarning]:
     """).fetchall()
 
     shadowed_rules: dict[tuple[str, int], set[str]] = {}
-    for src_file, src_line, prop_name, entity_id in rows:
+    for src_file, src_line, prop_name, _entity_id in rows:
         key = (src_file, src_line)
         shadowed_rules.setdefault(key, set()).add(prop_name)
 
@@ -118,7 +118,7 @@ def _detect_conflicting_intent(con: sqlite3.Connection) -> list[LintWarning]:
     """).fetchall()
 
     seen: set[tuple[int, str]] = set()
-    for entity_id, prop_name, val1, val2, spec in rows:
+    for entity_id, prop_name, val1, val2, _spec in rows:
         key = (entity_id, prop_name)
         if key in seen:
             continue

--- a/src/umwelt/policy/lint.py
+++ b/src/umwelt/policy/lint.py
@@ -89,7 +89,10 @@ def _detect_shadowed_rule(con: sqlite3.Connection) -> list[LintWarning]:
         warnings.append(LintWarning(
             smell="shadowed_rule",
             severity="info",
-            description=f"Rule at {src_file}:{src_line} never wins for properties: {', '.join(sorted(props))}",
+            description=(
+                f"Rule at {src_file}:{src_line} never wins"
+                f" for properties: {', '.join(sorted(props))}"
+            ),
             entities=(),
             property=None,
         ))
@@ -124,7 +127,10 @@ def _detect_conflicting_intent(con: sqlite3.Connection) -> list[LintWarning]:
         warnings.append(LintWarning(
             smell="conflicting_intent",
             severity="warning",
-            description=f"{entity_name} '{prop_name}': '{val1}' vs '{val2}' at same specificity — winner decided by source order",
+            description=(
+                f"{entity_name} '{prop_name}': '{val1}' vs '{val2}'"
+                " at same specificity — winner decided by source order"
+            ),
             entities=(entity_name,),
             property=prop_name,
         ))
@@ -174,7 +180,11 @@ def _detect_specificity_escalation(con: sqlite3.Connection) -> list[LintWarning]
             warnings.append(LintWarning(
                 smell="specificity_escalation",
                 severity="warning",
-                description=f"{entity_name} '{prop_name}' has {len(unique_specs)} specificity levels — possible escalation war",
+                description=(
+                    f"{entity_name} '{prop_name}' has"
+                    f" {len(unique_specs)} specificity levels"
+                    " — possible escalation war"
+                ),
                 entities=(entity_name,),
                 property=prop_name,
             ))

--- a/src/umwelt/policy/projections.py
+++ b/src/umwelt/policy/projections.py
@@ -88,11 +88,11 @@ LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
 WHERE e.type_name = '{safe_type}'
 GROUP BY e.id, e.entity_id, e.classes, e.attributes;
 """
-    con.executescript(ddl)
+    con.execute(ddl)
 
 
 def _create_resolved_entities_view(con: sqlite3.Connection) -> None:
-    con.executescript("""
+    con.execute("""
 CREATE VIEW IF NOT EXISTS resolved_entities AS
 SELECT e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes,
     json_group_object(rp.property_name, rp.property_value) AS properties

--- a/src/umwelt/policy/projections.py
+++ b/src/umwelt/policy/projections.py
@@ -1,0 +1,102 @@
+# src/umwelt/policy/projections.py
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+
+def create_projection_views(con: sqlite3.Connection) -> None:
+    _create_resolved_entities_view(con)
+    type_props = _get_type_properties(con)
+    for entity_type, props in type_props.items():
+        _create_typed_view(con, entity_type, props)
+
+
+def create_compilation_meta(
+    con: sqlite3.Connection,
+    *,
+    source_world: str | None = None,
+    source_stylesheet: str | None = None,
+) -> None:
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS compilation_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+
+    entity_count = con.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+    resolved_count_row = con.execute("SELECT COUNT(*) FROM resolved_properties").fetchone()
+    resolved_count = resolved_count_row[0] if resolved_count_row else 0
+
+    meta = {
+        "compiled_at": datetime.now(timezone.utc).isoformat(),
+        "entity_count": str(entity_count),
+        "resolved_count": str(resolved_count),
+        "dialect": "sqlite",
+    }
+    if source_world:
+        meta["source_world"] = source_world
+    if source_stylesheet:
+        meta["source_stylesheet"] = source_stylesheet
+
+    for key, value in meta.items():
+        con.execute(
+            "INSERT OR REPLACE INTO compilation_meta (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+    con.commit()
+
+
+def _get_type_properties(con: sqlite3.Connection) -> dict[str, list[str]]:
+    rows = con.execute(
+        "SELECT entity_type, name FROM property_types ORDER BY entity_type, name"
+    ).fetchall()
+    result: dict[str, list[str]] = {}
+    for entity_type, prop_name in rows:
+        result.setdefault(entity_type, []).append(prop_name)
+    return result
+
+
+def _create_typed_view(
+    con: sqlite3.Connection,
+    entity_type: str,
+    properties: list[str],
+) -> None:
+    view_name = entity_type + "s"
+    safe_view = view_name.replace('"', '""')
+
+    pivot_cols = []
+    for prop in properties:
+        col_name = prop.replace("-", "_")
+        safe_col = col_name.replace('"', '""')
+        safe_prop = prop.replace("'", "''")
+        pivot_cols.append(
+            f'    MAX(CASE WHEN rp.property_name = \'{safe_prop}\' '
+            f'THEN rp.property_value END) AS "{safe_col}"'
+        )
+
+    pivot_sql = ",\n".join(pivot_cols)
+    safe_type = entity_type.replace("'", "''")
+
+    ddl = f"""
+CREATE VIEW IF NOT EXISTS "{safe_view}" AS
+SELECT e.entity_id AS name, e.classes, e.attributes,
+{pivot_sql}
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+WHERE e.type_name = '{safe_type}'
+GROUP BY e.id, e.entity_id, e.classes, e.attributes;
+"""
+    con.executescript(ddl)
+
+
+def _create_resolved_entities_view(con: sqlite3.Connection) -> None:
+    con.executescript("""
+CREATE VIEW IF NOT EXISTS resolved_entities AS
+SELECT e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes,
+    json_group_object(rp.property_name, rp.property_value) AS properties
+FROM entities e
+LEFT JOIN resolved_properties rp ON e.id = rp.entity_id
+GROUP BY e.id, e.taxon, e.type_name, e.entity_id, e.classes, e.attributes;
+""")

--- a/src/umwelt/policy/queries.py
+++ b/src/umwelt/policy/queries.py
@@ -1,0 +1,162 @@
+# src/umwelt/policy/queries.py
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from umwelt.policy.engine import Candidate, TraceResult
+
+
+def resolve_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+    property: str | None = None,
+) -> str | dict[str, str] | None:
+    entity_row = _find_entity(con, type=type, id=id)
+    if entity_row is None:
+        return None if property else {}
+
+    entity_pk = entity_row[0]
+
+    if property is not None:
+        row = con.execute(
+            "SELECT property_value FROM resolved_properties "
+            "WHERE entity_id = ? AND property_name = ?",
+            (entity_pk, property),
+        ).fetchone()
+        return row[0] if row else None
+
+    rows = con.execute(
+        "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+        (entity_pk,),
+    ).fetchall()
+    return {name: value for name, value in rows}
+
+
+def resolve_all_entities(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+) -> list[dict]:
+    entities = con.execute(
+        "SELECT id, entity_id, classes, attributes FROM entities WHERE type_name = ?",
+        (type,),
+    ).fetchall()
+
+    results = []
+    for eid, entity_id, classes_json, attrs_json in entities:
+        props_rows = con.execute(
+            "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+            (eid,),
+        ).fetchall()
+        props = {name: value for name, value in props_rows}
+        results.append({
+            "entity_id": entity_id,
+            "type_name": type,
+            "classes": json.loads(classes_json) if classes_json else [],
+            "attributes": json.loads(attrs_json) if attrs_json else {},
+            "properties": props,
+        })
+    return results
+
+
+def trace_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+    property: str,
+) -> TraceResult:
+    entity_row = _find_entity(con, type=type, id=id)
+    if entity_row is None:
+        return TraceResult(
+            entity=f"{type}#{id}",
+            property=property,
+            value=None,
+            candidates=(),
+        )
+
+    entity_pk = entity_row[0]
+
+    winner_row = con.execute(
+        "SELECT property_value FROM resolved_properties "
+        "WHERE entity_id = ? AND property_name = ?",
+        (entity_pk, property),
+    ).fetchone()
+    winning_value = winner_row[0] if winner_row else None
+
+    rows = con.execute(
+        "SELECT property_value, specificity, rule_index, source_file, source_line "
+        "FROM cascade_candidates "
+        "WHERE entity_id = ? AND property_name = ? "
+        "ORDER BY specificity DESC, rule_index DESC",
+        (entity_pk, property),
+    ).fetchall()
+
+    candidates = []
+    winner_marked = False
+    for value, spec, rule_idx, src_file, src_line in rows:
+        is_winner = (value == winning_value and not winner_marked)
+        if is_winner:
+            winner_marked = True
+        candidates.append(Candidate(
+            value=value,
+            specificity=spec,
+            rule_index=rule_idx,
+            source_file=src_file or "",
+            source_line=src_line or 0,
+            won=is_winner,
+        ))
+
+    return TraceResult(
+        entity=f"{type}#{id}",
+        property=property,
+        value=winning_value,
+        candidates=tuple(candidates),
+    )
+
+
+def select_entities(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str | None = None,
+    classes: list[str] | None = None,
+) -> list[dict]:
+    sql = "SELECT id, entity_id, type_name, classes, attributes FROM entities WHERE type_name = ?"
+    params: list = [type]
+
+    if id is not None:
+        sql += " AND entity_id = ?"
+        params.append(id)
+
+    rows = con.execute(sql, params).fetchall()
+
+    results = []
+    for eid, entity_id, type_name, classes_json, attrs_json in rows:
+        entity_classes = json.loads(classes_json) if classes_json else []
+        if classes and not all(c in entity_classes for c in classes):
+            continue
+        results.append({
+            "id": eid,
+            "entity_id": entity_id,
+            "type_name": type_name,
+            "classes": entity_classes,
+            "attributes": json.loads(attrs_json) if attrs_json else {},
+        })
+    return results
+
+
+def _find_entity(
+    con: sqlite3.Connection,
+    *,
+    type: str,
+    id: str,
+) -> tuple | None:
+    return con.execute(
+        "SELECT id, entity_id, type_name, classes, attributes FROM entities "
+        "WHERE type_name = ? AND entity_id = ?",
+        (type, id),
+    ).fetchone()

--- a/src/umwelt/policy/queries.py
+++ b/src/umwelt/policy/queries.py
@@ -81,14 +81,18 @@ def trace_entity(
     entity_pk = entity_row[0]
 
     winner_row = con.execute(
-        "SELECT property_value FROM resolved_properties "
+        "SELECT property_value, specificity, rule_index "
+        "FROM resolved_properties "
         "WHERE entity_id = ? AND property_name = ?",
         (entity_pk, property),
     ).fetchone()
     winning_value = winner_row[0] if winner_row else None
+    winning_spec = winner_row[1] if winner_row else None
+    winning_rule_idx = winner_row[2] if winner_row else None
 
     rows = con.execute(
-        "SELECT property_value, specificity, rule_index, source_file, source_line "
+        "SELECT property_value, specificity, rule_index, "
+        "source_file, source_line "
         "FROM cascade_candidates "
         "WHERE entity_id = ? AND property_name = ? "
         "ORDER BY specificity DESC, rule_index DESC",
@@ -98,7 +102,11 @@ def trace_entity(
     candidates = []
     winner_marked = False
     for value, spec, rule_idx, src_file, src_line in rows:
-        is_winner = (value == winning_value and not winner_marked)
+        is_winner = (
+            not winner_marked
+            and spec == winning_spec
+            and rule_idx == winning_rule_idx
+        )
         if is_winner:
             winner_marked = True
         candidates.append(Candidate(

--- a/src/umwelt/registry/taxa.py
+++ b/src/umwelt/registry/taxa.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from umwelt.errors import RegistryError
 
@@ -44,6 +44,9 @@ class RegistryState:
     matchers: dict[str, MatcherProtocol] = field(default_factory=dict)
     # Multiple validators per taxon allowed; they all run in registration order.
     validators: dict[str, list[ValidatorProtocol]] = field(default_factory=dict)
+    # Keyed by shorthand key (e.g. "tools"). Values are ShorthandDef instances;
+    # typed as Any to avoid a circular import with umwelt.world.shorthands.
+    shorthands: dict[str, Any] = field(default_factory=dict)
 
 
 _GLOBAL_STATE = RegistryState()

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -29,6 +29,7 @@ def register_sandbox_vocabulary() -> None:
     _register_audit()             # Task 10: S3* cross-cut observer
     _register_validators()
     _register_sugar()
+    _register_world_shorthands()
 
 
 def _register_vsm_aliases() -> None:
@@ -432,3 +433,13 @@ def _register_actor() -> None:
 
     register_property(taxon="actor", entity="inferencer", name="model", value_type=str, description="Model to use for this inferencer.")
     register_property(taxon="actor", entity="inferencer", name="temperature", value_type=float, description="Sampling temperature.")
+
+
+def _register_world_shorthands() -> None:
+    from umwelt.world.shorthands import register_shorthand
+
+    register_shorthand(key="tools", entity_type="tool", form="list")
+    register_shorthand(key="modes", entity_type="mode", form="list")
+    register_shorthand(key="principal", entity_type="principal", form="scalar")
+    register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
+    register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")

--- a/src/umwelt/world/__init__.py
+++ b/src/umwelt/world/__init__.py
@@ -1,0 +1,1 @@
+"""World state subpackage: parse and materialize .world.yml files."""

--- a/src/umwelt/world/__init__.py
+++ b/src/umwelt/world/__init__.py
@@ -1,1 +1,32 @@
 """World state subpackage: parse and materialize .world.yml files."""
+
+from __future__ import annotations
+
+from umwelt.world.materialize import materialize, render_yaml
+from umwelt.world.model import (
+    DeclaredEntity,
+    DetailLevel,
+    MaterializedMeta,
+    MaterializedWorld,
+    Projection,
+    Provenance,
+    WorldFile,
+    WorldWarning,
+)
+from umwelt.world.parser import load_world
+from umwelt.world.validate import validate_world
+
+__all__ = [
+    "DeclaredEntity",
+    "DetailLevel",
+    "MaterializedMeta",
+    "MaterializedWorld",
+    "Projection",
+    "Provenance",
+    "WorldFile",
+    "WorldWarning",
+    "load_world",
+    "materialize",
+    "render_yaml",
+    "validate_world",
+]

--- a/src/umwelt/world/materialize.py
+++ b/src/umwelt/world/materialize.py
@@ -1,0 +1,109 @@
+"""Materialization of a WorldFile into a detail-level-specific snapshot.
+
+The three detail levels are:
+  FULL    — all entities with all attributes
+  OUTLINE — all entities, attributes stripped
+  SUMMARY — no entities, only aggregate meta counts
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections import Counter
+from typing import Any
+
+import yaml
+
+from umwelt.world.model import (
+    DeclaredEntity,
+    DetailLevel,
+    MaterializedMeta,
+    MaterializedWorld,
+    WorldFile,
+)
+
+
+def materialize(
+    world: WorldFile,
+    level: DetailLevel = DetailLevel.FULL,
+) -> MaterializedWorld:
+    """Return a MaterializedWorld from *world* at the requested *level*."""
+    type_counts: dict[str, int] = dict(Counter(e.type for e in world.entities))
+
+    if level == DetailLevel.FULL:
+        entities = world.entities
+    elif level == DetailLevel.OUTLINE:
+        entities = tuple(
+            DeclaredEntity(
+                type=e.type,
+                id=e.id,
+                classes=e.classes,
+                attributes={},
+                parent=e.parent,
+                provenance=e.provenance,
+            )
+            for e in world.entities
+        )
+    else:  # SUMMARY
+        entities = ()
+
+    meta = MaterializedMeta(
+        source=world.source_path,
+        materialized_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        detail_level=level.value,
+        entity_count=len(world.entities),
+        type_counts=type_counts,
+    )
+
+    return MaterializedWorld(
+        meta=meta,
+        entities=entities,
+        projections=world.projections,
+        warnings=world.warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# YAML rendering
+# ---------------------------------------------------------------------------
+
+
+def _entity_to_dict(entity: DeclaredEntity) -> dict[str, Any]:
+    d: dict[str, Any] = {"type": entity.type, "id": entity.id}
+    if entity.classes:
+        d["classes"] = list(entity.classes)
+    if entity.attributes:
+        d["attributes"] = dict(entity.attributes)
+    if entity.parent is not None:
+        d["parent"] = entity.parent
+    d["provenance"] = entity.provenance.value
+    return d
+
+
+def _projection_to_dict(proj: Any) -> dict[str, Any]:
+    d: dict[str, Any] = {"type": proj.type, "id": proj.id}
+    if proj.attributes:
+        d["attributes"] = dict(proj.attributes)
+    return d
+
+
+def render_yaml(materialized: MaterializedWorld) -> str:
+    """Serialize *materialized* to a YAML string."""
+    meta = materialized.meta
+    meta_dict: dict[str, Any] = {
+        "source": meta.source,
+        "materialized_at": meta.materialized_at,
+        "detail_level": meta.detail_level,
+        "entity_count": meta.entity_count,
+        "type_counts": dict(meta.type_counts),
+    }
+
+    data: dict[str, Any] = {"meta": meta_dict}
+
+    if materialized.entities:
+        data["entities"] = [_entity_to_dict(e) for e in materialized.entities]
+
+    if materialized.projections:
+        data["projections"] = [_projection_to_dict(p) for p in materialized.projections]
+
+    return yaml.dump(data, default_flow_style=False, sort_keys=False)

--- a/src/umwelt/world/model.py
+++ b/src/umwelt/world/model.py
@@ -1,0 +1,78 @@
+"""Data model for the umwelt world state layer.
+
+All types are frozen dataclasses with tuple-typed sequence fields so they are
+safely shareable and hashable — consistent with the pattern in umwelt.ast.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class DetailLevel(Enum):
+    SUMMARY = "summary"
+    OUTLINE = "outline"
+    FULL = "full"
+
+
+class Provenance(Enum):
+    EXPLICIT = "explicit"
+    DISCOVERED = "discovered"
+    PROJECTED = "projected"
+    INCLUDED = "included"
+
+
+@dataclass(frozen=True)
+class WorldWarning:
+    message: str
+    key: str | None = None
+    line: int | None = None
+
+
+@dataclass(frozen=True)
+class DeclaredEntity:
+    type: str
+    id: str
+    classes: tuple[str, ...] = ()
+    attributes: dict[str, Any] = field(default_factory=dict)
+    parent: str | None = None
+    provenance: Provenance = Provenance.EXPLICIT
+
+
+@dataclass(frozen=True)
+class Projection:
+    type: str
+    id: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorldFile:
+    entities: tuple[DeclaredEntity, ...]
+    projections: tuple[Projection, ...]
+    warnings: tuple[WorldWarning, ...]
+    source_path: str | None = None
+    discover_raw: tuple[dict[str, Any], ...] = ()
+    overrides_raw: dict[str, Any] = field(default_factory=dict)
+    fixed_raw: dict[str, Any] = field(default_factory=dict)
+    include_raw: tuple[str, ...] = ()
+    exclude_raw: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MaterializedMeta:
+    source: str | None
+    materialized_at: str
+    detail_level: str
+    entity_count: int
+    type_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MaterializedWorld:
+    meta: MaterializedMeta
+    entities: tuple[DeclaredEntity, ...]
+    projections: tuple[Projection, ...]
+    warnings: tuple[WorldWarning, ...]

--- a/src/umwelt/world/parser.py
+++ b/src/umwelt/world/parser.py
@@ -1,0 +1,184 @@
+"""YAML parser for .world.yml files.
+
+Reads a world file, expands shorthand keys into ``DeclaredEntity`` instances,
+merges shorthand-derived entities with explicit ``entities:`` block entries
+(explicit wins on ``(type, id)`` collision), and stashes Phase 2-3 keys with
+warnings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from umwelt.errors import WorldParseError
+from umwelt.world.model import DeclaredEntity, Projection, Provenance, WorldFile, WorldWarning
+from umwelt.world.shorthands import get_shorthand
+
+_STRUCTURAL_KEYS = frozenset({"entities", "discover", "projections", "overrides", "fixed", "include", "exclude"})
+_RESERVED_KEYS = frozenset({"vars", "when", "version"})
+_PHASE2_KEYS = frozenset({"discover", "overrides", "fixed", "include", "exclude"})
+
+
+def load_world(path: str | Path) -> WorldFile:
+    """Parse a .world.yml file and return a :class:`WorldFile`.
+
+    Raises:
+        FileNotFoundError: if *path* does not exist.
+        WorldParseError: if the file has structural problems.
+    """
+    path = Path(path)
+    text = path.read_text()  # raises FileNotFoundError naturally
+    data = yaml.safe_load(text)
+    if data is None:
+        data = {}
+
+    warnings: list[WorldWarning] = []
+
+    # Expand shorthands first
+    shorthand_entities, sh_warnings = _expand_shorthands(data)
+    warnings.extend(sh_warnings)
+
+    # Parse explicit entities block
+    explicit_entities: list[DeclaredEntity] = []
+    if "entities" in data:
+        raw = data["entities"]
+        if isinstance(raw, list):
+            for item in raw:
+                explicit_entities.append(_parse_entity_dict(item))
+
+    # Merge: shorthand first, explicit overwrites on (type, id) collision
+    merged: dict[tuple[str, str], DeclaredEntity] = {}
+    for e in shorthand_entities:
+        merged[(e.type, e.id)] = e
+    for e in explicit_entities:
+        merged[(e.type, e.id)] = e
+
+    # Parse projections block
+    projections: list[Projection] = []
+    if "projections" in data:
+        raw = data["projections"]
+        if isinstance(raw, list):
+            projections = _parse_projections(raw)
+
+    # Handle Phase 2-3 keys: stash raw values + emit warnings
+    discover_raw: tuple[dict[str, Any], ...] = ()
+    overrides_raw: dict[str, Any] = {}
+    fixed_raw: dict[str, Any] = {}
+    include_raw: tuple[str, ...] = ()
+    exclude_raw: tuple[str, ...] = ()
+
+    for key in _PHASE2_KEYS:
+        if key in data:
+            warnings.append(WorldWarning(
+                message=f"'{key}' is not yet implemented (Phase 2-3)",
+                key=key,
+            ))
+            if key == "discover":
+                discover_raw = tuple(data[key]) if isinstance(data[key], list) else ()
+            elif key == "overrides":
+                overrides_raw = data[key] if isinstance(data[key], dict) else {}
+            elif key == "fixed":
+                fixed_raw = data[key] if isinstance(data[key], dict) else {}
+            elif key == "include":
+                include_raw = tuple(str(x) for x in data[key]) if isinstance(data[key], list) else ()
+            elif key == "exclude":
+                exclude_raw = tuple(str(x) for x in data[key]) if isinstance(data[key], list) else ()
+
+    # Warn on reserved and unknown keys
+    known_keys = _STRUCTURAL_KEYS | _RESERVED_KEYS
+    for key in data:
+        if key in _RESERVED_KEYS:
+            warnings.append(WorldWarning(message=f"'{key}' is a reserved key", key=key))
+        elif key not in known_keys and get_shorthand(key) is None:
+            warnings.append(WorldWarning(message=f"unknown key '{key}'", key=key))
+
+    return WorldFile(
+        entities=tuple(merged.values()),
+        projections=tuple(projections),
+        warnings=tuple(warnings),
+        source_path=str(path),
+        discover_raw=discover_raw,
+        overrides_raw=overrides_raw,
+        fixed_raw=fixed_raw,
+        include_raw=include_raw,
+        exclude_raw=exclude_raw,
+    )
+
+
+def _parse_entity_dict(d: dict[str, Any]) -> DeclaredEntity:
+    """Parse a single entity dict from the ``entities:`` block."""
+    if "type" not in d:
+        raise WorldParseError("entity missing required 'type' field")
+    if "id" not in d:
+        raise WorldParseError("entity missing required 'id' field")
+
+    classes = d.get("classes", ())
+    if isinstance(classes, list):
+        classes = tuple(str(c) for c in classes)
+
+    return DeclaredEntity(
+        type=str(d["type"]),
+        id=str(d["id"]),
+        classes=classes,
+        attributes=dict(d.get("attributes", {})),
+        parent=str(d["parent"]) if d.get("parent") is not None else None,
+        provenance=Provenance.EXPLICIT,
+    )
+
+
+def _expand_shorthands(
+    data: dict[str, Any],
+) -> tuple[list[DeclaredEntity], list[WorldWarning]]:
+    """Expand all registered shorthand keys found in *data*."""
+    entities: list[DeclaredEntity] = []
+    warnings: list[WorldWarning] = []
+
+    for key, value in data.items():
+        if key in _STRUCTURAL_KEYS or key in _RESERVED_KEYS:
+            continue
+        shorthand = get_shorthand(key)
+        if shorthand is None:
+            continue  # unknown keys are flagged separately
+
+        if shorthand.form == "list":
+            if isinstance(value, list):
+                for item in value:
+                    entities.append(DeclaredEntity(
+                        type=shorthand.entity_type,
+                        id=str(item),
+                        provenance=Provenance.EXPLICIT,
+                    ))
+        elif shorthand.form == "scalar":
+            entities.append(DeclaredEntity(
+                type=shorthand.entity_type,
+                id=str(value),
+                provenance=Provenance.EXPLICIT,
+            ))
+        elif shorthand.form == "map" and isinstance(value, dict):
+                for k, v in value.items():
+                    attrs: dict[str, Any] = {}
+                    if shorthand.attribute_key is not None:
+                        attrs[shorthand.attribute_key] = str(v)
+                    entities.append(DeclaredEntity(
+                        type=shorthand.entity_type,
+                        id=str(k),
+                        attributes=attrs,
+                        provenance=Provenance.EXPLICIT,
+                    ))
+
+    return entities, warnings
+
+
+def _parse_projections(raw: list[dict[str, Any]]) -> list[Projection]:
+    """Parse the ``projections:`` list into :class:`Projection` instances."""
+    projections: list[Projection] = []
+    for d in raw:
+        projections.append(Projection(
+            type=str(d.get("type", "")),
+            id=str(d.get("id", "")),
+            attributes=dict(d.get("attributes", {})),
+        ))
+    return projections

--- a/src/umwelt/world/parser.py
+++ b/src/umwelt/world/parser.py
@@ -31,7 +31,10 @@ def load_world(path: str | Path) -> WorldFile:
     """
     path = Path(path)
     text = path.read_text()  # raises FileNotFoundError naturally
-    data = yaml.safe_load(text)
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorldParseError(f"invalid YAML: {exc}") from exc
     if data is None:
         data = {}
 
@@ -158,16 +161,16 @@ def _expand_shorthands(
                 provenance=Provenance.EXPLICIT,
             ))
         elif shorthand.form == "map" and isinstance(value, dict):
-                for k, v in value.items():
-                    attrs: dict[str, Any] = {}
-                    if shorthand.attribute_key is not None:
-                        attrs[shorthand.attribute_key] = str(v)
-                    entities.append(DeclaredEntity(
-                        type=shorthand.entity_type,
-                        id=str(k),
-                        attributes=attrs,
-                        provenance=Provenance.EXPLICIT,
-                    ))
+            for k, v in value.items():
+                attrs: dict[str, Any] = {}
+                if shorthand.attribute_key is not None:
+                    attrs[shorthand.attribute_key] = str(v)
+                entities.append(DeclaredEntity(
+                    type=shorthand.entity_type,
+                    id=str(k),
+                    attributes=attrs,
+                    provenance=Provenance.EXPLICIT,
+                ))
 
     return entities, warnings
 

--- a/src/umwelt/world/shorthands.py
+++ b/src/umwelt/world/shorthands.py
@@ -1,0 +1,46 @@
+"""Shorthand registry for the umwelt world state layer.
+
+Vocabulary consumers register top-level YAML keys here so the parser can
+expand them into entity declarations.  E.g. ``tools: [Read, Edit]`` expands
+to two ``tool`` entities when ``tools`` is registered with ``form="list"``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from umwelt.registry.taxa import _current_state
+
+
+@dataclass(frozen=True)
+class ShorthandDef:
+    """Definition of a top-level YAML shorthand key."""
+
+    key: str
+    entity_type: str
+    form: Literal["list", "scalar", "map"]
+    attribute_key: str | None = None
+
+
+def register_shorthand(
+    *,
+    key: str,
+    entity_type: str,
+    form: Literal["list", "scalar", "map"],
+    attribute_key: str | None = None,
+) -> None:
+    """Register a shorthand key in the active registry scope."""
+    state = _current_state()
+    state.shorthands[key] = ShorthandDef(
+        key=key,
+        entity_type=entity_type,
+        form=form,
+        attribute_key=attribute_key,
+    )
+
+
+def get_shorthand(key: str) -> ShorthandDef | None:
+    """Return the ShorthandDef for *key*, or None if not registered."""
+    state = _current_state()
+    return state.shorthands.get(key)

--- a/src/umwelt/world/validate.py
+++ b/src/umwelt/world/validate.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from umwelt.registry.entities import resolve_entity_type
+from umwelt.world.model import DeclaredEntity, WorldFile, WorldWarning
+
+
+def validate_world(world: WorldFile) -> WorldFile:
+    """Validate entity types against the registered vocabulary.
+
+    Returns a new WorldFile with validation warnings appended.
+    Unknown entity types produce warnings, not errors (forward compat).
+    """
+    new_warnings: list[WorldWarning] = []
+    for entity in world.entities:
+        new_warnings.extend(_validate_entity(entity))
+    return WorldFile(
+        entities=world.entities,
+        projections=world.projections,
+        warnings=world.warnings + tuple(new_warnings),
+        source_path=world.source_path,
+        discover_raw=world.discover_raw,
+        overrides_raw=world.overrides_raw,
+        fixed_raw=world.fixed_raw,
+        include_raw=world.include_raw,
+        exclude_raw=world.exclude_raw,
+    )
+
+
+def _validate_entity(entity: DeclaredEntity) -> list[WorldWarning]:
+    """Check one entity against the registry."""
+    warnings: list[WorldWarning] = []
+    taxa = resolve_entity_type(entity.type)
+    if not taxa:
+        warnings.append(WorldWarning(
+            message=f"unknown entity type '{entity.type}' (not in registered vocabulary)",
+            key=entity.type,
+        ))
+    return warnings

--- a/tests/policy/conftest.py
+++ b/tests/policy/conftest.py
@@ -1,0 +1,92 @@
+# tests/policy/conftest.py
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+
+
+@pytest.fixture
+def dialect():
+    return SQLiteDialect()
+
+
+@pytest.fixture
+def policy_db(dialect):
+    """In-memory SQLite with schema, entities, cascade_candidates, and resolution views.
+
+    Entities:
+      - tool#Read (id=1)
+      - tool#Edit (id=2, classes=["edit"])
+      - tool#Bash (id=3, classes=["dangerous", "shell"])
+      - mode#implement (id=4)
+      - mode#review (id=5)
+
+    Cascade candidates (rules):
+      Rule 0: tool { allow: true; max-level: 5; }         specificity (0,0,0,1,0,0,0,0)
+      Rule 1: tool.dangerous { max-level: 3; }             specificity (0,0,0,1,0,1,0,0)
+      Rule 2: tool#Bash { risk-note: "Prefer structured"; } specificity (0,0,1,1,0,0,0,0)
+      Rule 3: mode { allow: true; }                        specificity (0,0,0,1,0,0,0,0)
+      Rule 4: tool.dangerous { allow: false; }             specificity (0,0,0,1,0,1,0,0) [same spec as rule 1, higher index]
+    """
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Edit", json.dumps(["edit"]), json.dumps({"name": "Edit"}), None, 0),
+        (3, "capability", "tool", "Bash", json.dumps(["dangerous", "shell"]), json.dumps({"name": "Bash"}), None, 0),
+        (4, "state", "mode", "implement", None, json.dumps({"name": "implement"}), None, 0),
+        (5, "state", "mode", "review", None, json.dumps({"name": "review"}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+
+    # Self-closure entries
+    con.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure (ancestor_id, descendant_id, depth)
+        SELECT id, id, 0 FROM entities;
+    """)
+
+    spec_tool = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+    spec_tool_class = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+    spec_tool_id = '["00000","00000","00001","00001","00000","00000","00000","00000"]'
+    spec_mode = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+    candidates = [
+        # Rule 0: tool { allow: true; max-level: 5; }
+        (1, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (2, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (3, "allow", "true", "exact", spec_tool, 0, "policy.umw", 1),
+        (1, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        (2, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        (3, "max-level", "5", "<=", spec_tool, 0, "policy.umw", 1),
+        # Rule 1: tool.dangerous { max-level: 3; }
+        (3, "max-level", "3", "<=", spec_tool_class, 1, "policy.umw", 3),
+        # Rule 2: tool#Bash { risk-note: "Prefer structured"; }
+        (3, "risk-note", "Prefer structured", "exact", spec_tool_id, 2, "policy.umw", 5),
+        # Rule 3: mode { allow: true; }
+        (4, "allow", "true", "exact", spec_mode, 3, "policy.umw", 7),
+        (5, "allow", "true", "exact", spec_mode, 3, "policy.umw", 7),
+        # Rule 4: tool.dangerous { allow: false; } — same specificity as rule 0 for Bash, higher index
+        (3, "allow", "false", "exact", spec_tool_class, 4, "policy.umw", 9),
+    ]
+    con.executemany(
+        "INSERT INTO cascade_candidates "
+        "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        candidates,
+    )
+    con.commit()
+
+    create_resolution_views(con, dialect)
+    return con

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -73,10 +73,6 @@ class TestDataModels:
             c.value = "5"
 
 
-import json
-import sqlite3
-import tempfile
-from pathlib import Path
 
 from umwelt.errors import PolicyDenied
 from umwelt.policy.engine import PolicyEngine

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -1,0 +1,73 @@
+import pytest
+from umwelt.errors import PolicyDenied, PolicyError, PolicyCompilationError, UmweltError
+
+
+class TestErrorHierarchy:
+    def test_policy_error_is_umwelt_error(self):
+        assert issubclass(PolicyError, UmweltError)
+
+    def test_policy_denied_is_policy_error(self):
+        assert issubclass(PolicyDenied, PolicyError)
+
+    def test_policy_compilation_error_is_policy_error(self):
+        assert issubclass(PolicyCompilationError, PolicyError)
+
+    def test_policy_denied_fields(self):
+        exc = PolicyDenied(
+            entity="tool#Bash",
+            property="editable",
+            expected="true",
+            actual="false",
+        )
+        assert exc.entity == "tool#Bash"
+        assert exc.property == "editable"
+        assert exc.expected == "true"
+        assert exc.actual == "false"
+        assert "tool#Bash" in str(exc)
+        assert "editable" in str(exc)
+
+
+class TestDataModels:
+    def test_lint_warning_construction(self):
+        from umwelt.policy import LintWarning
+        w = LintWarning(
+            smell="narrow_win",
+            severity="warning",
+            description="Winner won by 1 specificity point",
+            entities=("tool#Bash",),
+            property="max-level",
+        )
+        assert w.smell == "narrow_win"
+        assert w.severity == "warning"
+
+    def test_trace_result_construction(self):
+        from umwelt.policy import TraceResult, Candidate
+        c = Candidate(
+            value="3",
+            specificity="00001,00000,00001",
+            rule_index=2,
+            source_file="policy.umw",
+            source_line=10,
+            won=True,
+        )
+        tr = TraceResult(
+            entity="tool#Bash",
+            property="max-level",
+            value="3",
+            candidates=(c,),
+        )
+        assert tr.value == "3"
+        assert len(tr.candidates) == 1
+        assert tr.candidates[0].won is True
+
+    def test_lint_warning_frozen(self):
+        from umwelt.policy import LintWarning
+        w = LintWarning(smell="narrow_win", severity="warning", description="test", entities=(), property=None)
+        with pytest.raises(AttributeError):
+            w.smell = "other"
+
+    def test_candidate_frozen(self):
+        from umwelt.policy import Candidate
+        c = Candidate(value="3", specificity="x", rule_index=0, source_file="", source_line=0, won=True)
+        with pytest.raises(AttributeError):
+            c.value = "5"

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -71,3 +71,215 @@ class TestDataModels:
         c = Candidate(value="3", specificity="x", rule_index=0, source_file="", source_line=0, won=True)
         with pytest.raises(AttributeError):
             c.value = "5"
+
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from umwelt.errors import PolicyDenied
+from umwelt.policy.engine import PolicyEngine
+
+
+@pytest.fixture
+def sample_world_yml(tmp_path):
+    p = tmp_path / "test.world.yml"
+    p.write_text("""
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+  - type: mode
+    id: implement
+""")
+    return p
+
+
+@pytest.fixture
+def sample_stylesheet(tmp_path):
+    p = tmp_path / "policy.umw"
+    p.write_text("""
+tool { allow: true; max-level: 5; }
+tool.dangerous { max-level: 3; allow: false; }
+mode { allow: true; }
+""")
+    return p
+
+
+class TestFromFiles:
+    def test_creates_engine(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine is not None
+
+    def test_resolve_after_from_files(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        val = engine.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_resolve_all_properties(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        props = engine.resolve(type="tool", id="Bash")
+        assert isinstance(props, dict)
+        assert "allow" in props
+        assert "max-level" in props
+
+
+class TestFromDb:
+    def test_roundtrip_save_load(self, sample_world_yml, sample_stylesheet, tmp_path):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        db_path = tmp_path / "policy.db"
+        engine1.save(str(db_path))
+
+        engine2 = PolicyEngine.from_db(str(db_path))
+        val = engine2.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_from_db_is_cow(self, sample_world_yml, sample_stylesheet, tmp_path):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        db_path = tmp_path / "policy.db"
+        engine1.save(str(db_path))
+
+        engine2 = PolicyEngine.from_db(str(db_path))
+        assert engine2.resolve(type="tool", id="Read", property="allow") == "true"
+
+
+class TestProgrammatic:
+    def test_programmatic_build(self):
+        engine = PolicyEngine()
+        engine.add_entities([
+            {"type": "tool", "id": "Read"},
+            {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+        ])
+        engine.add_stylesheet("tool { allow: true; }\ntool.dangerous { allow: false; }")
+
+        val = engine.resolve(type="tool", id="Read", property="allow")
+        assert val == "true"
+
+        val = engine.resolve(type="tool", id="Bash", property="allow")
+        assert val == "false"
+
+
+class TestExtend:
+    def test_extend_produces_new_engine(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        assert engine2 is not engine1
+
+    def test_extend_preserves_original(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        modes = engine1.resolve_all(type="mode")
+        assert len(modes) == 1
+
+    def test_extend_adds_entities(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            entities=[{"type": "mode", "id": "review"}],
+        )
+        modes = engine2.resolve_all(type="mode")
+        assert len(modes) == 2
+
+    def test_extend_with_stylesheet(self, sample_world_yml, sample_stylesheet):
+        engine1 = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine2 = engine1.extend(
+            stylesheet="tool#Read { visible: false; }",
+        )
+        val = engine2.resolve(type="tool", id="Read", property="visible")
+        assert val == "false"
+
+
+class TestConvenience:
+    def test_check_true(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine.check(type="tool", id="Read", allow="true") is True
+
+    def test_check_false(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        assert engine.check(type="tool", id="Bash", allow="true") is False
+
+    def test_require_passes(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        engine.require(type="tool", id="Read", allow="true")
+
+    def test_require_raises_policy_denied(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        with pytest.raises(PolicyDenied) as exc_info:
+            engine.require(type="tool", id="Bash", allow="true")
+        assert exc_info.value.actual == "false"
+
+
+class TestTrace:
+    def test_trace_returns_candidates(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        result = engine.trace(type="tool", id="Bash", property="allow")
+        assert result.value is not None
+        assert len(result.candidates) >= 1
+
+
+class TestLint:
+    def test_lint_returns_list(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        warnings = engine.lint()
+        assert isinstance(warnings, list)
+
+
+class TestExecute:
+    def test_raw_sql(self, sample_world_yml, sample_stylesheet):
+        engine = PolicyEngine.from_files(
+            world=sample_world_yml,
+            stylesheet=sample_stylesheet,
+        )
+        rows = engine.execute("SELECT COUNT(*) FROM entities")
+        assert rows[0][0] >= 3

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -1,5 +1,7 @@
 import pytest
-from umwelt.errors import PolicyDenied, PolicyError, PolicyCompilationError, UmweltError
+
+from umwelt.errors import PolicyCompilationError, PolicyDenied, PolicyError, UmweltError
+from umwelt.policy.engine import PolicyEngine
 
 
 class TestErrorHierarchy:
@@ -41,7 +43,7 @@ class TestDataModels:
         assert w.severity == "warning"
 
     def test_trace_result_construction(self):
-        from umwelt.policy import TraceResult, Candidate
+        from umwelt.policy import Candidate, TraceResult
         c = Candidate(
             value="3",
             specificity="00001,00000,00001",
@@ -71,11 +73,6 @@ class TestDataModels:
         c = Candidate(value="3", specificity="x", rule_index=0, source_file="", source_line=0, won=True)
         with pytest.raises(AttributeError):
             c.value = "5"
-
-
-
-from umwelt.errors import PolicyDenied
-from umwelt.policy.engine import PolicyEngine
 
 
 @pytest.fixture

--- a/tests/policy/test_integration.py
+++ b/tests/policy/test_integration.py
@@ -1,0 +1,135 @@
+# tests/policy/test_integration.py
+import pytest
+import yaml
+
+from umwelt.errors import PolicyDenied
+from umwelt.policy import PolicyEngine
+
+
+def test_full_pipeline(tmp_path):
+    """End-to-end: from_files -> resolve -> trace -> lint -> save -> from_db -> resolve."""
+    world_path = tmp_path / "delegate.world.yml"
+    world_path.write_text("""
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Edit
+    classes: [edit]
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell]
+  - type: mode
+    id: implement
+""")
+    style_path = tmp_path / "policy.umw"
+    style_path.write_text("""
+tool { allow: true; max-level: 5; }
+tool.dangerous { max-level: 3; allow: false; }
+tool#Bash { risk-note: Prefer structured tools; }
+mode { allow: true; }
+""")
+
+    # Build from files
+    engine = PolicyEngine.from_files(world=world_path, stylesheet=style_path)
+
+    # Resolve
+    assert engine.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine.resolve(type="tool", id="Bash", property="allow") == "false"
+    assert engine.resolve(type="tool", id="Bash", property="max-level") == "3"
+
+    bash_props = engine.resolve(type="tool", id="Bash")
+    assert isinstance(bash_props, dict)
+    assert "risk-note" in bash_props
+
+    # Resolve all
+    tools = engine.resolve_all(type="tool")
+    assert len(tools) == 3
+
+    # Trace
+    trace = engine.trace(type="tool", id="Bash", property="allow")
+    assert trace.value == "false"
+    assert len(trace.candidates) >= 2
+
+    # Lint
+    warnings = engine.lint()
+    assert isinstance(warnings, list)
+
+    # Check / require
+    assert engine.check(type="tool", id="Read", allow="true") is True
+    assert engine.check(type="tool", id="Bash", allow="true") is False
+
+    with pytest.raises(PolicyDenied):
+        engine.require(type="tool", id="Bash", allow="true")
+
+    # Save and reload
+    db_path = tmp_path / "policy.db"
+    engine.save(str(db_path))
+    assert db_path.exists()
+
+    engine2 = PolicyEngine.from_db(str(db_path))
+    assert engine2.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine2.resolve(type="tool", id="Bash", property="allow") == "false"
+
+    # Raw SQL
+    rows = engine2.execute("SELECT COUNT(*) FROM entities")
+    assert rows[0][0] >= 4
+
+
+def test_extend_cow_semantics(tmp_path):
+    """Extend produces a new engine; original is unchanged."""
+    world_path = tmp_path / "w.world.yml"
+    world_path.write_text("entities:\n  - type: tool\n    id: Read\n")
+    style_path = tmp_path / "p.umw"
+    style_path.write_text("tool { allow: true; }\n")
+
+    engine1 = PolicyEngine.from_files(world=world_path, stylesheet=style_path)
+    engine2 = engine1.extend(
+        entities=[{"type": "tool", "id": "Bash", "classes": ["dangerous"]}],
+        stylesheet="tool.dangerous { allow: false; }",
+    )
+
+    # Original unchanged
+    tools1 = engine1.resolve_all(type="tool")
+    assert len(tools1) == 1
+
+    # Extended has both
+    tools2 = engine2.resolve_all(type="tool")
+    assert len(tools2) == 2
+    assert engine2.resolve(type="tool", id="Bash", property="allow") == "false"
+
+
+def test_programmatic_construction():
+    """Build engine entirely in code."""
+    engine = PolicyEngine()
+    engine.add_entities([
+        {"type": "tool", "id": "Read"},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    engine.add_stylesheet("tool { allow: true; }\ntool.dangerous { allow: false; }")
+
+    assert engine.resolve(type="tool", id="Read", property="allow") == "true"
+    assert engine.resolve(type="tool", id="Bash", property="allow") == "false"
+
+
+def test_to_files_roundtrip(tmp_path):
+    """Export to files and verify they contain expected data."""
+    engine = PolicyEngine()
+    engine.add_entities([
+        {"type": "tool", "id": "Read"},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    engine.add_stylesheet("tool { allow: true; }")
+
+    world_out = tmp_path / "out.world.yml"
+    style_out = tmp_path / "out.umw"
+    engine.to_files(world=world_out, stylesheet=style_out)
+
+    assert world_out.exists()
+    assert style_out.exists()
+
+    world_data = yaml.safe_load(world_out.read_text())
+    assert len(world_data["entities"]) >= 2
+    ids = {e["id"] for e in world_data["entities"]}
+    assert "Read" in ids
+    assert "Bash" in ids

--- a/tests/policy/test_lint.py
+++ b/tests/policy/test_lint.py
@@ -7,7 +7,6 @@ import pytest
 from umwelt.compilers.sql.dialects import SQLiteDialect
 from umwelt.compilers.sql.resolution import create_resolution_views
 from umwelt.compilers.sql.schema import create_schema
-from umwelt.policy.engine import LintWarning
 from umwelt.policy.lint import run_lint
 
 

--- a/tests/policy/test_lint.py
+++ b/tests/policy/test_lint.py
@@ -1,0 +1,180 @@
+# tests/policy/test_lint.py
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.policy.engine import LintWarning
+from umwelt.policy.lint import run_lint
+
+
+@pytest.fixture
+def lint_db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Bash", json.dumps(["dangerous"]), json.dumps({"name": "Bash"}), None, 0),
+        (3, "capability", "tool", "Orphan", None, json.dumps({"name": "Orphan"}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+    con.executescript("""
+        DELETE FROM entity_closure;
+        INSERT INTO entity_closure (ancestor_id, descendant_id, depth)
+        SELECT id, id, 0 FROM entities;
+    """)
+    return con
+
+
+class TestNarrowWin:
+    def test_detects_narrow_win(self, lint_db):
+        dialect = SQLiteDialect()
+        spec_low = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec_high = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+
+        candidates = [
+            (2, "allow", "true", "exact", spec_low, 0, "a.umw", 1),
+            (2, "allow", "false", "exact", spec_high, 1, "a.umw", 3),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        narrow = [w for w in warnings if w.smell == "narrow_win"]
+        assert len(narrow) >= 1
+
+
+class TestShadowedRule:
+    def test_detects_shadowed_rule(self, lint_db):
+        dialect = SQLiteDialect()
+        spec_low = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec_high = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+
+        candidates = [
+            (2, "allow", "true", "exact", spec_low, 0, "a.umw", 5),
+            (2, "allow", "false", "exact", spec_high, 1, "a.umw", 10),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        shadowed = [w for w in warnings if w.smell == "shadowed_rule"]
+        assert len(shadowed) >= 1
+
+
+class TestUncoveredEntity:
+    def test_detects_uncovered_entity(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        candidates = [
+            (1, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        uncovered = [w for w in warnings if w.smell == "uncovered_entity"]
+        assert len(uncovered) >= 1
+        assert any("Orphan" in w.description for w in uncovered)
+
+
+class TestConflictingIntent:
+    def test_detects_conflicting_intent(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        candidates = [
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "false", "exact", spec, 1, "a.umw", 5),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        conflicting = [w for w in warnings if w.smell == "conflicting_intent"]
+        assert len(conflicting) >= 1
+
+
+class TestSpecificityEscalation:
+    def test_detects_escalation(self, lint_db):
+        dialect = SQLiteDialect()
+        spec1 = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        spec2 = '["00000","00000","00000","00001","00000","00001","00000","00000"]'
+        spec3 = '["00000","00000","00001","00001","00000","00001","00000","00000"]'
+
+        candidates = [
+            (2, "max-level", "5", "<=", spec1, 0, "a.umw", 1),
+            (2, "max-level", "3", "<=", spec2, 1, "a.umw", 3),
+            (2, "max-level", "1", "<=", spec3, 2, "a.umw", 5),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        escalation = [w for w in warnings if w.smell == "specificity_escalation"]
+        assert len(escalation) >= 1
+
+
+class TestNoSmells:
+    def test_clean_db_no_warnings(self, lint_db):
+        dialect = SQLiteDialect()
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+
+        candidates = [
+            (1, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (2, "allow", "true", "exact", spec, 0, "a.umw", 1),
+            (3, "allow", "true", "exact", spec, 0, "a.umw", 1),
+        ]
+        lint_db.executemany(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            candidates,
+        )
+        lint_db.commit()
+        create_resolution_views(lint_db, dialect)
+
+        warnings = run_lint(lint_db)
+        serious = [w for w in warnings if w.severity == "warning"]
+        assert len(serious) == 0

--- a/tests/policy/test_populate_world.py
+++ b/tests/policy/test_populate_world.py
@@ -6,7 +6,7 @@ import pytest
 from umwelt.compilers.sql.dialects import SQLiteDialect
 from umwelt.compilers.sql.populate import populate_from_world
 from umwelt.compilers.sql.schema import create_schema
-from umwelt.world.model import DeclaredEntity, Projection, Provenance, WorldFile
+from umwelt.world.model import DeclaredEntity, Projection, WorldFile
 
 
 @pytest.fixture

--- a/tests/policy/test_populate_world.py
+++ b/tests/policy/test_populate_world.py
@@ -1,0 +1,115 @@
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.populate import populate_from_world
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.world.model import DeclaredEntity, Projection, Provenance, WorldFile
+
+
+@pytest.fixture
+def empty_db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    yield con
+    con.close()
+
+
+class TestPopulateFromWorld:
+    def test_basic_entity_insertion(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read"),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT type_name, entity_id FROM entities WHERE entity_id = 'Read'"
+        ).fetchone()
+        assert row == ("tool", "Read")
+
+    def test_classes_stored_as_json(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Bash", classes=("dangerous", "shell")),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT classes FROM entities WHERE entity_id = 'Bash'"
+        ).fetchone()
+        assert json.loads(row[0]) == ["dangerous", "shell"]
+
+    def test_attributes_stored_as_json(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read", attributes={"description": "read files"}),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT attributes FROM entities WHERE entity_id = 'Read'"
+        ).fetchone()
+        assert json.loads(row[0])["description"] == "read files"
+
+    def test_multiple_entities(self, empty_db):
+        wf = WorldFile(
+            entities=(
+                DeclaredEntity(type="tool", id="Read"),
+                DeclaredEntity(type="tool", id="Edit"),
+                DeclaredEntity(type="mode", id="implement"),
+            ),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        count = empty_db.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+        assert count == 3
+
+    def test_projection_inserted_as_entity(self, empty_db):
+        wf = WorldFile(
+            entities=(),
+            projections=(Projection(type="dir", id="node_modules", attributes={"path": "node_modules/"}),),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        row = empty_db.execute(
+            "SELECT type_name, entity_id FROM entities WHERE entity_id = 'node_modules'"
+        ).fetchone()
+        assert row == ("dir", "node_modules")
+
+    def test_world_entity_wins_on_collision(self, empty_db):
+        # Pre-insert a matcher-discovered entity
+        empty_db.execute(
+            "INSERT INTO entities (taxon, type_name, entity_id, classes, attributes, depth) "
+            "VALUES ('capability', 'tool', 'Bash', NULL, NULL, 0)"
+        )
+        empty_db.commit()
+
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Bash", classes=("dangerous",)),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+
+        rows = empty_db.execute(
+            "SELECT classes FROM entities WHERE entity_id = 'Bash'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert json.loads(rows[0][0]) == ["dangerous"]
+
+    def test_closure_table_rebuilt(self, empty_db):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read"),),
+            projections=(),
+            warnings=(),
+        )
+        populate_from_world(empty_db, wf)
+        closure = empty_db.execute(
+            "SELECT COUNT(*) FROM entity_closure"
+        ).fetchone()[0]
+        assert closure >= 1  # at least self-closure

--- a/tests/policy/test_projections.py
+++ b/tests/policy/test_projections.py
@@ -1,0 +1,122 @@
+# tests/policy/test_projections.py
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import create_schema
+from umwelt.policy.projections import create_projection_views, create_compilation_meta
+
+
+@pytest.fixture
+def projection_db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+
+    prop_types = [
+        ("capability", "tool", "allow", "str", "exact", ""),
+        ("capability", "tool", "visible", "str", "exact", ""),
+        ("capability", "tool", "max-level", "int", "<=", ""),
+        ("state", "mode", "writable", "str", "exact", ""),
+        ("state", "mode", "strategy", "str", "exact", ""),
+    ]
+    con.executemany(
+        "INSERT INTO property_types (taxon, entity_type, name, value_type, comparison, description) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        prop_types,
+    )
+
+    entities = [
+        (1, "capability", "tool", "Read", None, json.dumps({"name": "Read"}), None, 0),
+        (2, "capability", "tool", "Bash", json.dumps(["dangerous"]), json.dumps({"name": "Bash"}), None, 0),
+        (3, "state", "mode", "implement", None, json.dumps({}), None, 0),
+    ]
+    con.executemany(
+        "INSERT INTO entities (id, taxon, type_name, entity_id, classes, attributes, parent_id, depth) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entities,
+    )
+
+    spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+    candidates = [
+        (1, "allow", "true", "exact", spec, 0, "", 0),
+        (2, "allow", "true", "exact", spec, 0, "", 0),
+        (2, "max-level", "3", "<=", spec, 0, "", 0),
+        (3, "writable", "src/", "exact", spec, 0, "", 0),
+    ]
+    con.executemany(
+        "INSERT INTO cascade_candidates "
+        "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        candidates,
+    )
+    con.commit()
+    create_resolution_views(con, dialect)
+    return con
+
+
+class TestProjectionViews:
+    def test_creates_tools_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM tools").fetchall()
+        assert len(rows) == 2
+
+    def test_tools_view_has_pivoted_columns(self, projection_db):
+        create_projection_views(projection_db)
+        row = projection_db.execute(
+            "SELECT name, allow, max_level FROM tools WHERE name = 'Bash'"
+        ).fetchone()
+        assert row is not None
+        assert row[1] == "true"
+        assert row[2] == "3"
+
+    def test_creates_modes_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM modes").fetchall()
+        assert len(rows) == 1
+
+    def test_modes_view_columns(self, projection_db):
+        create_projection_views(projection_db)
+        row = projection_db.execute(
+            "SELECT name, writable FROM modes WHERE name = 'implement'"
+        ).fetchone()
+        assert row is not None
+        assert row[1] == "src/"
+
+    def test_creates_resolved_entities_view(self, projection_db):
+        create_projection_views(projection_db)
+        rows = projection_db.execute("SELECT * FROM resolved_entities").fetchall()
+        assert len(rows) >= 2
+
+    def test_no_property_types_still_works(self):
+        dialect = SQLiteDialect()
+        con = sqlite3.connect(":memory:")
+        con.executescript(create_schema(dialect))
+        create_resolution_views(con, dialect)
+        create_projection_views(con)
+
+
+class TestCompilationMeta:
+    def test_creates_meta_table(self, projection_db):
+        create_compilation_meta(projection_db, source_world="test.world.yml", source_stylesheet="policy.umw")
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'source_world'"
+        ).fetchone()
+        assert row[0] == "test.world.yml"
+
+    def test_meta_has_entity_count(self, projection_db):
+        create_compilation_meta(projection_db)
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'entity_count'"
+        ).fetchone()
+        assert int(row[0]) == 3
+
+    def test_meta_has_compiled_at(self, projection_db):
+        create_compilation_meta(projection_db)
+        row = projection_db.execute(
+            "SELECT value FROM compilation_meta WHERE key = 'compiled_at'"
+        ).fetchone()
+        assert row[0]  # non-empty ISO timestamp

--- a/tests/policy/test_queries.py
+++ b/tests/policy/test_queries.py
@@ -1,5 +1,4 @@
 # tests/policy/test_queries.py
-import pytest
 
 from umwelt.policy.queries import resolve_entity, resolve_all_entities, trace_entity, select_entities
 

--- a/tests/policy/test_queries.py
+++ b/tests/policy/test_queries.py
@@ -1,0 +1,104 @@
+# tests/policy/test_queries.py
+import pytest
+
+from umwelt.policy.queries import resolve_entity, resolve_all_entities, trace_entity, select_entities
+
+
+class TestResolveEntity:
+    def test_resolve_single_property(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="Read", property="allow")
+        assert val == "true"
+
+    def test_resolve_all_properties(self, policy_db):
+        props = resolve_entity(policy_db, type="tool", id="Bash")
+        assert props["risk-note"] == "Prefer structured"
+        assert props["allow"] == "false"  # rule 4 wins (higher specificity class selector)
+
+    def test_resolve_cap_comparison(self, policy_db):
+        props = resolve_entity(policy_db, type="tool", id="Bash")
+        assert props["max-level"] == "3"  # cap: MIN wins
+
+    def test_resolve_nonexistent_entity(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="NonExistent", property="allow")
+        assert val is None
+
+    def test_resolve_nonexistent_property(self, policy_db):
+        val = resolve_entity(policy_db, type="tool", id="Read", property="nonexistent")
+        assert val is None
+
+    def test_resolve_mode_entity(self, policy_db):
+        val = resolve_entity(policy_db, type="mode", id="implement", property="allow")
+        assert val == "true"
+
+
+class TestResolveAll:
+    def test_resolve_all_tools(self, policy_db):
+        results = resolve_all_entities(policy_db, type="tool")
+        assert len(results) == 3
+        ids = {r["entity_id"] for r in results}
+        assert ids == {"Read", "Edit", "Bash"}
+
+    def test_resolve_all_includes_properties(self, policy_db):
+        results = resolve_all_entities(policy_db, type="tool")
+        bash = next(r for r in results if r["entity_id"] == "Bash")
+        assert bash["properties"]["allow"] == "false"
+        assert bash["properties"]["max-level"] == "3"
+
+    def test_resolve_all_modes(self, policy_db):
+        results = resolve_all_entities(policy_db, type="mode")
+        assert len(results) == 2
+
+    def test_resolve_all_unknown_type(self, policy_db):
+        results = resolve_all_entities(policy_db, type="nonexistent")
+        assert results == []
+
+
+class TestTraceEntity:
+    def test_trace_returns_all_candidates(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        assert len(result.candidates) >= 2  # rule 0 and rule 4
+
+    def test_trace_marks_winner(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        winners = [c for c in result.candidates if c.won]
+        assert len(winners) == 1
+        assert winners[0].value == "false"
+
+    def test_trace_value_matches_resolve(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="allow")
+        resolved = resolve_entity(policy_db, type="tool", id="Bash", property="allow")
+        assert result.value == resolved
+
+    def test_trace_nonexistent(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="NonExistent", property="allow")
+        assert result.value is None
+        assert result.candidates == ()
+
+    def test_trace_candidates_ordered_by_specificity(self, policy_db):
+        result = trace_entity(policy_db, type="tool", id="Bash", property="max-level")
+        specs = [c.specificity for c in result.candidates]
+        assert specs == sorted(specs, reverse=True)
+
+
+class TestSelectEntities:
+    def test_select_by_type(self, policy_db):
+        entities = select_entities(policy_db, type="tool")
+        assert len(entities) == 3
+
+    def test_select_by_type_and_id(self, policy_db):
+        entities = select_entities(policy_db, type="tool", id="Bash")
+        assert len(entities) == 1
+        assert entities[0]["entity_id"] == "Bash"
+
+    def test_select_by_classes(self, policy_db):
+        entities = select_entities(policy_db, type="tool", classes=["dangerous"])
+        assert len(entities) == 1
+        assert entities[0]["entity_id"] == "Bash"
+
+    def test_select_returns_entity_fields(self, policy_db):
+        entities = select_entities(policy_db, type="tool", id="Read")
+        e = entities[0]
+        assert "entity_id" in e
+        assert "type_name" in e
+        assert "classes" in e
+        assert "attributes" in e

--- a/tests/world/conftest.py
+++ b/tests/world/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+from umwelt.registry import AttrSchema, register_entity, register_taxon
+from umwelt.registry.taxa import registry_scope
+from umwelt.world.shorthands import register_shorthand
+
+
+@pytest.fixture
+def minimal_world_yml(tmp_path):
+    p = tmp_path / "test.world.yml"
+    p.write_text("entities:\n  - type: tool\n    id: Read\n")
+    return p
+
+
+@pytest.fixture
+def toy_world_vocab():
+    with registry_scope():
+        register_taxon(name="capability", description="test cap taxon")
+        register_entity(taxon="capability", name="tool",
+            attributes={"description": AttrSchema(type=str)}, description="a tool")
+        register_taxon(name="state", description="test state taxon")
+        register_entity(taxon="state", name="mode",
+            attributes={}, description="a mode")
+        register_taxon(name="principal", description="test principal")
+        register_entity(taxon="principal", name="principal",
+            attributes={}, description="a principal")
+        register_taxon(name="actor", description="test actor")
+        register_entity(taxon="actor", name="inferencer",
+            attributes={}, description="an inferencer")
+        register_taxon(name="world", description="test world")
+        register_entity(taxon="world", name="resource",
+            attributes={"limit": AttrSchema(type=str)}, description="a resource")
+        register_shorthand(key="tools", entity_type="tool", form="list")
+        register_shorthand(key="modes", entity_type="mode", form="list")
+        register_shorthand(key="principal", entity_type="principal", form="scalar")
+        register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
+        register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+        yield

--- a/tests/world/test_cli_materialize.py
+++ b/tests/world/test_cli_materialize.py
@@ -1,0 +1,52 @@
+
+import pytest
+import yaml
+
+from umwelt.cli import build_parser, main
+from umwelt.registry.taxa import registry_scope
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    """Isolate each test in its own registry scope so vocabulary can be re-registered."""
+    with registry_scope():
+        yield
+
+
+def test_materialize_subcommand_exists():
+    parser = build_parser()
+    args = parser.parse_args(["materialize", "test.world.yml"])
+    assert args.command == "materialize"
+
+def test_materialize_default_level():
+    parser = build_parser()
+    args = parser.parse_args(["materialize", "test.world.yml"])
+    assert args.level == "full"
+
+def test_materialize_accepts_level_flag():
+    parser = build_parser()
+    args = parser.parse_args(["materialize", "test.world.yml", "--level", "summary"])
+    assert args.level == "summary"
+
+def test_materialize_to_stdout(tmp_path, capsys):
+    p = tmp_path / "test.world.yml"
+    p.write_text("entities:\n  - type: tool\n    id: Read\n")
+    rc = main(["materialize", str(p)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = yaml.safe_load(out)
+    assert parsed["meta"]["entity_count"] == 1
+
+def test_materialize_to_file(tmp_path):
+    p = tmp_path / "test.world.yml"
+    p.write_text("entities:\n  - type: tool\n    id: Read\n")
+    out = tmp_path / "out.yml"
+    rc = main(["materialize", str(p), "-o", str(out)])
+    assert rc == 0
+    assert out.exists()
+    parsed = yaml.safe_load(out.read_text())
+    assert parsed["meta"]["entity_count"] == 1
+
+def test_materialize_file_not_found(capsys):
+    rc = main(["materialize", "/nonexistent.world.yml"])
+    assert rc == 2

--- a/tests/world/test_integration.py
+++ b/tests/world/test_integration.py
@@ -1,0 +1,64 @@
+"""End-to-end integration test for the world state layer."""
+
+from __future__ import annotations
+
+import yaml
+
+from umwelt.registry.taxa import registry_scope
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.world import load_world, materialize, render_yaml, validate_world
+from umwelt.world.model import DetailLevel
+
+
+def test_full_pipeline(tmp_path):
+    """Parse world file with shorthands, validate, materialize at all levels."""
+    p = tmp_path / "delegate.world.yml"
+    p.write_text(
+        "tools: [Read, Edit, Bash]\n"
+        "modes: [implement]\n"
+        "principal: Teague\n"
+        "entities:\n"
+        "  - type: tool\n"
+        "    id: Bash\n"
+        "    classes: [dangerous]\n"
+        "    attributes:\n"
+        '      description: "Execute shell commands"\n'
+        "projections:\n"
+        "  - type: dir\n"
+        "    id: node_modules\n"
+        "    attributes:\n"
+        '      path: "node_modules/"\n'
+    )
+    with registry_scope():
+        register_sandbox_vocabulary()
+        world = load_world(p)
+        world = validate_world(world)
+
+        # Bash should appear once (explicit wins over shorthand)
+        bash_entities = [e for e in world.entities if e.id == "Bash"]
+        assert len(bash_entities) == 1
+        assert bash_entities[0].classes == ("dangerous",)
+
+        # Full materialization
+        mw = materialize(world, DetailLevel.FULL)
+        assert mw.meta.entity_count == 5  # 3 tools + 1 mode + 1 principal
+        assert len(mw.projections) == 1
+        assert mw.meta.detail_level == "full"
+
+        # Outline strips attributes
+        mw_outline = materialize(world, DetailLevel.OUTLINE)
+        assert len(mw_outline.entities) == 5
+        for e in mw_outline.entities:
+            assert e.attributes == {}
+
+        # Summary has counts only
+        mw_summary = materialize(world, DetailLevel.SUMMARY)
+        assert len(mw_summary.entities) == 0
+        assert mw_summary.meta.entity_count == 5
+        assert mw_summary.meta.type_counts["tool"] == 3
+
+        # YAML round-trip
+        text = render_yaml(mw)
+        parsed = yaml.safe_load(text)
+        assert parsed["meta"]["entity_count"] == 5
+        assert len(parsed["entities"]) == 5

--- a/tests/world/test_materialize.py
+++ b/tests/world/test_materialize.py
@@ -1,0 +1,95 @@
+import yaml
+
+from umwelt.world.materialize import materialize, render_yaml
+from umwelt.world.model import (
+    DeclaredEntity,
+    DetailLevel,
+    Projection,
+    Provenance,
+    WorldFile,
+)
+
+
+def _sample_world():
+    return WorldFile(
+        entities=(
+            DeclaredEntity(type="tool", id="Read", attributes={"description": "read files"}),
+            DeclaredEntity(
+                type="tool", id="Edit", classes=("edit",), attributes={"description": "edit files"}
+            ),
+            DeclaredEntity(type="mode", id="implement"),
+        ),
+        projections=(
+            Projection(type="dir", id="node_modules", attributes={"path": "node_modules/"}),
+        ),
+        warnings=(),
+        source_path="test.world.yml",
+    )
+
+
+class TestMaterialize:
+    def test_full_includes_everything(self):
+        mw = materialize(_sample_world(), DetailLevel.FULL)
+        assert len(mw.entities) == 3
+        assert mw.entities[0].attributes["description"] == "read files"
+
+    def test_outline_strips_attributes(self):
+        mw = materialize(_sample_world(), DetailLevel.OUTLINE)
+        assert len(mw.entities) == 3
+        assert mw.entities[0].attributes == {}
+        assert mw.entities[1].classes == ("edit",)
+
+    def test_summary_has_no_entities(self):
+        mw = materialize(_sample_world(), DetailLevel.SUMMARY)
+        assert len(mw.entities) == 0
+
+    def test_summary_type_counts(self):
+        mw = materialize(_sample_world(), DetailLevel.SUMMARY)
+        assert mw.meta.type_counts == {"tool": 2, "mode": 1}
+
+    def test_meta_fields(self):
+        mw = materialize(_sample_world(), DetailLevel.FULL)
+        assert mw.meta.source == "test.world.yml"
+        assert mw.meta.entity_count == 3
+        assert mw.meta.detail_level == "full"
+        assert mw.meta.materialized_at  # non-empty ISO timestamp
+
+    def test_projections_at_all_levels(self):
+        for level in DetailLevel:
+            mw = materialize(_sample_world(), level)
+            assert len(mw.projections) == 1
+
+    def test_provenance_preserved(self):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read", provenance=Provenance.EXPLICIT),),
+            projections=(),
+            warnings=(),
+        )
+        mw = materialize(wf, DetailLevel.FULL)
+        assert mw.entities[0].provenance == Provenance.EXPLICIT
+
+
+class TestRenderYaml:
+    def test_roundtrip_valid_yaml(self):
+        mw = materialize(_sample_world(), DetailLevel.FULL)
+        text = render_yaml(mw)
+        parsed = yaml.safe_load(text)
+        assert "meta" in parsed
+        assert "entities" in parsed
+
+    def test_summary_format(self):
+        mw = materialize(_sample_world(), DetailLevel.SUMMARY)
+        text = render_yaml(mw)
+        parsed = yaml.safe_load(text)
+        assert parsed["meta"]["entity_count"] == 3
+        assert parsed["meta"]["type_counts"]["tool"] == 2
+        assert (
+            "entities" not in parsed or parsed["entities"] is None or len(parsed["entities"]) == 0
+        )
+
+    def test_full_includes_attributes(self):
+        mw = materialize(_sample_world(), DetailLevel.FULL)
+        text = render_yaml(mw)
+        parsed = yaml.safe_load(text)
+        tool_read = next(e for e in parsed["entities"] if e["id"] == "Read")
+        assert tool_read["attributes"]["description"] == "read files"

--- a/tests/world/test_model.py
+++ b/tests/world/test_model.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from umwelt.world.model import (
+    DeclaredEntity,
+    DetailLevel,
+    MaterializedMeta,
+    MaterializedWorld,
+    Projection,
+    Provenance,
+    WorldFile,
+    WorldWarning,
+)
+
+
+def test_declared_entity_defaults():
+    e = DeclaredEntity(type="tool", id="Read")
+    assert e.classes == ()
+    assert e.attributes == {}
+    assert e.parent is None
+    assert e.provenance == Provenance.EXPLICIT
+
+
+def test_declared_entity_frozen():
+    e = DeclaredEntity(type="tool", id="Read")
+    with pytest.raises(AttributeError):
+        e.type = "mode"
+
+
+def test_declared_entity_with_all_fields():
+    e = DeclaredEntity(
+        type="tool",
+        id="Bash",
+        classes=("dangerous",),
+        attributes={"description": "shell"},
+        parent="tools",
+        provenance=Provenance.EXPLICIT,
+    )
+    assert e.classes == ("dangerous",)
+    assert e.attributes["description"] == "shell"
+
+
+def test_projection_construction():
+    p = Projection(type="dir", id="node_modules", attributes={"path": "node_modules/"})
+    assert p.type == "dir"
+
+
+def test_world_file_defaults():
+    wf = WorldFile(entities=(), projections=(), warnings=())
+    assert wf.source_path is None
+    assert wf.discover_raw == ()
+    assert wf.include_raw == ()
+
+
+def test_detail_level_values():
+    assert DetailLevel.SUMMARY.value == "summary"
+    assert DetailLevel.OUTLINE.value == "outline"
+    assert DetailLevel.FULL.value == "full"
+
+
+def test_provenance_values():
+    assert Provenance.EXPLICIT.value == "explicit"
+    assert Provenance.PROJECTED.value == "projected"
+
+
+def test_materialized_world_construction():
+    meta = MaterializedMeta(
+        source="test.world.yml",
+        materialized_at="2026-04-19T00:00:00Z",
+        detail_level="full",
+        entity_count=0,
+        type_counts={},
+    )
+    mw = MaterializedWorld(meta=meta, entities=(), projections=(), warnings=())
+    assert mw.meta.entity_count == 0
+
+
+def test_world_warning():
+    w = WorldWarning(message="unknown key", key="foo")
+    assert w.line is None

--- a/tests/world/test_parser.py
+++ b/tests/world/test_parser.py
@@ -139,3 +139,9 @@ class TestEdgeCases:
     def test_file_not_found(self):
         with pytest.raises(FileNotFoundError):
             load_world(Path("/nonexistent/test.world.yml"))
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("[invalid: yaml: {broken")
+        with pytest.raises(WorldParseError, match="invalid YAML"):
+            load_world(p)

--- a/tests/world/test_parser.py
+++ b/tests/world/test_parser.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+
+from umwelt.errors import WorldParseError
+from umwelt.world.model import Provenance
+from umwelt.world.parser import load_world
+
+
+class TestExplicitEntities:
+    def test_parse_basic(self, minimal_world_yml):
+        wf = load_world(minimal_world_yml)
+        assert len(wf.entities) == 1
+        assert wf.entities[0].type == "tool"
+        assert wf.entities[0].id == "Read"
+
+    def test_parse_with_classes(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("entities:\n  - type: tool\n    id: Bash\n    classes: [dangerous, shell]\n")
+        wf = load_world(p)
+        assert wf.entities[0].classes == ("dangerous", "shell")
+
+    def test_parse_with_attributes(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text('entities:\n  - type: tool\n    id: Read\n    attributes:\n      description: "read files"\n')
+        wf = load_world(p)
+        assert wf.entities[0].attributes["description"] == "read files"
+
+    def test_parse_with_parent(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("entities:\n  - type: file\n    id: auth.py\n    parent: src\n")
+        wf = load_world(p)
+        assert wf.entities[0].parent == "src"
+
+    def test_provenance_is_explicit(self, minimal_world_yml):
+        wf = load_world(minimal_world_yml)
+        assert wf.entities[0].provenance == Provenance.EXPLICIT
+
+    def test_source_path_stored(self, minimal_world_yml):
+        wf = load_world(minimal_world_yml)
+        assert wf.source_path == str(minimal_world_yml)
+
+    def test_missing_type_raises(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("entities:\n  - id: Read\n")
+        with pytest.raises(WorldParseError, match="type"):
+            load_world(p)
+
+    def test_missing_id_raises(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("entities:\n  - type: tool\n")
+        with pytest.raises(WorldParseError, match="id"):
+            load_world(p)
+
+    def test_id_coerced_to_string(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("entities:\n  - type: resource\n    id: 42\n")
+        wf = load_world(p)
+        assert wf.entities[0].id == "42"
+
+
+class TestProjections:
+    def test_parse_projections(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("projections:\n  - type: dir\n    id: node_modules\n    attributes:\n      path: node_modules/\n")
+        wf = load_world(p)
+        assert len(wf.projections) == 1
+        assert wf.projections[0].id == "node_modules"
+
+
+class TestShorthandExpansion:
+    def test_tools_shorthand(self, tmp_path, toy_world_vocab):
+        p = tmp_path / "t.world.yml"
+        p.write_text("tools: [Read, Edit]\n")
+        wf = load_world(p)
+        assert len(wf.entities) == 2
+        assert wf.entities[0].type == "tool"
+        assert {e.id for e in wf.entities} == {"Read", "Edit"}
+
+    def test_modes_shorthand(self, tmp_path, toy_world_vocab):
+        p = tmp_path / "t.world.yml"
+        p.write_text("modes: [implement, review]\n")
+        wf = load_world(p)
+        assert len(wf.entities) == 2
+        assert all(e.type == "mode" for e in wf.entities)
+
+    def test_scalar_shorthand(self, tmp_path, toy_world_vocab):
+        p = tmp_path / "t.world.yml"
+        p.write_text("principal: Teague\n")
+        wf = load_world(p)
+        assert len(wf.entities) == 1
+        assert wf.entities[0].type == "principal"
+        assert wf.entities[0].id == "Teague"
+
+    def test_map_shorthand(self, tmp_path, toy_world_vocab):
+        p = tmp_path / "t.world.yml"
+        p.write_text("resources:\n  memory: 512MB\n  wall-time: 5m\n")
+        wf = load_world(p)
+        assert len(wf.entities) == 2
+        mem = next(e for e in wf.entities if e.id == "memory")
+        assert mem.attributes["limit"] == "512MB"
+
+    def test_explicit_overrides_shorthand(self, tmp_path, toy_world_vocab):
+        p = tmp_path / "t.world.yml"
+        p.write_text("tools: [Read]\nentities:\n  - type: tool\n    id: Read\n    classes: [safe]\n")
+        wf = load_world(p)
+        reads = [e for e in wf.entities if e.id == "Read"]
+        assert len(reads) == 1
+        assert reads[0].classes == ("safe",)
+
+
+class TestWarnings:
+    def test_discover_warning(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("discover:\n  - matcher: filesystem\n    root: src/\n")
+        wf = load_world(p)
+        assert any("not yet implemented" in w.message.lower() for w in wf.warnings)
+
+    def test_reserved_key_warning(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("vars:\n  root: /workspace\n")
+        wf = load_world(p)
+        assert any("reserved" in w.message.lower() for w in wf.warnings)
+
+    def test_unknown_key_warning(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("frobnicate: true\n")
+        wf = load_world(p)
+        assert any("unknown" in w.message.lower() for w in wf.warnings)
+
+
+class TestEdgeCases:
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "t.world.yml"
+        p.write_text("")
+        wf = load_world(p)
+        assert len(wf.entities) == 0
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_world(Path("/nonexistent/test.world.yml"))

--- a/tests/world/test_shorthands.py
+++ b/tests/world/test_shorthands.py
@@ -1,0 +1,33 @@
+"""Tests for the shorthand registry."""
+
+from umwelt.registry.taxa import registry_scope
+from umwelt.world.shorthands import ShorthandDef, get_shorthand, register_shorthand
+
+
+def test_register_and_retrieve():
+    with registry_scope():
+        register_shorthand(key="tools", entity_type="tool", form="list")
+        sd = get_shorthand("tools")
+        assert sd is not None
+        assert sd.entity_type == "tool"
+        assert sd.form == "list"
+
+
+def test_unknown_returns_none():
+    with registry_scope():
+        assert get_shorthand("nonexistent") is None
+
+
+def test_map_form_with_attribute_key():
+    with registry_scope():
+        register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+        sd = get_shorthand("resources")
+        assert sd is not None
+        assert sd.attribute_key == "limit"
+
+
+def test_scope_isolation():
+    with registry_scope():
+        register_shorthand(key="tools", entity_type="tool", form="list")
+    with registry_scope():
+        assert get_shorthand("tools") is None

--- a/tests/world/test_shorthands.py
+++ b/tests/world/test_shorthands.py
@@ -1,7 +1,7 @@
 """Tests for the shorthand registry."""
 
 from umwelt.registry.taxa import registry_scope
-from umwelt.world.shorthands import ShorthandDef, get_shorthand, register_shorthand
+from umwelt.world.shorthands import get_shorthand, register_shorthand
 
 
 def test_register_and_retrieve():

--- a/tests/world/test_shorthands.py
+++ b/tests/world/test_shorthands.py
@@ -31,3 +31,15 @@ def test_scope_isolation():
         register_shorthand(key="tools", entity_type="tool", form="list")
     with registry_scope():
         assert get_shorthand("tools") is None
+
+
+def test_sandbox_vocabulary_registers_shorthands():
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+    with registry_scope():
+        register_sandbox_vocabulary()
+        assert get_shorthand("tools") is not None
+        assert get_shorthand("modes") is not None
+        assert get_shorthand("principal") is not None
+        assert get_shorthand("inferencer") is not None
+        assert get_shorthand("resources") is not None

--- a/tests/world/test_validate.py
+++ b/tests/world/test_validate.py
@@ -1,0 +1,48 @@
+from umwelt.world.model import DeclaredEntity, WorldFile, WorldWarning
+from umwelt.world.validate import validate_world
+
+
+class TestValidation:
+    def test_known_type_no_warning(self, toy_world_vocab):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="tool", id="Read"),),
+            projections=(), warnings=(),
+        )
+        result = validate_world(wf)
+        type_warnings = [w for w in result.warnings if "unknown" in w.message.lower() and "type" in w.message.lower()]
+        assert len(type_warnings) == 0
+
+    def test_unknown_type_produces_warning(self, toy_world_vocab):
+        wf = WorldFile(
+            entities=(DeclaredEntity(type="frobnitz", id="X"),),
+            projections=(), warnings=(),
+        )
+        result = validate_world(wf)
+        assert any("frobnitz" in w.message for w in result.warnings)
+
+    def test_preserves_existing_warnings(self, toy_world_vocab):
+        existing = WorldWarning(message="prior warning")
+        wf = WorldFile(entities=(), projections=(), warnings=(existing,))
+        result = validate_world(wf)
+        assert existing in result.warnings
+
+    def test_empty_registry_warns_all(self):
+        from umwelt.registry.taxa import registry_scope
+        with registry_scope():
+            wf = WorldFile(
+                entities=(DeclaredEntity(type="tool", id="Read"),),
+                projections=(), warnings=(),
+            )
+            result = validate_world(wf)
+            assert any("tool" in w.message for w in result.warnings)
+
+    def test_multiple_entities_validated(self, toy_world_vocab):
+        wf = WorldFile(
+            entities=(
+                DeclaredEntity(type="tool", id="Read"),
+                DeclaredEntity(type="unknown_thing", id="X"),
+            ),
+            projections=(), warnings=(),
+        )
+        result = validate_world(wf)
+        assert any("unknown_thing" in w.message for w in result.warnings)


### PR DESCRIPTION
## Summary

- **World State Layer** (`umwelt.world`): YAML parser for `.world.yml` files with shorthand expansion, vocabulary validation, three-level materialization, and `umwelt materialize` CLI command
- **PolicyEngine** (`umwelt.policy`): Consumer-facing Python API wrapping compiled SQLite databases. Three constructors, four query modes (resolve, trace, lint, select), COW extend, typed projection views, world file entity population
- **Replaces ducklog** for downstream consumers (Kibitzer, Lackpy)
- **Docs updated**: vision README, package-design, how-it-works guide

20 commits, 70+ new tests, all passing.

## Test plan
- [ ] `pytest tests/world/ -v` — all world state tests pass
- [ ] `pytest tests/policy/ -v` — all PolicyEngine tests pass
- [ ] `pytest tests/ -v` — no regressions beyond pre-existing failures
- [ ] `ruff check src/umwelt/world/ src/umwelt/policy/` — clean