### PR TITLE
feat: resource block model + MCP-projected tool attributes

### DIFF
--- a/docs/guide/entity-reference.md
+++ b/docs/guide/entity-reference.md
@@ -197,25 +197,25 @@ file#README.md                   { editable: false; }
 
 ---
 
-### `resource` — runtime resource
+### `resource` — runtime resource block
 
-A runtime resource with a limit. The `kind` attribute selects which resource.
+A single entity declaring runtime limits. Each limit is a property — the cascade resolves them independently, and `restrictive_direction="min"` ensures the tightest bound wins.
 
 | Attribute | Type | Required | Description |
 |---|---|---|---|
-| `kind` | str | yes | Resource kind: `memory`, `cpu-time`, `wall-time`, `max-fds`, `tmpfs` |
+| `name` | str | no | Resource block name |
 
 | Property | Type | Comparison | Description |
 |---|---|---|---|
-| `limit` | str | exact | Resource limit value with unit (e.g. `512MB`, `60s`, `128`) |
+| `memory` | str | <= (min) | Memory limit with unit (e.g. `512MB`, `1GB`) |
+| `wall-time` | str | <= (min) | Wall-clock time limit (e.g. `10m`, `1h`) |
+| `cpu` | str | <= (min) | CPU core limit (e.g. `2`, `0.5`) |
+| `max-fds` | int | <= (min) | Maximum open file descriptors |
 
 **Selector examples:**
 ```css
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
-resource[kind="cpu-time"]  { limit: 3m; }
-resource[kind="max-fds"]   { limit: 128; }
-resource[kind="tmpfs"]     { limit: 64MB; }
+resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+mode#implement resource { memory: 1GB; wall-time: 30m; }
 ```
 
 ---
@@ -652,8 +652,7 @@ world#env-name                        ← world taxon (S0 — root of environmen
 │   │       └── file[name="util.py"]
 │   └── dir[name="tests"]
 │       └── file[name="test_login.py"]
-├── resource[kind="memory"]           ← runtime limits
-├── resource[kind="wall-time"]
+├── resource                          ← runtime limits (memory, wall-time, cpu, max-fds)
 ├── network                           ← network access
 ├── env[name="CI"]                    ← env vars
 └── exec[name="bash"]                 ← executable binaries

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -19,7 +19,7 @@ world#env-name                    ← the root: a named environment
       dir[name="auth"]
         file[name="login.py"]    ← a file the agent might edit
           node.function#auth     ← a code construct inside the file (v1.1)
-  resource[kind="memory"]         ← a runtime budget
+  resource                         ← a runtime resource block (memory, wall-time, etc.)
   network                         ← network access
   env[name="CI"]                  ← an environment variable
 ```

--- a/docs/guide/writing-views.md
+++ b/docs/guide/writing-views.md
@@ -112,11 +112,13 @@ After the agent modifies any file, these commands run in order. If one fails, th
 ## Resource limits
 
 ```css
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
-resource[kind="cpu-time"]  { limit: 3m; }
-resource[kind="max-fds"]   { limit: 128; }
-resource[kind="tmpfs"]     { limit: 64MB; }
+resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+```
+
+Each limit is a property on a single `resource` entity — the cascade resolves them independently. Override specific limits per mode or environment:
+
+```css
+mode#implement resource { memory: 1GB; wall-time: 30m; }
 ```
 
 These compile to nsjail rlimits, bwrap wrappers (prlimit/timeout), or equivalent mechanisms on other targets. Missing limits mean "tool default."
@@ -156,13 +158,12 @@ hook[event="after-change"] { run: "ruff check src/"; }
 /* Development: everything editable, Bash allowed */
 world#dev file { editable: true; }
 world#dev tool[name="Bash"] { allow: true; max-level: 4; }
-world#dev resource[kind="wall-time"] { limit: 30m; }
+world#dev resource { wall-time: 30m; }
 
 /* CI: read-only, tight limits */
 world#ci file { editable: false; }
 world#ci tool[name="Bash"] { allow: true; max-level: 2; }
-world#ci resource[kind="memory"] { limit: 512MB; }
-world#ci resource[kind="wall-time"] { limit: 5m; }
+world#ci resource { memory: 512MB; wall-time: 5m; }
 
 /* Exploration: read-only, no editing tools */
 world#explore tool { allow: false; }
@@ -212,7 +213,7 @@ For common patterns, umwelt supports at-rule shorthand that desugars to entity s
 | `@tools { allow: Read, Edit; deny: Bash; }` | `tool[name="Read"] { allow: true; }` `tool[name="Edit"] { allow: true; }` `tool[name="Bash"] { allow: false; }` |
 | `@after-change { test: pytest; }` | `hook[event="after-change"] { run: "pytest"; }` |
 | `@network { deny: *; }` | `network { deny: "*"; }` |
-| `@budget { memory: 512MB; }` | `resource[kind="memory"] { limit: 512MB; }` |
+| `@budget { memory: 512MB; }` | `resource { memory: 512MB; }` |
 | `@env { allow: CI; }` | `env[name="CI"] { allow: true; }` |
 
 Both forms are first-class. Mix them freely. The @ syntax is shorter for simple cases; the entity-selector form is more powerful (compound selectors, named environments, fine-grained attribute matching).
@@ -230,8 +231,7 @@ world#auth-fix {
   tool[name="Edit"]  { allow: true; }
   tool[name="Bash"]  { allow: false; }
 
-  resource[kind="memory"]    { limit: 512MB; }
-  resource[kind="wall-time"] { limit: 5m; }
+  resource { memory: 512MB; wall-time: 5m; }
   network { deny: "*"; }
 
   hook[event="after-change"] {

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ world#auth-fix {
   tool[name="Read"]        { allow: true; }
   tool[name="Bash"]        { allow: false; }
   network                  { deny: "*"; }
-  resource[kind="memory"]  { limit: 512MB; }
+  resource                 { memory: 512MB; wall-time: 5m; }
   hook[event="after-change"] { run: "pytest tests/auth/"; }
 }
 ```

--- a/docs/vision/entity-model.md
+++ b/docs/vision/entity-model.md
@@ -60,7 +60,7 @@ The W-axis entities. Files, directories, code nodes, mounts, env vars, network e
 | `mount` | — | `src`, `dst`, `type`, `writable` | A bind mount in the workspace. |
 | `env` | — | `name`, `value` (write-only — reading value from a view is disallowed for safety) | An environment variable. |
 | `network` | — | `host`, `port`, `protocol` | A network endpoint. v1 supports `*` wildcard only; explicit hosts are v1.1+. |
-| `resource` | — | `kind`, `unit`, `limit` | A runtime resource: memory, cpu, wall-time, cpu-time, tmpfs, max-fds. |
+| `resource` | — | `memory`, `cpu-time`, `wall-time`, `tmpfs`, `max-fds` | A runtime resource. Each limit dimension is a property on the entity: `memory`, `cpu-time`, `wall-time`, `tmpfs`, `max-fds`. |
 
 #### Structural relationships
 
@@ -75,8 +75,7 @@ dir[name="src"] dir[name="test"] file      { editable: false; }
 file:glob("src/**/*.py")                    { editable: true; }
 file[path^="src/auth/"] node[kind="function"][name="authenticate"] { show: body; }
 
-resource[kind="memory"]                    { limit: 512MB; }
-resource[kind="wall-time"]                 { limit: 60s; }
+resource                                   { memory: 512MB; wall-time: 60s; }
 network                                    { deny: "*"; }
 env[name="CI"]                             { allow: true; }
 env[name="PYTHONPATH"]                     { allow: true; }
@@ -273,7 +272,7 @@ tool[name="Bash"] file[path^="src/auth/"] node[kind="function"][name="protected"
 actor#delegate file[path^="secrets/"] { visible: false; }
           /* delegate actors cannot see files in secrets/ */
 
-job[delegate="true"] resource[kind="memory"] { max-limit: 256MB; }
+job[delegate="true"] resource { max-memory: 256MB; }
           /* sub-delegate jobs have a tighter memory cap than the parent */
 
 hook[event="before-call"] tool[name="Bash"] { allow-pattern: "git *", "pytest *"; }
@@ -410,7 +409,7 @@ Both selectors have `file` as the entity type, but they resolve to different tax
 @world {
   file[path^="src/"]       { editable: true; }
   file[path$=".md"]        { editable: false; }
-  resource[kind="memory"]  { limit: 512MB; }
+  resource                 { memory: 512MB; }
   network                  { deny: "*"; }
 }
 
@@ -619,7 +618,7 @@ The existing v1 sandbox at-rules (`@source`, `@tools`, `@after-change`, `@networ
 | `@source("src/auth") { .fn#authenticate { show: body; editable: true; } }` | `file[path^="src/auth/"] node[kind="function"][name="authenticate"] { show: body; editable: true; }` |
 | `@tools { allow: Read, Edit; deny: Bash; kit: python-dev; }` | `tool[name="Read"] { allow: true; } tool[name="Edit"] { allow: true; } tool[name="Bash"] { allow: false; } kit[name="python-dev"] { allow: true; }` |
 | `@network { deny: *; }` | `network { deny: "*"; }` |
-| `@budget { memory: 512MB; wall-time: 60s; }` | `resource[kind="memory"] { limit: 512MB; } resource[kind="wall-time"] { limit: 60s; }` |
+| `@budget { memory: 512MB; wall-time: 60s; }` | `resource { memory: 512MB; wall-time: 60s; }` |
 | `@env { allow: CI, PYTHONPATH; deny: *; }` | `env[name="CI"] { allow: true; } env[name="PYTHONPATH"] { allow: true; } env { allow: false; }` (with cascade: specific wins over `*`) |
 | `@after-change { test: pytest tests/; lint: ruff check src/; }` | `hook[event="after-change"] { run: "pytest tests/"; run: "ruff check src/"; }` |
 
@@ -647,10 +646,10 @@ blq's `SandboxSpec` has eight dimensions. Here's how each one maps to the entity
 |---|---|---|
 | `network` | `none`, `localhost`, `allowed_hosts`, `unrestricted` | `network { deny: "*" }` / `network[host="localhost"] { allow: true }` / etc. |
 | `filesystem` | `readonly`, `workspace_only`, `scoped_write`, `unrestricted` | `file { editable: false }` (readonly) / `file:glob("workspace/**") { editable: true }` (workspace_only) / (unrestricted = omit) |
-| `timeout` | duration | `resource[kind="wall-time"] { limit: <duration>; }` |
-| `memory` | size | `resource[kind="memory"] { limit: <size>; }` |
-| `cpu` | duration | `resource[kind="cpu-time"] { limit: <duration>; }` |
-| `processes` | `isolated`, `visible` | `resource[kind="pids"] { isolation: <mode>; }` (or cleaner: `tool { max-level: 4; }` to block level 7 subprocess spawn) |
+| `timeout` | duration | `resource { wall-time: <duration>; }` |
+| `memory` | size | `resource { memory: <size>; }` |
+| `cpu` | duration | `resource { cpu-time: <duration>; }` |
+| `processes` | `isolated`, `visible` | `resource { pids: <mode>; }` (or cleaner: `tool { max-level: 4; }` to block level 7 subprocess spawn) |
 | `tmpfs` | size | `mount[dst="/tmp"] { type: "tmpfs"; size: <size>; }` |
 | `paths_hidden` | list | `dir[path="/home"] { visible: false; } dir[path="/var"] { visible: false; } ...` |
 
@@ -716,7 +715,7 @@ The validator receives the parsed rules for its taxon and returns a list of warn
 - Globs are well-formed.
 - Known entity types and property names are used correctly.
 
-Cross-taxon invariants (e.g., "if `tool[name="Bash"] { allow: true }` then `resource[kind="wall-time"]` must set a limit") are not in v1. They would require a whole-view validator that sees multiple taxa at once; deferred.
+Cross-taxon invariants (e.g., "if `tool[name="Bash"] { allow: true }` then `resource` must set a `wall-time` limit") are not in v1. They would require a whole-view validator that sees multiple taxa at once; deferred.
 
 Unknown at-rules, unknown entity types, and unknown declarations are always preserved with warnings, following the forward-compatibility principle from the policy-layer doc. A view can reference taxa that aren't currently registered; the view parses fine, and compilers that understand those taxa produce output for them while compilers that don't silently skip. This is how views written for a future vocabulary degrade on older umwelt installations.
 
@@ -740,7 +739,7 @@ world (4 rules)
   file[path^="src/auth/"]            editable=true
   file                                editable=false
   network                             deny="*"
-  resource[kind="memory"]             limit=512MB
+  resource                            memory=512MB
 
 capability (2 rules)
   tool                                max-level=2

--- a/docs/vision/notes/roadmap-additions.md
+++ b/docs/vision/notes/roadmap-additions.md
@@ -67,7 +67,7 @@ A visual (and textual) browser/editor for umwelt views. DevTools for policy.
         ▸ file[name="oauth.py"]     ← EDITABLE
       ▾ dir[name="common"]
         ▸ file[name="util.py"]      ← read-only
-  ▸ resource[kind="memory"]          512MB
+  ▸ resource                          memory=512MB
   ▸ network                          BLOCKED
   ▸ env[name="CI"]                   allowed
 

--- a/docs/vision/notes/selector-semantics.md
+++ b/docs/vision/notes/selector-semantics.md
@@ -17,7 +17,7 @@ file[path^="src/auth/"]     { editable: true; }
 tool[name="Bash"]            { allow: false; }
 hook[event="after-change"]   { run: "pytest"; }
 network                      { deny: "*"; }
-resource[kind="memory"]      { limit: 512MB; }
+resource                     { memory: 512MB; }
 ```
 
 **Rationale**:

--- a/docs/vision/view-format.md
+++ b/docs/vision/view-format.md
@@ -27,8 +27,7 @@ tool[name="Bash"]  { allow: false; }
 
 network { deny: "*"; }
 
-resource[kind="memory"]   { limit: 512MB; }
-resource[kind="wall-time"]{ limit: 60s; }
+resource { memory: 512MB; wall-time: 60s; }
 
 hook[event="after-change"] {
   run: "pytest tests/test_auth.py";
@@ -226,7 +225,7 @@ tool[name="Bash"] file[path^="src/auth/"] { editable: false; }
 actor#delegate file[path^="secrets/"] { visible: false; }
           /* sub-delegate actors cannot see secrets */
 
-job[delegate="true"] resource[kind="memory"] { max-limit: 256MB; }
+job[delegate="true"] resource { max-memory: 256MB; }
           /* delegated jobs have a tighter memory cap than their parent */
 ```
 
@@ -274,7 +273,7 @@ Examples:
 
 ```
 tool          { max-level: 2; }             /* tools capped at computation level ≤ 2 */
-resource[kind="memory"] { max-limit: 512MB; }    /* memory cap at most 512MB */
+resource { max-memory: 512MB; }                  /* memory cap at most 512MB */
 tool          { only-kits: python-dev, rust-dev; }   /* only these kits allowed */
 ```
 
@@ -436,7 +435,7 @@ network                              { deny: "*"; }
 
 ### `@budget { ... }`
 
-Desugars to one `resource[kind=...] { limit: N }` rule per dimension.
+Desugars to a single `resource { ... }` rule with each dimension as a property.
 
 ```
 @budget {
@@ -451,11 +450,13 @@ Desugars to one `resource[kind=...] { limit: N }` rule per dimension.
 equivalent to:
 
 ```
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 60s;   }
-resource[kind="cpu-time"]  { limit: 30s;   }
-resource[kind="max-fds"]   { limit: 128;   }
-resource[kind="tmpfs"]     { limit: 64MB;  }
+resource {
+  memory:    512MB;
+  wall-time: 60s;
+  cpu-time:  30s;
+  max-fds:   128;
+  tmpfs:     64MB;
+}
 ```
 
 ### `@env { ... }`
@@ -499,7 +500,7 @@ tool[name="Grep"]   { allow: true; }
 tool[name="Glob"]   { allow: true; }
 
 network                  { deny: "*"; }
-resource[kind="wall-time"] { limit: 60s; }
+resource                 { wall-time: 60s; }
 ```
 
 Use case: "look at the codebase and tell me where the auth logic lives." The delegate can't change anything, can't run commands, can't reach the network. It has 60 seconds.
@@ -521,8 +522,7 @@ tool[name="Bash"] { allow: false; }
 tool[name="Write"]{ allow: false; }
 
 network                    { deny: "*"; }
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
+resource                   { memory: 512MB; wall-time: 5m; }
 
 hook[event="after-change"] {
   run: "pytest tests/auth/ -x";
@@ -566,9 +566,7 @@ tool[name="Read"]     { allow: true; }
 tool[name="Bash"]     { allow: true; max-level: 2; }
 
 network                    { deny: "*"; }
-resource[kind="memory"]    { limit: 1GB; }
-resource[kind="wall-time"] { limit: 10m; }
-resource[kind="tmpfs"]     { limit: 128MB; }
+resource                   { memory: 1GB; wall-time: 10m; tmpfs: 128MB; }
 
 env[name="PYTHONPATH"]     { allow: true; }
 env[name="PYTEST_ADDOPTS"] { allow: true; }
@@ -594,8 +592,7 @@ tool[name="Bash"] {
   deny-pattern:  "rm -rf *", "curl *", "ssh *", "sudo *";
 }
 
-resource[kind="memory"]     { limit: 512MB; }
-resource[kind="wall-time"]  { limit: 5m; }
+resource { memory: 512MB; wall-time: 5m; }
 network { deny: "*"; }
 
 hook[event="after-change"] {
@@ -631,11 +628,13 @@ tool[name="Bash"]       { allow: false; }
 tool[altitude="os"]     { max-level: 4; }
 
 /* Runtime budget */
-resource[kind="memory"]     { limit: 512MB; }
-resource[kind="wall-time"]  { limit: 5m; }
-resource[kind="cpu-time"]   { limit: 3m; }
-resource[kind="max-fds"]    { limit: 128; }
-resource[kind="tmpfs"]      { limit: 64MB; }
+resource {
+  memory:    512MB;
+  wall-time: 5m;
+  cpu-time:  3m;
+  max-fds:   128;
+  tmpfs:     64MB;
+}
 
 /* Network and env */
 network { deny: "*"; }

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -214,9 +214,9 @@ def _register_world() -> None:
         taxon="world",
         name="resource",
         attributes={
-            "kind": AttrSchema(type=str, required=True, description="Resource kind: memory, cpu-time, wall-time, max-fds, tmpfs"),
+            "name": AttrSchema(type=str, description="Resource block name"),
         },
-        description="A runtime resource with a limit.",
+        description="A resource block declaring runtime limits (memory, wall-time, cpu, etc.).",
         category="budget",
     )
 
@@ -260,7 +260,10 @@ def _register_world() -> None:
     register_property(taxon="world", entity="file", name="show", value_type=str, description="What to show: body, outline, signature.")
     register_property(taxon="world", entity="dir", name="editable", value_type=bool, restrictive_direction="false", description="Whether the actor may modify files in this dir.")
     register_property(taxon="world", entity="dir", name="visible", value_type=bool, restrictive_direction="false", description="Whether the actor can see this dir.")
-    register_property(taxon="world", entity="resource", name="limit", value_type=str, restrictive_direction="min", description="Resource limit value with unit (e.g. 512MB, 60s).")
+    register_property(taxon="world", entity="resource", name="memory", value_type=str, restrictive_direction="min", description="Memory limit with unit (e.g. 512MB, 1GB).")
+    register_property(taxon="world", entity="resource", name="wall-time", value_type=str, restrictive_direction="min", description="Wall-clock time limit (e.g. 10m, 1h).")
+    register_property(taxon="world", entity="resource", name="cpu", value_type=str, restrictive_direction="min", description="CPU core limit (e.g. 2, 0.5).")
+    register_property(taxon="world", entity="resource", name="max-fds", value_type=int, restrictive_direction="min", description="Maximum open file descriptors.")
     register_property(taxon="world", entity="network", name="deny", value_type=str, restrictive_direction="superset", description="Deny pattern ('*' for all).")
     register_property(taxon="world", entity="network", name="allow", value_type=bool, restrictive_direction="false", description="Whether this endpoint is allowed.")
     register_property(taxon="world", entity="env", name="allow", value_type=bool, restrictive_direction="false", description="Whether this env var is passed through.")
@@ -312,6 +315,8 @@ def _register_capability() -> None:
             "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
             "altitude": AttrSchema(type=str, description="Enforcement altitude: os, language, semantic, conversational"),
             "level": AttrSchema(type=int, description="Computation level 0-8"),
+            "param-count": AttrSchema(type=int, description="Number of parameters (MCP-projected)"),
+            "output-type": AttrSchema(type=str, description="Output format: structured, text, stream (MCP-projected)"),
         },
         description="A tool the actor can call.",
         category="tools",
@@ -447,4 +452,4 @@ def _register_world_shorthands() -> None:
     register_shorthand(key="modes", entity_type="mode", form="list")
     register_shorthand(key="principal", entity_type="principal", form="scalar")
     register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
-    register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+    register_shorthand(key="resources", entity_type="resource", form="block")

--- a/src/umwelt/world/parser.py
+++ b/src/umwelt/world/parser.py
@@ -160,15 +160,23 @@ def _expand_shorthands(
                 id=str(value),
                 provenance=Provenance.EXPLICIT,
             ))
+        elif shorthand.form == "block" and isinstance(value, dict):
+            attrs = {str(k): str(v) for k, v in value.items()}
+            entities.append(DeclaredEntity(
+                type=shorthand.entity_type,
+                id=shorthand.entity_type,
+                attributes=attrs,
+                provenance=Provenance.EXPLICIT,
+            ))
         elif shorthand.form == "map" and isinstance(value, dict):
             for k, v in value.items():
-                attrs: dict[str, Any] = {}
+                attrs_map: dict[str, Any] = {}
                 if shorthand.attribute_key is not None:
-                    attrs[shorthand.attribute_key] = str(v)
+                    attrs_map[shorthand.attribute_key] = str(v)
                 entities.append(DeclaredEntity(
                     type=shorthand.entity_type,
                     id=str(k),
-                    attributes=attrs,
+                    attributes=attrs_map,
                     provenance=Provenance.EXPLICIT,
                 ))
 

--- a/src/umwelt/world/shorthands.py
+++ b/src/umwelt/world/shorthands.py
@@ -19,7 +19,7 @@ class ShorthandDef:
 
     key: str
     entity_type: str
-    form: Literal["list", "scalar", "map"]
+    form: Literal["list", "scalar", "map", "block"]
     attribute_key: str | None = None
 
 
@@ -27,7 +27,7 @@ def register_shorthand(
     *,
     key: str,
     entity_type: str,
-    form: Literal["list", "scalar", "map"],
+    form: Literal["list", "scalar", "map", "block"],
     attribute_key: str | None = None,
 ) -> None:
     """Register a shorthand key in the active registry scope."""

--- a/tests/sandbox/test_vocabulary.py
+++ b/tests/sandbox/test_vocabulary.py
@@ -60,7 +60,7 @@ def test_world_resource_entity():
     with registry_scope():
         _register_sandbox()
         entity = get_entity("world", "resource")
-        assert "kind" in entity.attributes
+        assert "name" in entity.attributes
 
 
 def test_world_network_entity():
@@ -136,11 +136,13 @@ def test_hook_run_property():
         assert prop.name == "run"
 
 
-def test_resource_limit_property():
+def test_resource_properties():
     with registry_scope():
         _register_sandbox()
-        prop = get_property("world", "resource", "limit")
-        assert prop.name == "limit"
+        for name in ("memory", "wall-time", "cpu", "max-fds"):
+            prop = get_property("world", "resource", name)
+            assert prop.name == name
+            assert prop.restrictive_direction == "min"
 
 
 def test_network_deny_property():

--- a/tests/world/conftest.py
+++ b/tests/world/conftest.py
@@ -29,10 +29,10 @@ def toy_world_vocab():
             attributes={}, description="an inferencer")
         register_taxon(name="world", description="test world")
         register_entity(taxon="world", name="resource",
-            attributes={"limit": AttrSchema(type=str)}, description="a resource")
+            attributes={"name": AttrSchema(type=str)}, description="a resource block")
         register_shorthand(key="tools", entity_type="tool", form="list")
         register_shorthand(key="modes", entity_type="mode", form="list")
         register_shorthand(key="principal", entity_type="principal", form="scalar")
         register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
-        register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+        register_shorthand(key="resources", entity_type="resource", form="block")
         yield

--- a/tests/world/test_integration.py
+++ b/tests/world/test_integration.py
@@ -17,6 +17,9 @@ def test_full_pipeline(tmp_path):
         "tools: [Read, Edit, Bash]\n"
         "modes: [implement]\n"
         "principal: Teague\n"
+        "resources:\n"
+        "  memory: 1GB\n"
+        "  wall-time: 10m\n"
         "entities:\n"
         "  - type: tool\n"
         "    id: Bash\n"
@@ -39,26 +42,32 @@ def test_full_pipeline(tmp_path):
         assert len(bash_entities) == 1
         assert bash_entities[0].classes == ("dangerous",)
 
+        # Resource block should be one entity with attributes
+        resource_entities = [e for e in world.entities if e.type == "resource"]
+        assert len(resource_entities) == 1
+        assert resource_entities[0].attributes["memory"] == "1GB"
+        assert resource_entities[0].attributes["wall-time"] == "10m"
+
         # Full materialization
         mw = materialize(world, DetailLevel.FULL)
-        assert mw.meta.entity_count == 5  # 3 tools + 1 mode + 1 principal
+        assert mw.meta.entity_count == 6  # 3 tools + 1 mode + 1 principal + 1 resource
         assert len(mw.projections) == 1
         assert mw.meta.detail_level == "full"
 
         # Outline strips attributes
         mw_outline = materialize(world, DetailLevel.OUTLINE)
-        assert len(mw_outline.entities) == 5
+        assert len(mw_outline.entities) == 6
         for e in mw_outline.entities:
             assert e.attributes == {}
 
         # Summary has counts only
         mw_summary = materialize(world, DetailLevel.SUMMARY)
         assert len(mw_summary.entities) == 0
-        assert mw_summary.meta.entity_count == 5
+        assert mw_summary.meta.entity_count == 6
         assert mw_summary.meta.type_counts["tool"] == 3
 
         # YAML round-trip
         text = render_yaml(mw)
         parsed = yaml.safe_load(text)
-        assert parsed["meta"]["entity_count"] == 5
-        assert len(parsed["entities"]) == 5
+        assert parsed["meta"]["entity_count"] == 6
+        assert len(parsed["entities"]) == 6

--- a/tests/world/test_parser.py
+++ b/tests/world/test_parser.py
@@ -92,13 +92,16 @@ class TestShorthandExpansion:
         assert wf.entities[0].type == "principal"
         assert wf.entities[0].id == "Teague"
 
-    def test_map_shorthand(self, tmp_path, toy_world_vocab):
+    def test_block_shorthand(self, tmp_path, toy_world_vocab):
         p = tmp_path / "t.world.yml"
         p.write_text("resources:\n  memory: 512MB\n  wall-time: 5m\n")
         wf = load_world(p)
-        assert len(wf.entities) == 2
-        mem = next(e for e in wf.entities if e.id == "memory")
-        assert mem.attributes["limit"] == "512MB"
+        assert len(wf.entities) == 1
+        res = wf.entities[0]
+        assert res.type == "resource"
+        assert res.id == "resource"
+        assert res.attributes["memory"] == "512MB"
+        assert res.attributes["wall-time"] == "5m"
 
     def test_explicit_overrides_shorthand(self, tmp_path, toy_world_vocab):
         p = tmp_path / "t.world.yml"

--- a/tests/world/test_shorthands.py
+++ b/tests/world/test_shorthands.py
@@ -33,6 +33,15 @@ def test_scope_isolation():
         assert get_shorthand("tools") is None
 
 
+def test_block_form():
+    with registry_scope():
+        register_shorthand(key="resources", entity_type="resource", form="block")
+        sd = get_shorthand("resources")
+        assert sd is not None
+        assert sd.form == "block"
+        assert sd.attribute_key is None
+
+
 def test_sandbox_vocabulary_registers_shorthands():
     from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
 
@@ -42,4 +51,17 @@ def test_sandbox_vocabulary_registers_shorthands():
         assert get_shorthand("modes") is not None
         assert get_shorthand("principal") is not None
         assert get_shorthand("inferencer") is not None
-        assert get_shorthand("resources") is not None
+        res = get_shorthand("resources")
+        assert res is not None
+        assert res.form == "block"
+
+
+def test_tool_entity_has_mcp_attributes():
+    from umwelt.registry.entities import get_entity
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+    with registry_scope():
+        register_sandbox_vocabulary()
+        tool_def = get_entity("capability", "tool")
+        assert "param-count" in tool_def.attributes
+        assert "output-type" in tool_def.attributes


### PR DESCRIPTION
## Summary

- **Resource block model**: `resource` is now a single entity with per-limit properties (`memory`, `wall-time`, `cpu`, `max-fds`) instead of N separate `resource#memory`, `resource#wall-time` entities. Matches k8s/slurm/nsjail resource block pattern. Each property uses `restrictive_direction="min"` so the cascade picks the tightest bound.
- **Block shorthand form**: New `form="block"` for the shorthand registry — `resources: {memory: 1GB, wall-time: 10m}` creates one entity with map keys as attributes.
- **MCP-projected tool attributes**: `param-count` and `output-type` added to tool entity schema, enabling selectors like `tool[param-count="0"]` and `tool[output-type="structured"]`.
- **Doc updates**: All guide and vision docs updated to use `resource { memory: 512MB; }` instead of `resource[kind="memory"] { limit: 512MB; }`.

## Note

The sandbox runtime code (desugarer, compilers, matchers, `ResourceEntity` dataclass) still uses the old `resource[kind=...]` model internally. That migration is a follow-up when compilers are updated — it touches ~30 tests across nsjail, bwrap, and state matcher.

## Test plan

- [x] All 171 world/vocabulary/policy tests pass
- [x] No regressions in existing test suite (36 pre-existing CLI failures are unrelated — subprocess module import issue in worktree)
- [ ] Follow-up: migrate sandbox runtime to resource block model

🤖 Generated with [Claude Code](https://claude.com/claude-code)