### PR TITLE
docs: comprehensive plugin, PolicyEngine, and world file guides

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -471,6 +471,95 @@ World file (.world.yml)          Stylesheet (.umw)
 
 Everything in the compiled database is queryable via `engine.execute()` if the high-level API doesn't cover your case.
 
+## Multi-plugin coexistence
+
+When multiple plugins register entities in the same taxon, the world file population path handles this naturally — each plugin's entities go through `load_world()` into the compiled database, and the PolicyEngine resolves them together. No matcher conflicts arise because compilation doesn't use matchers.
+
+For live evaluation (runtime selector matching against state that isn't pre-compiled), the one-matcher-per-taxon constraint can be a problem. If blq and kibitzer both need to provide entities in the `state` taxon, they can't independently register matchers.
+
+The recommended pattern is a composite matcher that delegates by entity type:
+
+```python
+class CompositeMatcher:
+    """Delegate to per-type matchers within a single taxon."""
+
+    def __init__(self):
+        self._delegates: dict[str, MatcherProtocol] = {}
+
+    def add(self, entity_type: str, matcher: MatcherProtocol):
+        self._delegates[entity_type] = matcher
+
+    def match_type(self, type_name: str, context=None) -> list:
+        delegate = self._delegates.get(type_name)
+        return delegate.match_type(type_name, context) if delegate else []
+
+    def children(self, parent, child_type: str) -> list:
+        delegate = self._delegates.get(child_type)
+        return delegate.children(parent, child_type) if delegate else []
+
+    def condition_met(self, selector, context=None) -> bool:
+        return all(d.condition_met(selector, context) for d in self._delegates.values())
+
+    def get_attribute(self, entity, name: str):
+        for delegate in self._delegates.values():
+            val = delegate.get_attribute(entity, name)
+            if val is not None:
+                return val
+        return None
+
+    def get_id(self, entity) -> str | None:
+        for delegate in self._delegates.values():
+            val = delegate.get_id(entity)
+            if val is not None:
+                return val
+        return None
+```
+
+Register the composite once for the taxon; each plugin adds its delegate:
+
+```python
+composite = CompositeMatcher()
+composite.add("hook", kibitzer_matcher)
+composite.add("job", blq_matcher)
+register_matcher(taxon="state", matcher=composite)
+```
+
+This preserves the 1:1 taxon→matcher mapping at the registry level while allowing multiple sources underneath. In practice, most plugins won't need this — world file population covers the common case.
+
+## Cross-taxon policy invariants
+
+Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, resource#wall-time must have a limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
+
+```python
+def lint_bash_requires_wall_time(engine: PolicyEngine) -> list[LintWarning]:
+    bash_allowed = engine.check(type="tool", id="Bash", allow="true")
+    wall_time = engine.resolve(type="resource", id="wall-time", property="limit")
+    if bash_allowed and wall_time is None:
+        return [LintWarning(
+            smell="missing_constraint",
+            severity="warning",
+            description="tool#Bash is allowed but resource#wall-time has no limit",
+            entities=("tool#Bash", "resource#wall-time"),
+            property=None,
+        )]
+    return []
+```
+
+Custom lint rules run after compilation and can query any entity type. This avoids adding a cross-taxon validator protocol — the PolicyEngine query API is already the cross-taxon interface.
+
+## Plugin discovery (future)
+
+Currently, plugins must be explicitly imported and their `register_*()` functions called. For systems where many plugins coexist, a future version will support `entry_points`-based autodiscovery:
+
+```toml
+# In a plugin's pyproject.toml
+[project.entry-points."umwelt.plugins"]
+blq = "blq.umwelt_plugin:register"
+kibitzer = "kibitzer.umwelt_plugin:register"
+```
+
+Until then, the recommended pattern is a single orchestration function that imports and registers all plugins needed for a given deployment.
+
 ## Design principles for plugin authors
 
 **Register at import time.** Call `register_*` functions when your module is imported, not lazily. This ensures the vocabulary is available before any parsing happens.

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -329,6 +329,90 @@ register_property(
 
 Now `secret[sensitivity="critical"] { visible: false; audit: true; }` works in any view.
 
+## The matcher protocol
+
+Most consumers query the compiled database through the PolicyEngine and never need a matcher. But if your plugin needs to evaluate selectors against a live world (not a pre-compiled snapshot), you implement the `MatcherProtocol`:
+
+```python
+from umwelt.registry.matchers import MatcherProtocol, register_matcher
+
+class FilesystemMatcher:
+    """Evaluate selectors against actual filesystem state."""
+
+    def __init__(self, root: str):
+        self.root = root
+
+    def match_type(self, type_name: str, context=None) -> list:
+        """Return all entities of this type in your world."""
+        if type_name == "dir":
+            return [p for p in Path(self.root).iterdir() if p.is_dir()]
+        if type_name == "file":
+            return [p for p in Path(self.root).rglob("*") if p.is_file()]
+        return []
+
+    def children(self, parent, child_type: str) -> list:
+        """Return child entities of `parent` matching `child_type`."""
+        if child_type == "file":
+            return [p for p in parent.iterdir() if p.is_file()]
+        if child_type == "dir":
+            return [p for p in parent.iterdir() if p.is_dir()]
+        return []
+
+    def condition_met(self, selector, context=None) -> bool:
+        """Evaluate a cross-taxon context qualifier."""
+        return True
+
+    def get_attribute(self, entity, name: str):
+        """Return an attribute value on an entity."""
+        if name == "path":
+            return str(entity)
+        if name == "name":
+            return entity.name
+        return None
+
+    def get_id(self, entity) -> str | None:
+        """Return the entity's #id for selector matching."""
+        return entity.name
+```
+
+The five methods:
+
+| Method | When it's called | What it returns |
+|---|---|---|
+| `match_type(type_name)` | Type selector (`file`, `dir`) | All entities of that type |
+| `children(parent, child_type)` | Descendant selector (`dir file`) | Children of `parent` matching `child_type` |
+| `condition_met(selector)` | Cross-taxon qualifier | Whether the context condition holds |
+| `get_attribute(entity, name)` | Attribute selector (`[path$=".py"]`) | The attribute value, or None |
+| `get_id(entity)` | ID selector (`#auth.py`) | The entity's identity string |
+
+Register it for a taxon:
+
+```python
+register_matcher(taxon="world", matcher=FilesystemMatcher("/workspace"))
+```
+
+The selector engine calls your matcher methods but never interprets the entity handles — they're opaque to the core. A filesystem matcher returns `Path` objects; an in-memory test matcher returns dicts; a database-backed matcher returns row IDs. The core doesn't care.
+
+**When you don't need a matcher:** If your entities are declared in world files and compiled via `PolicyEngine.from_files()`, the compilation pipeline handles selector matching internally. You only need a custom matcher for live evaluation against runtime state.
+
+## Desugaring and stability
+
+umwelt provides `@`-rule syntactic sugar that desugars into standard selectors and declarations:
+
+```css
+/* Sugar */
+@tools Read, Edit, Bash { visible: true; }
+
+/* Desugars to */
+tool#Read { visible: true; }
+tool#Edit { visible: true; }
+tool#Bash { visible: true; }
+```
+
+This desugaring implicitly commits to specific entity type names and property names. `@tools` assumes a `tool` entity type exists; `visible` assumes the property is registered. If you're building on the sandbox vocabulary, these names are stable. If you're extending with your own vocabulary, be aware that your `@`-rules create dependencies on your entity and property names.
+
+The desugaring happens at parse time — the compiled database never sees `@`-rules, only the expanded selectors. This means `trace()` shows the desugared form, which can be surprising if you're debugging a stylesheet that uses sugar heavily.
+
 ## Registry isolation in tests
 
 The vocabulary registry is global by default. In tests, use `registry_scope()` to isolate:

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,410 @@
+# Plugins
+
+umwelt's core is vocabulary-agnostic. It provides the parser, selector engine, cascade resolver, and compiler protocol — but knows nothing about files, tools, modes, or networks. All of that comes from plugins.
+
+This guide explains the philosophy, shows how the first-party sandbox plugin works, and walks through building your own.
+
+## Philosophy
+
+### The common language problem
+
+Every enforcement tool in a multi-agent system invents its own configuration format. nsjail has protobuf textproto, bwrap has argv flags, lackpy has Python namespace dicts, kibitzer has hook rules. They all describe variants of the same thing — what the actor can see, edit, call, and consume — but none of them can read each other's descriptions, and none of them compose.
+
+umwelt is the lingua franca those tools translate from. A single view file describes the policy; compilers translate it into whatever native format each tool expects. The policy is written once; each tool reads the subset it cares about.
+
+### Two plugin roles
+
+Plugins interact with umwelt in exactly two ways:
+
+**Generators** populate the world — they declare what entities exist. A filesystem scanner adds `file` and `dir` entities. A tool registry adds `tool` entities. A runtime monitor adds `resource` and `budget` entities. Generators run before compilation; their output is the DOM that stylesheets match against.
+
+**Interactors** consume resolved policy — they query what the cascade decided and act on it. Kibitzer queries tool visibility. Lackpy queries the tool namespace. A workspace builder queries file editability. Interactors run after compilation; their input is the PolicyEngine.
+
+Most real plugins are interactors. Generators are less common because world files handle most entity declaration.
+
+### umwelt declares, consumers enforce
+
+This is the load-bearing design principle. umwelt resolves policy ("tool#Bash has max-level: 3"). Consumers enforce it ("I will reject Bash invocations above level 3"). umwelt never interprets what a value *means* — it resolves what the cascade says the value *is*.
+
+This separation is why the PolicyEngine returns strings, not typed values. `"true"` is a string. Your consumer decides whether to treat it as a boolean, a feature flag, or a sentinel value. umwelt is a specification engine; the semantics live in consumers.
+
+### Vocabulary is the extension surface
+
+The plugin registration API has six hooks:
+
+| Registration | What it adds | Who uses it |
+|---|---|---|
+| `register_taxon()` | A namespace for entity types | Anyone adding a new domain |
+| `register_entity()` | An entity type within a taxon | Anyone adding matchable entities |
+| `register_property()` | A property on an entity type | Anyone adding policy-controllable attributes |
+| `register_shorthand()` | A world file shorthand key | Anyone simplifying YAML authoring |
+| `register_matcher()` | A matcher for a taxon | Anyone evaluating selectors at runtime |
+| `register_validator()` | A validator for a taxon | Anyone adding structural validation |
+
+The first four are the most common. Matchers and validators are advanced — most interactors don't need them because they query the compiled database, not the live DOM.
+
+## The sandbox plugin: a worked example
+
+The first-party sandbox plugin (`umwelt.sandbox`) registers the entire sandbox vocabulary. It's the best example of how a real plugin works.
+
+### Taxa registration
+
+```python
+from umwelt.registry import register_taxon
+
+register_taxon(
+    name="world",
+    description="Entities the actor can couple to: filesystem, network, environment.",
+    ma_concept="world_coupling_axis",
+)
+
+register_taxon(
+    name="capability",
+    description="What the actor can do: tools, kits, effects.",
+    ma_concept="decision_surface_axis",
+)
+
+register_taxon(
+    name="state",
+    description="What the Harness tracks: hooks, jobs, budgets, modes.",
+    ma_concept="observation_layer",
+)
+```
+
+A **taxon** is a namespace. Selectors within a taxon compete in the same cascade; selectors across taxa never interfere. The sandbox registers three: `world` (what exists), `capability` (what the actor can do), and `state` (what the system tracks).
+
+### Entity registration
+
+```python
+from umwelt.registry import register_entity, AttrSchema
+
+register_entity(
+    taxon="capability",
+    name="tool",
+    attributes={
+        "name": AttrSchema(type=str, required=True, description="Tool name"),
+        "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
+        "level": AttrSchema(type=int, description="Computation level 0-8"),
+    },
+    description="A tool the actor can call.",
+    category="tools",
+)
+```
+
+An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against.
+
+### Property registration
+
+```python
+from umwelt.registry import register_property
+
+register_property(
+    taxon="capability",
+    entity="tool",
+    name="visible",
+    value_type=bool,
+    description="Whether the tool is displayed to the delegate.",
+)
+
+register_property(
+    taxon="capability",
+    entity="tool",
+    name="max-level",
+    value_type=int,
+    comparison="<=",
+    value_attribute="level",
+    value_range=(0, 8),
+    description="Maximum computation level permitted.",
+    category="effects_ceiling",
+)
+```
+
+A **property** is what declarations set. `tool { visible: true; }` sets the `visible` property. Properties have comparison semantics:
+
+| Comparison | Resolution rule | Use case |
+|---|---|---|
+| `exact` (default) | Highest specificity wins | Boolean flags, string values |
+| `<=` | Tightest bound (MIN) wins | Numeric caps (max-level, limits) |
+| `pattern-in` | Set union of all matching values | Allow/deny pattern lists |
+
+### Shorthand registration
+
+```python
+from umwelt.world.shorthands import register_shorthand
+
+register_shorthand(key="tools", entity_type="tool", form="list")
+register_shorthand(key="modes", entity_type="mode", form="list")
+register_shorthand(key="principal", entity_type="principal", form="scalar")
+register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+```
+
+Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Three forms:
+
+| Form | YAML syntax | Expansion |
+|---|---|---|
+| `list` | `tools: [Read, Edit]` | One entity per list item, item becomes the `id` |
+| `scalar` | `principal: Teague` | One entity, value becomes the `id` |
+| `map` | `resources: {memory: 512MB}` | One entity per key, key is `id`, value goes to `attribute_key` |
+
+### Wiring it together
+
+The sandbox plugin's entry point calls all registrations:
+
+```python
+def register_sandbox_vocabulary():
+    _register_world()        # world, file, dir, resource, network, env, mount
+    _register_capability()   # tool, kit
+    _register_state()        # hook, job, budget, mode
+    _register_actor()        # inferencer, executor
+    _register_principal()    # principal (identity axis)
+    _register_audit()        # observation, manifest (observer axis)
+    _register_validators()   # structural validation
+    _register_sugar()        # @-rule desugaring
+    _register_world_shorthands()  # world file shorthands
+```
+
+PolicyEngine calls `register_sandbox_vocabulary()` automatically when you use `from_files()` or the programmatic builder. Consumers using `from_db()` skip this — the vocabulary is already baked into the compiled database.
+
+## Building your own plugin
+
+### Example: a rate-limiting policy domain
+
+Suppose you're building a system that rate-limits API calls per endpoint. You want to express this as policy:
+
+```css
+endpoint#/api/users { rate-limit: 100; burst: 20; }
+endpoint#/api/admin { rate-limit: 10; burst: 5; }
+endpoint.public { rate-limit: 1000; }
+```
+
+#### Step 1: Register the vocabulary
+
+```python
+# my_plugin/vocabulary.py
+from umwelt.registry import register_taxon, register_entity, register_property, AttrSchema
+from umwelt.world.shorthands import register_shorthand
+
+def register_rate_limit_vocabulary():
+    register_taxon(
+        name="api",
+        description="API endpoints and their rate-limiting policy.",
+    )
+
+    register_entity(
+        taxon="api",
+        name="endpoint",
+        attributes={
+            "path": AttrSchema(type=str, required=True, description="URL path pattern"),
+            "method": AttrSchema(type=str, description="HTTP method (GET, POST, etc.)"),
+        },
+        description="An API endpoint.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="rate-limit",
+        value_type=int,
+        comparison="<=",
+        description="Requests per minute.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="burst",
+        value_type=int,
+        comparison="<=",
+        description="Burst capacity above the rate limit.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="auth-required",
+        value_type=bool,
+        description="Whether authentication is required.",
+    )
+
+    register_shorthand(key="endpoints", entity_type="endpoint", form="list")
+```
+
+#### Step 2: Write a world file
+
+```yaml
+# api.world.yml
+endpoints: [/api/users, /api/admin, /api/health]
+
+entities:
+  - type: endpoint
+    id: /api/admin
+    classes: [admin, restricted]
+  - type: endpoint
+    id: /api/health
+    classes: [public]
+```
+
+#### Step 3: Write a stylesheet
+
+```css
+/* api-policy.umw */
+endpoint { rate-limit: 100; burst: 20; auth-required: true; }
+endpoint.public { rate-limit: 1000; auth-required: false; }
+endpoint.restricted { rate-limit: 10; burst: 5; }
+```
+
+#### Step 4: Query from your consumer
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine()
+engine.register_vocabulary(register_rate_limit_vocabulary)
+engine.add_entities([
+    {"type": "endpoint", "id": "/api/users"},
+    {"type": "endpoint", "id": "/api/admin", "classes": ["admin", "restricted"]},
+    {"type": "endpoint", "id": "/api/health", "classes": ["public"]},
+])
+engine.add_stylesheet("""
+    endpoint { rate-limit: 100; burst: 20; auth-required: true; }
+    endpoint.public { rate-limit: 1000; auth-required: false; }
+    endpoint.restricted { rate-limit: 10; burst: 5; }
+""")
+
+# Now use it in your rate limiter
+def get_rate_config(engine, path):
+    props = engine.resolve(type="endpoint", id=path)
+    return {
+        "rate_limit": int(props.get("rate-limit", "100")),
+        "burst": int(props.get("burst", "20")),
+        "auth_required": props.get("auth-required") == "true",
+    }
+
+config = get_rate_config(engine, "/api/admin")
+# → {"rate_limit": 10, "burst": 5, "auth_required": True}
+```
+
+#### Step 5: Use the compiled database
+
+For production, compile once and distribute:
+
+```python
+# At build time
+engine.save("api-policy.db")
+
+# At runtime (fast — no parsing)
+engine = PolicyEngine.from_db("api-policy.db")
+config = get_rate_config(engine, "/api/admin")
+```
+
+### Example: extending the sandbox vocabulary
+
+You don't need a new taxon for every extension. If your entities fit an existing taxon, add them there:
+
+```python
+from umwelt.registry import register_entity, register_property, AttrSchema
+
+register_entity(
+    taxon="world",
+    name="secret",
+    parent="dir",
+    attributes={
+        "path": AttrSchema(type=str, required=True),
+        "sensitivity": AttrSchema(type=str, description="Classification: low, medium, high, critical"),
+    },
+    description="A secret file requiring special access policy.",
+)
+
+register_property(
+    taxon="world", entity="secret",
+    name="visible",
+    value_type=bool,
+    description="Whether the agent can see this secret.",
+)
+
+register_property(
+    taxon="world", entity="secret",
+    name="audit",
+    value_type=bool,
+    description="Whether access to this secret is audited.",
+)
+```
+
+Now `secret[sensitivity="critical"] { visible: false; audit: true; }` works in any view.
+
+## Registry isolation in tests
+
+The vocabulary registry is global by default. In tests, use `registry_scope()` to isolate:
+
+```python
+from umwelt.registry.taxa import registry_scope
+
+def test_my_vocabulary():
+    with registry_scope():
+        register_rate_limit_vocabulary()
+        # Registry state is isolated to this block
+        # — won't interfere with other tests
+
+    # Registry is restored to its previous state here
+```
+
+`registry_scope()` creates a fresh registry state and restores the previous state on exit. This means tests can register whatever vocabulary they need without polluting each other.
+
+## The compilation pipeline
+
+Understanding what happens when the PolicyEngine compiles helps you write better plugins.
+
+```
+World file (.world.yml)          Stylesheet (.umw)
+         │                              │
+    load_world()                    parse()
+         │                              │
+    WorldFile                        View (AST)
+         │                              │
+    populate_from_world()       compile_view()
+         │                              │
+    ┌────┴──────────────────────────────┴────┐
+    │          SQLite database               │
+    │                                        │
+    │  entities table ← from world file      │
+    │  selectors table ← from stylesheet     │
+    │  cascade_candidates ← selector × entity│
+    │  resolved_properties ← cascade winner  │
+    │  projection views ← vocabulary-driven  │
+    │  compilation_meta ← provenance         │
+    └────────────────────────────────────────┘
+                     │
+              PolicyEngine
+                     │
+         resolve / trace / lint
+```
+
+1. **World file** is parsed into a `WorldFile` with `DeclaredEntity` instances
+2. **Entities** are inserted into the `entities` table (with classes and attributes as JSON)
+3. **Stylesheet** is parsed into a `View` AST
+4. **Each selector** is compiled against the entities table, producing `cascade_candidates` — every (entity, property, value, specificity, rule_index) combination
+5. **Resolution views** resolve the cascade: `_resolved_exact` (highest specificity), `_resolved_cap` (MIN for `<=` comparison), `_resolved_pattern` (set union for `pattern-in`)
+6. **`resolved_properties`** is the UNION of the three resolution strategies — the final answer
+7. **Projection views** pivot `resolved_properties` into one-row-per-entity views for convenience
+8. **PolicyEngine** wraps the connection and provides the query API
+
+Everything in the compiled database is queryable via `engine.execute()` if the high-level API doesn't cover your case.
+
+## Design principles for plugin authors
+
+**Register at import time.** Call `register_*` functions when your module is imported, not lazily. This ensures the vocabulary is available before any parsing happens.
+
+**Use comparison semantics.** If a property represents a cap or limit, register it with `comparison="<="`. The cascade will correctly resolve to the tightest bound. If it represents a set of patterns, use `comparison="pattern-in"` for set union.
+
+**Keep consumers thin.** Your consumer should call `engine.resolve()` and interpret the string. Don't reimplement cascade resolution, specificity computation, or selector matching — that's what umwelt is for.
+
+**Compile once, query many times.** Use `from_files()` or the programmatic builder during setup, then `save()` the result. Distribute the `.db` file to consumers, which load it with `from_db()` (fast — no parsing needed).
+
+**Use extend() for specialization.** If your consumer needs to fork the policy for different contexts (per-request, per-mode, per-user), use `extend()` rather than rebuilding from scratch. The SQLite backup is fast and gives you true isolation.
+
+**Test with the programmatic builder.** Create a `PolicyEngine()`, add entities and a stylesheet, and assert on `resolve()`. No files needed. The `registry_scope()` fixture keeps your tests isolated.
+
+## Next steps
+
+- [PolicyEngine](policy-engine.md) — the full API reference for consuming resolved policy
+- [World Files](world-files.md) — declare the entities your policy matches
+- [Writing Views](writing-views.md) — write the stylesheets that set policy
+- [How It Works](how-it-works.md) — the architecture underneath
+- [Entity Reference](entity-reference.md) — all registered entity types and properties

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -85,13 +85,15 @@ register_entity(
         "name": AttrSchema(type=str, required=True, description="Tool name"),
         "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
         "level": AttrSchema(type=int, description="Computation level 0-8"),
+        "param-count": AttrSchema(type=int, description="Number of parameters (MCP-projected)"),
+        "output-type": AttrSchema(type=str, description="Output format: structured, text, stream"),
     },
     description="A tool the actor can call.",
     category="tools",
 )
 ```
 
-An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against.
+An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against — including MCP-projected attributes like `param-count` and `output-type` that enable selectors like `tool[output-type="structured"] { cache: true; }`.
 
 ### Property registration
 
@@ -135,16 +137,17 @@ from umwelt.world.shorthands import register_shorthand
 register_shorthand(key="tools", entity_type="tool", form="list")
 register_shorthand(key="modes", entity_type="mode", form="list")
 register_shorthand(key="principal", entity_type="principal", form="scalar")
-register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+register_shorthand(key="resources", entity_type="resource", form="block")
 ```
 
-Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Three forms:
+Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Four forms:
 
 | Form | YAML syntax | Expansion |
 |---|---|---|
 | `list` | `tools: [Read, Edit]` | One entity per list item, item becomes the `id` |
 | `scalar` | `principal: Teague` | One entity, value becomes the `id` |
-| `map` | `resources: {memory: 512MB}` | One entity per key, key is `id`, value goes to `attribute_key` |
+| `map` | `tags: {hot: critical}` | One entity per key, key is `id`, value goes to `attribute_key` |
+| `block` | `resources: {memory: 512MB}` | One entity, keys become attributes |
 
 ### Wiring it together
 
@@ -528,18 +531,18 @@ This preserves the 1:1 taxon→matcher mapping at the registry level while allow
 
 ## Cross-taxon policy invariants
 
-Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, resource#wall-time must have a limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
+Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, the resource block must set a wall-time limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
 
 ```python
 def lint_bash_requires_wall_time(engine: PolicyEngine) -> list[LintWarning]:
     bash_allowed = engine.check(type="tool", id="Bash", allow="true")
-    wall_time = engine.resolve(type="resource", id="wall-time", property="limit")
+    wall_time = engine.resolve(type="resource", id="resource", property="wall-time")
     if bash_allowed and wall_time is None:
         return [LintWarning(
             smell="missing_constraint",
             severity="warning",
-            description="tool#Bash is allowed but resource#wall-time has no limit",
-            entities=("tool#Bash", "resource#wall-time"),
+            description="tool#Bash is allowed but resource has no wall-time limit",
+            entities=("tool#Bash", "resource"),
             property=None,
         )]
     return []

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -1,0 +1,419 @@
+# PolicyEngine
+
+The PolicyEngine is the consumer-facing Python API for querying resolved policy. It compiles a world file and a stylesheet into an in-memory SQLite database, resolves the CSS cascade, and answers questions about the result.
+
+**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it.
+
+## Quick start
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+
+# What's the resolved value of a property?
+engine.resolve(type="tool", id="Bash", property="visible")  # → "true"
+
+# Get all resolved properties for an entity
+engine.resolve(type="tool", id="Bash")  # → {"visible": "true", "max-level": "3", ...}
+
+# Does the policy match what we expect?
+engine.check(type="tool", id="Bash", visible="true")  # → True
+
+# Enforce it — raises PolicyDenied on mismatch
+engine.require(type="tool", id="Bash", visible="true")
+```
+
+## Three constructors
+
+PolicyEngine has three ways to create an instance, corresponding to three points in the lifecycle:
+
+### Author time: `from_files()`
+
+Compile from source files. Parses the world YAML, parses the stylesheet, builds the full compiled database.
+
+```python
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+```
+
+Use this when you have the original source files and want the full compilation pipeline — parsing, vocabulary registration, cascade resolution, projection views.
+
+### Consumer time: `from_db()`
+
+Load a pre-compiled database. No parsing, no compilation. The database is copied into memory (copy-on-write semantics — the original file is never modified).
+
+```python
+engine = PolicyEngine.from_db("compiled.duckdb")
+```
+
+Use this in consumers that receive a compiled policy database. Kibitzer loads its policy this way — the compilation happened at authoring time, and Kibitzer just queries the result.
+
+### Runtime: programmatic builder
+
+Build an engine incrementally from Python data structures. Useful for testing, runtime composition, and consumers that construct policy dynamically.
+
+```python
+engine = PolicyEngine()
+engine.add_entities([
+    {"type": "tool", "id": "Read", "classes": ["safe"]},
+    {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    {"type": "mode", "id": "implement"},
+])
+engine.add_stylesheet("""
+    tool { visible: true; allow: true; }
+    tool.dangerous { max-level: 3; }
+""")
+```
+
+Compilation is lazy — the engine compiles on first query, not on construction. You can call `add_entities()` and `add_stylesheet()` multiple times before querying.
+
+## Query modes
+
+### resolve — what does the policy say?
+
+```python
+# Single property
+value = engine.resolve(type="tool", id="Bash", property="max-level")
+# → "3" or None if no rule matches
+
+# All properties for an entity
+props = engine.resolve(type="tool", id="Bash")
+# → {"visible": "true", "allow": "true", "max-level": "3"}
+
+# All entities of a type with their properties
+all_tools = engine.resolve_all(type="tool")
+# → [{"entity_id": "Read", "type_name": "tool", "classes": [...], "properties": {...}}, ...]
+```
+
+All values are strings. The cascade resolves to string values; your consumer interprets them. `"true"` is the string `"true"`, not the Python boolean `True`. This is intentional — umwelt is a specification engine, not a runtime.
+
+### trace — why does the policy say that?
+
+```python
+from umwelt.policy import TraceResult, Candidate
+
+result: TraceResult = engine.trace(
+    type="tool", id="Bash", property="max-level",
+)
+
+print(f"Winner: {result.value}")  # → "3"
+
+for c in result.candidates:
+    marker = "✓" if c.won else " "
+    print(f"  [{marker}] {c.value}  spec={c.specificity}  "
+          f"rule={c.rule_index}  {c.source_file}:{c.source_line}")
+```
+
+Output:
+
+```
+Winner: 3
+  [✓] 3  spec=[0,1,1]  rule=2  policy.umw:3
+  [ ] 5  spec=[0,0,1]  rule=1  policy.umw:1
+```
+
+Trace shows every cascade candidate that competed for a property, ordered by specificity (highest first). The winner is marked with `won=True`. This is how you debug "why did my tool get max-level 3 instead of 5?" — you can see which rule won and why.
+
+### lint — are there policy smells?
+
+```python
+from umwelt.policy import LintWarning
+
+warnings: list[LintWarning] = engine.lint()
+
+for w in warnings:
+    print(f"[{w.severity}] {w.smell}: {w.description}")
+```
+
+Five smell detectors:
+
+| Smell | Severity | What it catches |
+|---|---|---|
+| `narrow_win` | warning | Winner beat runner-up by specificity margin of 1 — fragile |
+| `shadowed_rule` | info | A rule that never wins for any entity — dead code |
+| `conflicting_intent` | warning | Same specificity, opposite values — winner decided by source order alone |
+| `uncovered_entity` | info | An entity with no resolved properties — nothing matches it |
+| `specificity_escalation` | warning | 3+ specificity levels for one property — possible escalation war |
+
+Lint is useful for policy authors debugging their stylesheets. Consumers can also use it to report warnings to users.
+
+### check and require — enforce constraints
+
+```python
+# Soft check: returns True/False
+if not engine.check(type="tool", id="Bash", visible="true", allow="true"):
+    print("Policy violation")
+
+# Hard check: raises PolicyDenied
+try:
+    engine.require(type="tool", id="Bash", visible="true")
+except PolicyDenied as e:
+    print(f"Denied: {e.entity} {e.property}={e.actual} (expected {e.expected})")
+```
+
+`check()` tests multiple properties at once — all must match for it to return `True`. `require()` raises `PolicyDenied` on the first mismatch.
+
+## COW extend — fork and specialize
+
+`extend()` produces a new engine with additional entities and/or stylesheet rules. The original engine is never modified.
+
+```python
+base = PolicyEngine.from_files(world="base.world.yml", stylesheet="base.umw")
+
+# Fork with additional rules
+strict = base.extend(stylesheet="tool.dangerous { allow: false; }")
+
+# Fork with additional entities
+expanded = base.extend(entities=[
+    {"type": "tool", "id": "NewTool", "classes": ["experimental"]},
+])
+
+# Fork with both
+custom = base.extend(
+    entities=[{"type": "mode", "id": "review"}],
+    stylesheet="mode#review tool { max-level: 2; }",
+)
+
+# The original is untouched
+base.resolve(type="tool", id="Bash", property="allow")     # → "true"
+strict.resolve(type="tool", id="Bash", property="allow")   # → "false"
+```
+
+This is implemented via SQLite `backup()` — the entire compiled database is copied into a new in-memory connection, then the new entities/rules are compiled on top. The cost is proportional to database size (typically <1ms for reasonable policy sizes).
+
+Use cases:
+
+- **Mode switching**: fork with a mode-specific stylesheet overlay
+- **Per-request specialization**: add context-specific entities before querying
+- **Testing**: create a base engine in a fixture, extend per test
+
+## Persistence
+
+### Save to file
+
+```python
+engine.save("compiled.duckdb")
+```
+
+Writes the compiled SQLite database to a file. Another consumer can load it with `from_db()`. The database contains everything: entities, cascade candidates, resolved properties, projection views, compilation metadata.
+
+### Round-trip export
+
+```python
+engine.to_files(world="exported.world.yml", stylesheet="exported.umw")
+```
+
+Best-effort export back to source files. The world YAML is reconstructed from the entities table. The stylesheet is copied from the original source (if tracked in compilation metadata) or reconstructed as a comment block.
+
+## Raw SQL escape hatch
+
+The compiled database is a SQLite database with a well-defined schema. If the query API doesn't cover your use case, you can run SQL directly:
+
+```python
+rows = engine.execute(
+    "SELECT entity_id, type_name FROM entities WHERE type_name = ?",
+    ("tool",),
+)
+```
+
+### Database schema
+
+| Table | Purpose |
+|---|---|
+| `entities` | All declared entities (type, id, classes, attributes as JSON) |
+| `selectors` | Compiled selector rules |
+| `cascade_candidates` | Every (entity, property, value) candidate before resolution |
+| `property_types` | Registered property schemas (type, comparison semantics) |
+| `resolved_properties` | **The resolution result** — winning value per (entity, property) |
+| `compilation_meta` | Provenance: source files, timestamps, counts |
+
+### Projection views
+
+The compiled database also contains vocabulary-driven SQL views:
+
+| View | What it provides |
+|---|---|
+| `resolved_entities` | All entities with their resolved properties as a JSON object |
+| `tools` | Pivot view: one row per tool, one column per tool property |
+| `modes` | Pivot view for modes |
+| (per entity type) | One pivot view per registered entity type with properties |
+
+These views are generated from the vocabulary registry — whatever entity types and properties are registered get their own pivot view. A consumer can query `SELECT * FROM tools WHERE visible = 'true'` directly.
+
+## Observability
+
+PolicyEngine logs to `umwelt.policy` via Python's standard `logging`:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+| Level | What's logged |
+|---|---|
+| `INFO` | `compile` (source files, entity count), `resolve` (entity, property, value), `resolve_all`, `extend` |
+| `WARNING` | `require_denied` (entity, property, expected vs actual), lint warnings |
+| `DEBUG` | `trace` (entity, property, candidate count), vocabulary/projection skip reasons |
+
+All log entries include structured `extra` fields for machine consumption.
+
+## Error handling
+
+```python
+from umwelt.errors import PolicyDenied, PolicyError, UmweltError
+
+# PolicyDenied — raised by require()
+# PolicyError — base class for all policy errors
+# UmweltError — base class for all umwelt errors
+```
+
+`PolicyDenied` has structured fields:
+
+```python
+try:
+    engine.require(type="tool", id="Bash", visible="false")
+except PolicyDenied as e:
+    e.entity    # "tool#Bash"
+    e.property  # "visible"
+    e.expected  # "false"
+    e.actual    # "true"
+```
+
+## Worked example: a Kibitzer-style consumer
+
+Kibitzer is a semantic-altitude tool that observes and coaches an AI agent during a session. It needs to know which tools are visible, what their max computation level is, and whether specific modes are active. Here's how it integrates:
+
+```python
+from umwelt.policy import PolicyEngine, PolicyDenied
+
+class KibitzerSession:
+    def __init__(self, policy_db: str):
+        self.engine = PolicyEngine.from_db(policy_db)
+
+    def is_tool_allowed(self, tool_name: str) -> bool:
+        return self.engine.check(type="tool", id=tool_name, allow="true")
+
+    def get_tool_config(self, tool_name: str) -> dict:
+        props = self.engine.resolve(type="tool", id=tool_name)
+        if props is None:
+            return {"visible": False, "allowed": False}
+        return {
+            "visible": props.get("visible") == "true",
+            "allowed": props.get("allow") == "true",
+            "max_level": int(props.get("max-level", "8")),
+            "patterns": props.get("allow-pattern", "").split(","),
+        }
+
+    def get_visible_tools(self) -> list[str]:
+        all_tools = self.engine.resolve_all(type="tool")
+        return [
+            t["entity_id"]
+            for t in all_tools
+            if t["properties"].get("visible") == "true"
+        ]
+
+    def enforce_tool_call(self, tool_name: str):
+        """Raise if tool is not allowed by policy."""
+        self.engine.require(type="tool", id=tool_name, allow="true")
+
+    def switch_mode(self, mode_name: str) -> "KibitzerSession":
+        """Fork the engine with a mode-specific overlay."""
+        child_engine = self.engine.extend(
+            entities=[{"type": "mode", "id": mode_name}],
+        )
+        session = KibitzerSession.__new__(KibitzerSession)
+        session.engine = child_engine
+        return session
+```
+
+The key pattern: Kibitzer never interprets CSS selectors or cascade rules. It asks the PolicyEngine "what does the resolved policy say about tool X?" and acts on the answer. umwelt handles the compilation; Kibitzer handles the enforcement.
+
+## Worked example: a Lackpy-style namespace builder
+
+Lackpy restricts which tools an AI agent can call at the language level. It builds a Python namespace from resolved policy:
+
+```python
+from umwelt.policy import PolicyEngine
+
+def build_tool_namespace(engine: PolicyEngine) -> dict:
+    """Build a tool restriction namespace from resolved policy."""
+    all_tools = engine.resolve_all(type="tool")
+    namespace = {}
+
+    for tool in all_tools:
+        name = tool["entity_id"]
+        props = tool["properties"]
+
+        if props.get("allow") != "true":
+            continue
+
+        entry = {"name": name}
+
+        if "max-level" in props:
+            entry["max_level"] = int(props["max-level"])
+
+        if "allow-pattern" in props:
+            entry["patterns"] = [
+                p.strip() for p in props["allow-pattern"].split(",")
+            ]
+
+        namespace[name] = entry
+
+    return namespace
+
+# Usage
+engine = PolicyEngine.from_db("compiled.duckdb")
+ns = build_tool_namespace(engine)
+# → {"Read": {"name": "Read"}, "Bash": {"name": "Bash", "max_level": 3, "patterns": ["git *"]}}
+```
+
+## Worked example: policy-aware test fixture
+
+Use PolicyEngine in tests to verify that your policy produces the expected results:
+
+```python
+import pytest
+from umwelt.policy import PolicyEngine
+
+@pytest.fixture
+def engine():
+    e = PolicyEngine()
+    e.add_entities([
+        {"type": "tool", "id": "Read", "classes": ["safe"]},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    e.add_stylesheet("""
+        tool { visible: true; allow: true; }
+        tool.dangerous { max-level: 3; }
+        tool.safe { max-level: 8; }
+    """)
+    return e
+
+def test_dangerous_tools_are_capped(engine):
+    assert engine.resolve(type="tool", id="Bash", property="max-level") == "3"
+
+def test_safe_tools_are_uncapped(engine):
+    assert engine.resolve(type="tool", id="Read", property="max-level") == "8"
+
+def test_all_tools_visible(engine):
+    for tool in engine.resolve_all(type="tool"):
+        assert tool["properties"].get("visible") == "true"
+
+def test_policy_has_no_smells(engine):
+    warnings = engine.lint()
+    errors = [w for w in warnings if w.severity == "warning"]
+    assert errors == [], f"Policy smells: {[w.description for w in errors]}"
+```
+
+## Next steps
+
+- [World Files](world-files.md) — declare the entities your policy matches against
+- [Writing Views](writing-views.md) — write the stylesheets
+- [Plugins](plugins.md) — extend the vocabulary with custom entity types and properties
+- [How It Works](how-it-works.md) — understand the architecture

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -1,8 +1,8 @@
 # PolicyEngine
 
-The PolicyEngine is the consumer-facing Python API for querying resolved policy. It compiles a world file and a stylesheet into an in-memory SQLite database, resolves the CSS cascade, and answers questions about the result.
+The PolicyEngine is the primary API for consumers integrating with umwelt. It's the only interface most plugins need — the parser, selector engine, cascade resolver, and SQL compiler are internal implementation details that consumers never touch directly.
 
-**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it.
+**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it. The parsing and compilation pipeline is an internal concern; consumers interact with the PolicyEngine, not with the parser or compiler.
 
 ## Quick start
 
@@ -372,6 +372,43 @@ engine = PolicyEngine.from_db("compiled.duckdb")
 ns = build_tool_namespace(engine)
 # → {"Read": {"name": "Read"}, "Bash": {"name": "Bash", "max_level": 3, "patterns": ["git *"]}}
 ```
+
+## Worked example: a sandbox builder querying exec policy
+
+A sandbox builder like nsjail reads exec and dir policy — a completely different slice of the same compiled database. It doesn't care about tools or modes:
+
+```python
+from umwelt.policy import PolicyEngine
+
+def build_nsjail_config(engine: PolicyEngine) -> dict:
+    """Build nsjail mount and exec configuration from resolved policy."""
+    config = {"mounts": [], "exec_paths": []}
+
+    for exe in engine.resolve_all(type="exec"):
+        props = exe["properties"]
+        path = props.get("path")
+        if path:
+            config["exec_paths"].append(path)
+            if props.get("search-path"):
+                config["search_paths"] = props["search-path"].split(":")
+
+    for d in engine.resolve_all(type="dir"):
+        props = d["properties"]
+        config["mounts"].append({
+            "src": props.get("path", ""),
+            "dst": props.get("path", ""),
+            "rw": props.get("writable") == "true",
+        })
+
+    return config
+
+engine = PolicyEngine.from_db("compiled.duckdb")
+nsjail = build_nsjail_config(engine)
+# → {"mounts": [{"src": "src/", "dst": "src/", "rw": true}],
+#    "exec_paths": ["/bin/bash", "/usr/bin/git"]}
+```
+
+This consumer never queries tool or mode entities. Kibitzer queries tools; the sandbox builder queries execs and dirs. Same database, different consumers reading different slices — that's the "umwelt declares, consumers enforce" pattern in practice.
 
 ## Worked example: policy-aware test fixture
 

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -145,6 +145,80 @@ projections:
 
 Projections are stored separately from entities — they represent what the environment *will* provide, not what the world file *declares*. In the compiled database, projections appear in the entities table with `provenance: projected`.
 
+## Tools vs executables
+
+A `tool` is a first-class capability provided to the inferencer — an MCP tool like Read, Edit, or Bash. An `exec` is an executable binary that exists in the environment — `bash`, `python3`, `git`. These are independent concepts: `tool#Bash` describes a capability the agent can invoke, but says nothing about how it's implemented. It might call `/bin/bash`, it might be a Python reimplementation, it might delegate to a WASM sandbox. The exec entities describe what binaries the environment provides, regardless of which tools use them.
+
+```yaml
+entities:
+  # Tools — what the inferencer can call
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+
+  # Executables — what runs in the environment
+  - type: exec
+    id: bash
+    attributes:
+      path: /bin/bash
+  - type: exec
+    id: git
+    attributes:
+      path: /usr/bin/git
+  - type: exec
+    id: python3
+    attributes:
+      path: /usr/bin/python3
+```
+
+These are independent entity types in different taxa — `tool` lives in `capability`, `exec` lives in `world`. They don't need to reference each other. A consumer like nsjail queries exec policy to build its sandbox configuration; a consumer like Kibitzer queries tool policy to decide what to show the agent. Each consumer reads the slice of policy it cares about.
+
+```css
+/* Tool-level: what the agent sees */
+tool#Bash { allow: true; max-level: 3; }
+
+/* Executable-level: what the sandbox restricts */
+exec#bash    { path: "/bin/bash"; }
+exec#git     { path: "/usr/bin/git"; }
+exec#python3 { path: "/usr/bin/python3"; search-path: "/usr/bin:/usr/local/bin"; }
+```
+
+The relationship between `tool#Bash` and the executables it invokes is a consumer concern — umwelt doesn't model it. The tool entity describes what the inferencer can call; the exec entities describe what binaries exist in the environment. Different consumers enforce different parts of this policy independently.
+
+## Directories and files
+
+The world taxon includes `dir` and `file` entities for filesystem structure:
+
+```yaml
+entities:
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+      name: "src"
+  - type: dir
+    id: tests
+    attributes:
+      path: "tests/"
+      name: "tests"
+  - type: file
+    id: auth.py
+    attributes:
+      path: "src/auth/auth.py"
+      name: "auth.py"
+      language: "python"
+```
+
+`file` is a child of `dir` in the world hierarchy, so descendant selectors work:
+
+```css
+dir[name="src"] file { editable: true; }       /* files under src/ */
+dir[name="tests"] file { editable: false; }     /* tests are read-only */
+file[path$=".py"] { visible: true; }            /* all Python files visible */
+```
+
+In practice, file and directory entities are often populated by projections or filesystem matchers rather than declared by hand in the world file.
+
 ## Combining everything
 
 A realistic world file for a code editing session:
@@ -174,6 +248,16 @@ entities:
     classes: [dangerous]
     attributes:
       description: "Overwrite entire files"
+
+  - type: exec
+    id: bash
+    attributes:
+      path: /bin/bash
+
+  - type: exec
+    id: git
+    attributes:
+      path: /usr/bin/git
 
 projections:
   - type: dir

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -49,11 +49,11 @@ Available shorthands (from the sandbox vocabulary):
 | `modes` | `mode` | list | `modes: [implement, review]` |
 | `principal` | `principal` | scalar | `principal: Teague` |
 | `inferencer` | `inferencer` | scalar | `inferencer: claude-sonnet` |
-| `resources` | `resource` | map | `resources: {memory: 512MB, wall-time: 5m}` |
+| `resources` | `resource` | block | `resources: {memory: 512MB, wall-time: 5m}` |
 
-### Map shorthands
+### Block shorthands
 
-Map shorthands create entities with an attribute set from the value:
+Block shorthands create a single entity with all key-value pairs as attributes:
 
 ```yaml
 resources:
@@ -61,7 +61,14 @@ resources:
   wall-time: 5m
 ```
 
-This creates two `resource` entities: `resource#memory` with `limit: 512MB` and `resource#wall-time` with `limit: 5m`. The `limit` attribute is configured by the shorthand's `attribute_key`.
+This creates one `resource` entity with attributes `{memory: "512MB", "wall-time": "5m"}`. The stylesheet then sets policy on the resource block as properties:
+
+```css
+resource { memory: 512MB; wall-time: 5m; }
+mode#implement resource { memory: 1GB; }
+```
+
+Each limit resolves independently in the cascade ��� you can override one without touching the others. This mirrors how Kubernetes, slurm, and nsjail model resource blocks.
 
 ## Explicit entities
 
@@ -276,8 +283,7 @@ tool#Bash { allow-pattern: "git *"; allow-pattern: "pytest *"; }
 
 mode#implement tool { max-level: 5; }
 
-resource#memory { limit: 1GB; }
-resource#wall-time { limit: 10m; }
+resource { memory: 1GB; wall-time: 10m; }
 ```
 
 Compile and query:

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -1,0 +1,273 @@
+# World Files
+
+A world file (`.world.yml`) declares the entities that exist in an agent's environment — the tools it can call, the modes it operates in, the resources it has access to. It's the DOM that stylesheets match against.
+
+## Your first world file
+
+```yaml
+# env.world.yml
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Edit
+  - type: mode
+    id: implement
+```
+
+Three entities. Two tools and a mode. A stylesheet can now match these:
+
+```css
+tool#Read { visible: true; }
+tool#Edit { visible: true; allow: true; }
+mode#implement tool { max-level: 5; }
+```
+
+Inspect it:
+
+```bash
+umwelt materialize env.world.yml
+```
+
+## Shorthand syntax
+
+Writing `entities:` blocks for every tool gets tedious. Shorthand keys expand into entities via the vocabulary registry:
+
+```yaml
+# Same result, less typing
+tools: [Read, Edit]
+modes: [implement]
+```
+
+`tools: [Read, Edit]` expands to two `tool` entities. `modes: [implement]` expands to one `mode` entity. The shorthand registry knows which entity type each key maps to.
+
+Available shorthands (from the sandbox vocabulary):
+
+| Key | Entity type | Form | Example |
+|---|---|---|---|
+| `tools` | `tool` | list | `tools: [Read, Edit, Bash]` |
+| `modes` | `mode` | list | `modes: [implement, review]` |
+| `principal` | `principal` | scalar | `principal: Teague` |
+| `inferencer` | `inferencer` | scalar | `inferencer: claude-sonnet` |
+| `resources` | `resource` | map | `resources: {memory: 512MB, wall-time: 5m}` |
+
+### Map shorthands
+
+Map shorthands create entities with an attribute set from the value:
+
+```yaml
+resources:
+  memory: 512MB
+  wall-time: 5m
+```
+
+This creates two `resource` entities: `resource#memory` with `limit: 512MB` and `resource#wall-time` with `limit: 5m`. The `limit` attribute is configured by the shorthand's `attribute_key`.
+
+## Explicit entities
+
+For entities that need classes, attributes, or parent references, use the full `entities:` block:
+
+```yaml
+tools: [Read, Edit, Bash]
+
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell]
+    attributes:
+      description: "Execute shell commands"
+
+  - type: tool
+    id: Read
+    attributes:
+      description: "Read files from the filesystem"
+```
+
+### Merge semantics
+
+When a shorthand and an explicit entry declare the same `(type, id)` pair, the explicit entry wins. In the example above, `Bash` appears in both `tools:` and `entities:` — the explicit entry with classes and attributes is kept; the shorthand version is discarded.
+
+This lets you use shorthands for the common case and override specific entities when you need more detail.
+
+## Classes
+
+Classes work exactly like CSS classes. An entity can have zero or more:
+
+```yaml
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell, system]
+```
+
+Stylesheets match classes with `.`:
+
+```css
+tool.dangerous { max-level: 3; }
+tool.shell { allow-pattern: "echo *"; }
+```
+
+## Attributes
+
+Attributes are key-value metadata on an entity:
+
+```yaml
+entities:
+  - type: tool
+    id: Read
+    attributes:
+      description: "Read files from the filesystem"
+      kit: "filesystem"
+```
+
+Stylesheets match attributes with `[]`:
+
+```css
+tool[kit="filesystem"] { visible: true; }
+```
+
+## Projections
+
+Projections declare entities that will be populated by external systems (filesystem discovery, runtime state, etc.):
+
+```yaml
+projections:
+  - type: dir
+    id: node_modules
+    attributes:
+      path: "node_modules/"
+
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+```
+
+Projections are stored separately from entities — they represent what the environment *will* provide, not what the world file *declares*. In the compiled database, projections appear in the entities table with `provenance: projected`.
+
+## Combining everything
+
+A realistic world file for a code editing session:
+
+```yaml
+# delegate.world.yml
+principal: Teague
+inferencer: claude-sonnet
+
+tools: [Read, Edit, Bash, Grep, Glob, Write]
+modes: [implement]
+
+resources:
+  memory: 1GB
+  wall-time: 10m
+  max-fds: 256
+
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+    attributes:
+      description: "Execute shell commands"
+
+  - type: tool
+    id: Write
+    classes: [dangerous]
+    attributes:
+      description: "Overwrite entire files"
+
+projections:
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+```
+
+Pair it with a stylesheet:
+
+```css
+/* policy.umw */
+tool { visible: true; allow: true; }
+tool.dangerous { max-level: 3; }
+tool#Bash { allow-pattern: "git *"; allow-pattern: "pytest *"; }
+
+mode#implement tool { max-level: 5; }
+
+resource#memory { limit: 1GB; }
+resource#wall-time { limit: 10m; }
+```
+
+Compile and query:
+
+```bash
+umwelt compile --target sqlite -o world.db policy.umw --world delegate.world.yml
+```
+
+Or use the Python API:
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+engine.resolve(type="tool", id="Bash", property="max-level")  # → "3"
+```
+
+## Materialization
+
+`umwelt materialize` renders a world file at three detail levels:
+
+```bash
+# Full: all entities with all attributes
+umwelt materialize env.world.yml --level full
+
+# Outline: entities with classes but no attributes
+umwelt materialize env.world.yml --level outline
+
+# Summary: just counts by type
+umwelt materialize env.world.yml --level summary
+```
+
+Write to a file:
+
+```bash
+umwelt materialize env.world.yml -o snapshot.yml
+```
+
+This is useful for inspecting what the world file produces after shorthand expansion — the materialized output shows every entity that will enter the compiled database.
+
+## Vocabulary validation
+
+When the sandbox vocabulary is registered, the parser validates entity types against the registry:
+
+```yaml
+entities:
+  - type: frobnitz    # ← unknown type
+    id: X
+```
+
+This produces a warning (not an error): `unknown entity type 'frobnitz' (not in registered vocabulary)`. Unknown types are allowed for forward compatibility — you can declare entities for vocabulary that hasn't been registered yet.
+
+## Future keys
+
+Some keys are parsed and stored but produce warnings because they aren't implemented yet:
+
+| Key | Status | Purpose |
+|---|---|---|
+| `discover:` | Phase 2 | Filesystem/runtime entity discovery |
+| `overrides:` | Phase 2 | Per-environment overrides |
+| `fixed:` | Phase 2 | Immutable constraints |
+| `include:` | Phase 2 | Include other world files |
+| `exclude:` | Phase 2 | Exclude entities from included files |
+| `vars:` | Reserved | Template variables |
+| `when:` | Reserved | Conditional blocks |
+| `version:` | Reserved | Schema versioning |
+
+These keys are stored on the `WorldFile` dataclass so future versions can process them without re-parsing.
+
+## Next steps
+
+- [PolicyEngine](policy-engine.md) — query resolved policy from Python
+- [Writing Views](writing-views.md) — write stylesheets that match world entities
+- [Plugins](plugins.md) — extend the vocabulary with your own entity types

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,9 @@ nav:
   - Home: index.md
   - Guide:
     - Writing Views: guide/writing-views.md
+    - World Files: guide/world-files.md
+    - PolicyEngine: guide/policy-engine.md
+    - Plugins: guide/plugins.md
     - Entity Reference: guide/entity-reference.md
     - How It Works: guide/how-it-works.md
     - SQL Compiler:


### PR DESCRIPTION
## Summary

Three new guide pages (1,100 lines total):

- **World Files** (`docs/guide/world-files.md`): declaring the DOM — shorthand syntax, merge semantics, classes, attributes, projections, materialization, vocabulary validation, future keys
- **PolicyEngine** (`docs/guide/policy-engine.md`): consumer-facing API — three constructors, four query modes, COW extend, persistence, raw SQL, observability, worked examples for Kibitzer and Lackpy integration patterns, test fixtures
- **Plugins** (`docs/guide/plugins.md`): philosophy and extension — two plugin roles (generators vs interactors), "umwelt declares, consumers enforce" principle, full vocabulary registration walkthrough, rate-limiting domain example, compilation pipeline diagram, design principles

Also updates mkdocs.yml nav to include the new pages.

## Test plan
- [ ] `mkdocs serve` renders all three pages
- [ ] Internal links resolve correctly
- [ ] Code examples are syntactically correct
- [ ] Examples match current API (PolicyEngine methods, registry functions)