### PR TITLE
v0.6: resource blocks, mode filtering, plugin guide, PolicyEngine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ world#auth-fix {
   tool[name="Edit"]        { allow: true; }
   tool[name="Bash"]        { allow: false; }
   network                  { deny: "*"; }
-  resource[kind="memory"]  { limit: 512MB; }
-  resource[kind="wall-time"] { limit: 5m; }
+  resource                 { memory: 512MB; wall-time: 5m; }
   hook[event="after-change"] {
     run: "pytest tests/auth/ -x";
     run: "ruff check src/auth/";
@@ -77,8 +76,7 @@ tool[name="Bash"] { allow: false; }
 hook[event="after-change"] { run: "pytest tests/auth/ -x"; }
 
 /* Resource limits */
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
+resource { memory: 512MB; wall-time: 5m; }
 network { deny: "*"; }
 ```
 
@@ -109,7 +107,7 @@ world#dev tool[name="Bash"] { allow: true; max-level: 4; }
 /* CI */
 world#ci file { editable: false; }
 world#ci tool[name="Bash"] { max-level: 2; }
-world#ci resource[kind="memory"] { limit: 512MB; }
+world#ci resource { memory: 512MB; }
 ```
 
 Resolve against a specific environment: `umwelt dry-run --world dev project.umw`.

--- a/docs/guide/entity-reference.md
+++ b/docs/guide/entity-reference.md
@@ -197,25 +197,25 @@ file#README.md                   { editable: false; }
 
 ---
 
-### `resource` — runtime resource
+### `resource` — runtime resource block
 
-A runtime resource with a limit. The `kind` attribute selects which resource.
+A single entity declaring runtime limits. Each limit is a property — the cascade resolves them independently, and `restrictive_direction="min"` ensures the tightest bound wins.
 
 | Attribute | Type | Required | Description |
 |---|---|---|---|
-| `kind` | str | yes | Resource kind: `memory`, `cpu-time`, `wall-time`, `max-fds`, `tmpfs` |
+| `name` | str | no | Resource block name |
 
 | Property | Type | Comparison | Description |
 |---|---|---|---|
-| `limit` | str | exact | Resource limit value with unit (e.g. `512MB`, `60s`, `128`) |
+| `memory` | str | <= (min) | Memory limit with unit (e.g. `512MB`, `1GB`) |
+| `wall-time` | str | <= (min) | Wall-clock time limit (e.g. `10m`, `1h`) |
+| `cpu` | str | <= (min) | CPU core limit (e.g. `2`, `0.5`) |
+| `max-fds` | int | <= (min) | Maximum open file descriptors |
 
 **Selector examples:**
 ```css
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
-resource[kind="cpu-time"]  { limit: 3m; }
-resource[kind="max-fds"]   { limit: 128; }
-resource[kind="tmpfs"]     { limit: 64MB; }
+resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+mode#implement resource { memory: 1GB; wall-time: 30m; }
 ```
 
 ---
@@ -652,8 +652,7 @@ world#env-name                        ← world taxon (S0 — root of environmen
 │   │       └── file[name="util.py"]
 │   └── dir[name="tests"]
 │       └── file[name="test_login.py"]
-├── resource[kind="memory"]           ← runtime limits
-├── resource[kind="wall-time"]
+├── resource                          ← runtime limits (memory, wall-time, cpu, max-fds)
 ├── network                           ← network access
 ├── env[name="CI"]                    ← env vars
 └── exec[name="bash"]                 ← executable binaries

--- a/docs/guide/entity-reference.md
+++ b/docs/guide/entity-reference.md
@@ -209,12 +209,13 @@ A single entity declaring runtime limits. Each limit is a property — the casca
 |---|---|---|---|
 | `memory` | str | <= (min) | Memory limit with unit (e.g. `512MB`, `1GB`) |
 | `wall-time` | str | <= (min) | Wall-clock time limit (e.g. `10m`, `1h`) |
-| `cpu` | str | <= (min) | CPU core limit (e.g. `2`, `0.5`) |
+| `cpu-time` | str | <= (min) | CPU time limit (e.g. `30s`, `5m`) |
 | `max-fds` | int | <= (min) | Maximum open file descriptors |
+| `tmpfs` | str | <= (min) | Tmpfs size for /tmp (e.g. `64MB`, `256MB`) |
 
 **Selector examples:**
 ```css
-resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+resource { memory: 512MB; wall-time: 5m; cpu-time: 30s; max-fds: 128; }
 mode#implement resource { memory: 1GB; wall-time: 30m; }
 ```
 

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -19,7 +19,7 @@ world#env-name                    ← the root: a named environment
       dir[name="auth"]
         file[name="login.py"]    ← a file the agent might edit
           node.function#auth     ← a code construct inside the file (v1.1)
-  resource[kind="memory"]         ← a runtime budget
+  resource                         ← a runtime resource block (memory, wall-time, etc.)
   network                         ← network access
   env[name="CI"]                  ← an environment variable
 ```

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -471,6 +471,95 @@ World file (.world.yml)          Stylesheet (.umw)
 
 Everything in the compiled database is queryable via `engine.execute()` if the high-level API doesn't cover your case.
 
+## Multi-plugin coexistence
+
+When multiple plugins register entities in the same taxon, the world file population path handles this naturally — each plugin's entities go through `load_world()` into the compiled database, and the PolicyEngine resolves them together. No matcher conflicts arise because compilation doesn't use matchers.
+
+For live evaluation (runtime selector matching against state that isn't pre-compiled), the one-matcher-per-taxon constraint can be a problem. If blq and kibitzer both need to provide entities in the `state` taxon, they can't independently register matchers.
+
+The recommended pattern is a composite matcher that delegates by entity type:
+
+```python
+class CompositeMatcher:
+    """Delegate to per-type matchers within a single taxon."""
+
+    def __init__(self):
+        self._delegates: dict[str, MatcherProtocol] = {}
+
+    def add(self, entity_type: str, matcher: MatcherProtocol):
+        self._delegates[entity_type] = matcher
+
+    def match_type(self, type_name: str, context=None) -> list:
+        delegate = self._delegates.get(type_name)
+        return delegate.match_type(type_name, context) if delegate else []
+
+    def children(self, parent, child_type: str) -> list:
+        delegate = self._delegates.get(child_type)
+        return delegate.children(parent, child_type) if delegate else []
+
+    def condition_met(self, selector, context=None) -> bool:
+        return all(d.condition_met(selector, context) for d in self._delegates.values())
+
+    def get_attribute(self, entity, name: str):
+        for delegate in self._delegates.values():
+            val = delegate.get_attribute(entity, name)
+            if val is not None:
+                return val
+        return None
+
+    def get_id(self, entity) -> str | None:
+        for delegate in self._delegates.values():
+            val = delegate.get_id(entity)
+            if val is not None:
+                return val
+        return None
+```
+
+Register the composite once for the taxon; each plugin adds its delegate:
+
+```python
+composite = CompositeMatcher()
+composite.add("hook", kibitzer_matcher)
+composite.add("job", blq_matcher)
+register_matcher(taxon="state", matcher=composite)
+```
+
+This preserves the 1:1 taxon→matcher mapping at the registry level while allowing multiple sources underneath. In practice, most plugins won't need this — world file population covers the common case.
+
+## Cross-taxon policy invariants
+
+Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, resource#wall-time must have a limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
+
+```python
+def lint_bash_requires_wall_time(engine: PolicyEngine) -> list[LintWarning]:
+    bash_allowed = engine.check(type="tool", id="Bash", allow="true")
+    wall_time = engine.resolve(type="resource", id="wall-time", property="limit")
+    if bash_allowed and wall_time is None:
+        return [LintWarning(
+            smell="missing_constraint",
+            severity="warning",
+            description="tool#Bash is allowed but resource#wall-time has no limit",
+            entities=("tool#Bash", "resource#wall-time"),
+            property=None,
+        )]
+    return []
+```
+
+Custom lint rules run after compilation and can query any entity type. This avoids adding a cross-taxon validator protocol — the PolicyEngine query API is already the cross-taxon interface.
+
+## Plugin discovery (future)
+
+Currently, plugins must be explicitly imported and their `register_*()` functions called. For systems where many plugins coexist, a future version will support `entry_points`-based autodiscovery:
+
+```toml
+# In a plugin's pyproject.toml
+[project.entry-points."umwelt.plugins"]
+blq = "blq.umwelt_plugin:register"
+kibitzer = "kibitzer.umwelt_plugin:register"
+```
+
+Until then, the recommended pattern is a single orchestration function that imports and registers all plugins needed for a given deployment.
+
 ## Design principles for plugin authors
 
 **Register at import time.** Call `register_*` functions when your module is imported, not lazily. This ensures the vocabulary is available before any parsing happens.

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -329,6 +329,90 @@ register_property(
 
 Now `secret[sensitivity="critical"] { visible: false; audit: true; }` works in any view.
 
+## The matcher protocol
+
+Most consumers query the compiled database through the PolicyEngine and never need a matcher. But if your plugin needs to evaluate selectors against a live world (not a pre-compiled snapshot), you implement the `MatcherProtocol`:
+
+```python
+from umwelt.registry.matchers import MatcherProtocol, register_matcher
+
+class FilesystemMatcher:
+    """Evaluate selectors against actual filesystem state."""
+
+    def __init__(self, root: str):
+        self.root = root
+
+    def match_type(self, type_name: str, context=None) -> list:
+        """Return all entities of this type in your world."""
+        if type_name == "dir":
+            return [p for p in Path(self.root).iterdir() if p.is_dir()]
+        if type_name == "file":
+            return [p for p in Path(self.root).rglob("*") if p.is_file()]
+        return []
+
+    def children(self, parent, child_type: str) -> list:
+        """Return child entities of `parent` matching `child_type`."""
+        if child_type == "file":
+            return [p for p in parent.iterdir() if p.is_file()]
+        if child_type == "dir":
+            return [p for p in parent.iterdir() if p.is_dir()]
+        return []
+
+    def condition_met(self, selector, context=None) -> bool:
+        """Evaluate a cross-taxon context qualifier."""
+        return True
+
+    def get_attribute(self, entity, name: str):
+        """Return an attribute value on an entity."""
+        if name == "path":
+            return str(entity)
+        if name == "name":
+            return entity.name
+        return None
+
+    def get_id(self, entity) -> str | None:
+        """Return the entity's #id for selector matching."""
+        return entity.name
+```
+
+The five methods:
+
+| Method | When it's called | What it returns |
+|---|---|---|
+| `match_type(type_name)` | Type selector (`file`, `dir`) | All entities of that type |
+| `children(parent, child_type)` | Descendant selector (`dir file`) | Children of `parent` matching `child_type` |
+| `condition_met(selector)` | Cross-taxon qualifier | Whether the context condition holds |
+| `get_attribute(entity, name)` | Attribute selector (`[path$=".py"]`) | The attribute value, or None |
+| `get_id(entity)` | ID selector (`#auth.py`) | The entity's identity string |
+
+Register it for a taxon:
+
+```python
+register_matcher(taxon="world", matcher=FilesystemMatcher("/workspace"))
+```
+
+The selector engine calls your matcher methods but never interprets the entity handles — they're opaque to the core. A filesystem matcher returns `Path` objects; an in-memory test matcher returns dicts; a database-backed matcher returns row IDs. The core doesn't care.
+
+**When you don't need a matcher:** If your entities are declared in world files and compiled via `PolicyEngine.from_files()`, the compilation pipeline handles selector matching internally. You only need a custom matcher for live evaluation against runtime state.
+
+## Desugaring and stability
+
+umwelt provides `@`-rule syntactic sugar that desugars into standard selectors and declarations:
+
+```css
+/* Sugar */
+@tools Read, Edit, Bash { visible: true; }
+
+/* Desugars to */
+tool#Read { visible: true; }
+tool#Edit { visible: true; }
+tool#Bash { visible: true; }
+```
+
+This desugaring implicitly commits to specific entity type names and property names. `@tools` assumes a `tool` entity type exists; `visible` assumes the property is registered. If you're building on the sandbox vocabulary, these names are stable. If you're extending with your own vocabulary, be aware that your `@`-rules create dependencies on your entity and property names.
+
+The desugaring happens at parse time — the compiled database never sees `@`-rules, only the expanded selectors. This means `trace()` shows the desugared form, which can be surprising if you're debugging a stylesheet that uses sugar heavily.
+
 ## Registry isolation in tests
 
 The vocabulary registry is global by default. In tests, use `registry_scope()` to isolate:

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,410 @@
+# Plugins
+
+umwelt's core is vocabulary-agnostic. It provides the parser, selector engine, cascade resolver, and compiler protocol — but knows nothing about files, tools, modes, or networks. All of that comes from plugins.
+
+This guide explains the philosophy, shows how the first-party sandbox plugin works, and walks through building your own.
+
+## Philosophy
+
+### The common language problem
+
+Every enforcement tool in a multi-agent system invents its own configuration format. nsjail has protobuf textproto, bwrap has argv flags, lackpy has Python namespace dicts, kibitzer has hook rules. They all describe variants of the same thing — what the actor can see, edit, call, and consume — but none of them can read each other's descriptions, and none of them compose.
+
+umwelt is the lingua franca those tools translate from. A single view file describes the policy; compilers translate it into whatever native format each tool expects. The policy is written once; each tool reads the subset it cares about.
+
+### Two plugin roles
+
+Plugins interact with umwelt in exactly two ways:
+
+**Generators** populate the world — they declare what entities exist. A filesystem scanner adds `file` and `dir` entities. A tool registry adds `tool` entities. A runtime monitor adds `resource` and `budget` entities. Generators run before compilation; their output is the DOM that stylesheets match against.
+
+**Interactors** consume resolved policy — they query what the cascade decided and act on it. Kibitzer queries tool visibility. Lackpy queries the tool namespace. A workspace builder queries file editability. Interactors run after compilation; their input is the PolicyEngine.
+
+Most real plugins are interactors. Generators are less common because world files handle most entity declaration.
+
+### umwelt declares, consumers enforce
+
+This is the load-bearing design principle. umwelt resolves policy ("tool#Bash has max-level: 3"). Consumers enforce it ("I will reject Bash invocations above level 3"). umwelt never interprets what a value *means* — it resolves what the cascade says the value *is*.
+
+This separation is why the PolicyEngine returns strings, not typed values. `"true"` is a string. Your consumer decides whether to treat it as a boolean, a feature flag, or a sentinel value. umwelt is a specification engine; the semantics live in consumers.
+
+### Vocabulary is the extension surface
+
+The plugin registration API has six hooks:
+
+| Registration | What it adds | Who uses it |
+|---|---|---|
+| `register_taxon()` | A namespace for entity types | Anyone adding a new domain |
+| `register_entity()` | An entity type within a taxon | Anyone adding matchable entities |
+| `register_property()` | A property on an entity type | Anyone adding policy-controllable attributes |
+| `register_shorthand()` | A world file shorthand key | Anyone simplifying YAML authoring |
+| `register_matcher()` | A matcher for a taxon | Anyone evaluating selectors at runtime |
+| `register_validator()` | A validator for a taxon | Anyone adding structural validation |
+
+The first four are the most common. Matchers and validators are advanced — most interactors don't need them because they query the compiled database, not the live DOM.
+
+## The sandbox plugin: a worked example
+
+The first-party sandbox plugin (`umwelt.sandbox`) registers the entire sandbox vocabulary. It's the best example of how a real plugin works.
+
+### Taxa registration
+
+```python
+from umwelt.registry import register_taxon
+
+register_taxon(
+    name="world",
+    description="Entities the actor can couple to: filesystem, network, environment.",
+    ma_concept="world_coupling_axis",
+)
+
+register_taxon(
+    name="capability",
+    description="What the actor can do: tools, kits, effects.",
+    ma_concept="decision_surface_axis",
+)
+
+register_taxon(
+    name="state",
+    description="What the Harness tracks: hooks, jobs, budgets, modes.",
+    ma_concept="observation_layer",
+)
+```
+
+A **taxon** is a namespace. Selectors within a taxon compete in the same cascade; selectors across taxa never interfere. The sandbox registers three: `world` (what exists), `capability` (what the actor can do), and `state` (what the system tracks).
+
+### Entity registration
+
+```python
+from umwelt.registry import register_entity, AttrSchema
+
+register_entity(
+    taxon="capability",
+    name="tool",
+    attributes={
+        "name": AttrSchema(type=str, required=True, description="Tool name"),
+        "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
+        "level": AttrSchema(type=int, description="Computation level 0-8"),
+    },
+    description="A tool the actor can call.",
+    category="tools",
+)
+```
+
+An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against.
+
+### Property registration
+
+```python
+from umwelt.registry import register_property
+
+register_property(
+    taxon="capability",
+    entity="tool",
+    name="visible",
+    value_type=bool,
+    description="Whether the tool is displayed to the delegate.",
+)
+
+register_property(
+    taxon="capability",
+    entity="tool",
+    name="max-level",
+    value_type=int,
+    comparison="<=",
+    value_attribute="level",
+    value_range=(0, 8),
+    description="Maximum computation level permitted.",
+    category="effects_ceiling",
+)
+```
+
+A **property** is what declarations set. `tool { visible: true; }` sets the `visible` property. Properties have comparison semantics:
+
+| Comparison | Resolution rule | Use case |
+|---|---|---|
+| `exact` (default) | Highest specificity wins | Boolean flags, string values |
+| `<=` | Tightest bound (MIN) wins | Numeric caps (max-level, limits) |
+| `pattern-in` | Set union of all matching values | Allow/deny pattern lists |
+
+### Shorthand registration
+
+```python
+from umwelt.world.shorthands import register_shorthand
+
+register_shorthand(key="tools", entity_type="tool", form="list")
+register_shorthand(key="modes", entity_type="mode", form="list")
+register_shorthand(key="principal", entity_type="principal", form="scalar")
+register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+```
+
+Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Three forms:
+
+| Form | YAML syntax | Expansion |
+|---|---|---|
+| `list` | `tools: [Read, Edit]` | One entity per list item, item becomes the `id` |
+| `scalar` | `principal: Teague` | One entity, value becomes the `id` |
+| `map` | `resources: {memory: 512MB}` | One entity per key, key is `id`, value goes to `attribute_key` |
+
+### Wiring it together
+
+The sandbox plugin's entry point calls all registrations:
+
+```python
+def register_sandbox_vocabulary():
+    _register_world()        # world, file, dir, resource, network, env, mount
+    _register_capability()   # tool, kit
+    _register_state()        # hook, job, budget, mode
+    _register_actor()        # inferencer, executor
+    _register_principal()    # principal (identity axis)
+    _register_audit()        # observation, manifest (observer axis)
+    _register_validators()   # structural validation
+    _register_sugar()        # @-rule desugaring
+    _register_world_shorthands()  # world file shorthands
+```
+
+PolicyEngine calls `register_sandbox_vocabulary()` automatically when you use `from_files()` or the programmatic builder. Consumers using `from_db()` skip this — the vocabulary is already baked into the compiled database.
+
+## Building your own plugin
+
+### Example: a rate-limiting policy domain
+
+Suppose you're building a system that rate-limits API calls per endpoint. You want to express this as policy:
+
+```css
+endpoint#/api/users { rate-limit: 100; burst: 20; }
+endpoint#/api/admin { rate-limit: 10; burst: 5; }
+endpoint.public { rate-limit: 1000; }
+```
+
+#### Step 1: Register the vocabulary
+
+```python
+# my_plugin/vocabulary.py
+from umwelt.registry import register_taxon, register_entity, register_property, AttrSchema
+from umwelt.world.shorthands import register_shorthand
+
+def register_rate_limit_vocabulary():
+    register_taxon(
+        name="api",
+        description="API endpoints and their rate-limiting policy.",
+    )
+
+    register_entity(
+        taxon="api",
+        name="endpoint",
+        attributes={
+            "path": AttrSchema(type=str, required=True, description="URL path pattern"),
+            "method": AttrSchema(type=str, description="HTTP method (GET, POST, etc.)"),
+        },
+        description="An API endpoint.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="rate-limit",
+        value_type=int,
+        comparison="<=",
+        description="Requests per minute.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="burst",
+        value_type=int,
+        comparison="<=",
+        description="Burst capacity above the rate limit.",
+    )
+
+    register_property(
+        taxon="api", entity="endpoint",
+        name="auth-required",
+        value_type=bool,
+        description="Whether authentication is required.",
+    )
+
+    register_shorthand(key="endpoints", entity_type="endpoint", form="list")
+```
+
+#### Step 2: Write a world file
+
+```yaml
+# api.world.yml
+endpoints: [/api/users, /api/admin, /api/health]
+
+entities:
+  - type: endpoint
+    id: /api/admin
+    classes: [admin, restricted]
+  - type: endpoint
+    id: /api/health
+    classes: [public]
+```
+
+#### Step 3: Write a stylesheet
+
+```css
+/* api-policy.umw */
+endpoint { rate-limit: 100; burst: 20; auth-required: true; }
+endpoint.public { rate-limit: 1000; auth-required: false; }
+endpoint.restricted { rate-limit: 10; burst: 5; }
+```
+
+#### Step 4: Query from your consumer
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine()
+engine.register_vocabulary(register_rate_limit_vocabulary)
+engine.add_entities([
+    {"type": "endpoint", "id": "/api/users"},
+    {"type": "endpoint", "id": "/api/admin", "classes": ["admin", "restricted"]},
+    {"type": "endpoint", "id": "/api/health", "classes": ["public"]},
+])
+engine.add_stylesheet("""
+    endpoint { rate-limit: 100; burst: 20; auth-required: true; }
+    endpoint.public { rate-limit: 1000; auth-required: false; }
+    endpoint.restricted { rate-limit: 10; burst: 5; }
+""")
+
+# Now use it in your rate limiter
+def get_rate_config(engine, path):
+    props = engine.resolve(type="endpoint", id=path)
+    return {
+        "rate_limit": int(props.get("rate-limit", "100")),
+        "burst": int(props.get("burst", "20")),
+        "auth_required": props.get("auth-required") == "true",
+    }
+
+config = get_rate_config(engine, "/api/admin")
+# → {"rate_limit": 10, "burst": 5, "auth_required": True}
+```
+
+#### Step 5: Use the compiled database
+
+For production, compile once and distribute:
+
+```python
+# At build time
+engine.save("api-policy.db")
+
+# At runtime (fast — no parsing)
+engine = PolicyEngine.from_db("api-policy.db")
+config = get_rate_config(engine, "/api/admin")
+```
+
+### Example: extending the sandbox vocabulary
+
+You don't need a new taxon for every extension. If your entities fit an existing taxon, add them there:
+
+```python
+from umwelt.registry import register_entity, register_property, AttrSchema
+
+register_entity(
+    taxon="world",
+    name="secret",
+    parent="dir",
+    attributes={
+        "path": AttrSchema(type=str, required=True),
+        "sensitivity": AttrSchema(type=str, description="Classification: low, medium, high, critical"),
+    },
+    description="A secret file requiring special access policy.",
+)
+
+register_property(
+    taxon="world", entity="secret",
+    name="visible",
+    value_type=bool,
+    description="Whether the agent can see this secret.",
+)
+
+register_property(
+    taxon="world", entity="secret",
+    name="audit",
+    value_type=bool,
+    description="Whether access to this secret is audited.",
+)
+```
+
+Now `secret[sensitivity="critical"] { visible: false; audit: true; }` works in any view.
+
+## Registry isolation in tests
+
+The vocabulary registry is global by default. In tests, use `registry_scope()` to isolate:
+
+```python
+from umwelt.registry.taxa import registry_scope
+
+def test_my_vocabulary():
+    with registry_scope():
+        register_rate_limit_vocabulary()
+        # Registry state is isolated to this block
+        # — won't interfere with other tests
+
+    # Registry is restored to its previous state here
+```
+
+`registry_scope()` creates a fresh registry state and restores the previous state on exit. This means tests can register whatever vocabulary they need without polluting each other.
+
+## The compilation pipeline
+
+Understanding what happens when the PolicyEngine compiles helps you write better plugins.
+
+```
+World file (.world.yml)          Stylesheet (.umw)
+         │                              │
+    load_world()                    parse()
+         │                              │
+    WorldFile                        View (AST)
+         │                              │
+    populate_from_world()       compile_view()
+         │                              │
+    ┌────┴──────────────────────────────┴────┐
+    │          SQLite database               │
+    │                                        │
+    │  entities table ← from world file      │
+    │  selectors table ← from stylesheet     │
+    │  cascade_candidates ← selector × entity│
+    │  resolved_properties ← cascade winner  │
+    │  projection views ← vocabulary-driven  │
+    │  compilation_meta ← provenance         │
+    └────────────────────────────────────────┘
+                     │
+              PolicyEngine
+                     │
+         resolve / trace / lint
+```
+
+1. **World file** is parsed into a `WorldFile` with `DeclaredEntity` instances
+2. **Entities** are inserted into the `entities` table (with classes and attributes as JSON)
+3. **Stylesheet** is parsed into a `View` AST
+4. **Each selector** is compiled against the entities table, producing `cascade_candidates` — every (entity, property, value, specificity, rule_index) combination
+5. **Resolution views** resolve the cascade: `_resolved_exact` (highest specificity), `_resolved_cap` (MIN for `<=` comparison), `_resolved_pattern` (set union for `pattern-in`)
+6. **`resolved_properties`** is the UNION of the three resolution strategies — the final answer
+7. **Projection views** pivot `resolved_properties` into one-row-per-entity views for convenience
+8. **PolicyEngine** wraps the connection and provides the query API
+
+Everything in the compiled database is queryable via `engine.execute()` if the high-level API doesn't cover your case.
+
+## Design principles for plugin authors
+
+**Register at import time.** Call `register_*` functions when your module is imported, not lazily. This ensures the vocabulary is available before any parsing happens.
+
+**Use comparison semantics.** If a property represents a cap or limit, register it with `comparison="<="`. The cascade will correctly resolve to the tightest bound. If it represents a set of patterns, use `comparison="pattern-in"` for set union.
+
+**Keep consumers thin.** Your consumer should call `engine.resolve()` and interpret the string. Don't reimplement cascade resolution, specificity computation, or selector matching — that's what umwelt is for.
+
+**Compile once, query many times.** Use `from_files()` or the programmatic builder during setup, then `save()` the result. Distribute the `.db` file to consumers, which load it with `from_db()` (fast — no parsing needed).
+
+**Use extend() for specialization.** If your consumer needs to fork the policy for different contexts (per-request, per-mode, per-user), use `extend()` rather than rebuilding from scratch. The SQLite backup is fast and gives you true isolation.
+
+**Test with the programmatic builder.** Create a `PolicyEngine()`, add entities and a stylesheet, and assert on `resolve()`. No files needed. The `registry_scope()` fixture keeps your tests isolated.
+
+## Next steps
+
+- [PolicyEngine](policy-engine.md) — the full API reference for consuming resolved policy
+- [World Files](world-files.md) — declare the entities your policy matches
+- [Writing Views](writing-views.md) — write the stylesheets that set policy
+- [How It Works](how-it-works.md) — the architecture underneath
+- [Entity Reference](entity-reference.md) — all registered entity types and properties

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -85,13 +85,15 @@ register_entity(
         "name": AttrSchema(type=str, required=True, description="Tool name"),
         "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
         "level": AttrSchema(type=int, description="Computation level 0-8"),
+        "param-count": AttrSchema(type=int, description="Number of parameters (MCP-projected)"),
+        "output-type": AttrSchema(type=str, description="Output format: structured, text, stream"),
     },
     description="A tool the actor can call.",
     category="tools",
 )
 ```
 
-An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against.
+An **entity type** is a CSS element type. Once `tool` is registered, selectors like `tool#Bash`, `tool.dangerous`, and `tool[kit="filesystem"]` become valid. The `attributes` schema defines what attribute selectors can match against — including MCP-projected attributes like `param-count` and `output-type` that enable selectors like `tool[output-type="structured"] { cache: true; }`.
 
 ### Property registration
 
@@ -135,16 +137,17 @@ from umwelt.world.shorthands import register_shorthand
 register_shorthand(key="tools", entity_type="tool", form="list")
 register_shorthand(key="modes", entity_type="mode", form="list")
 register_shorthand(key="principal", entity_type="principal", form="scalar")
-register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+register_shorthand(key="resources", entity_type="resource", form="block")
 ```
 
-Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Three forms:
+Shorthands let world file authors write `tools: [Read, Edit]` instead of explicit entity blocks. Four forms:
 
 | Form | YAML syntax | Expansion |
 |---|---|---|
 | `list` | `tools: [Read, Edit]` | One entity per list item, item becomes the `id` |
 | `scalar` | `principal: Teague` | One entity, value becomes the `id` |
-| `map` | `resources: {memory: 512MB}` | One entity per key, key is `id`, value goes to `attribute_key` |
+| `map` | `tags: {hot: critical}` | One entity per key, key is `id`, value goes to `attribute_key` |
+| `block` | `resources: {memory: 512MB}` | One entity, keys become attributes |
 
 ### Wiring it together
 
@@ -528,18 +531,18 @@ This preserves the 1:1 taxon→matcher mapping at the registry level while allow
 
 ## Cross-taxon policy invariants
 
-Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, resource#wall-time must have a limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
+Per-taxon validators can check structural constraints within a taxon, but some invariants span taxa — "if tool#Bash is allowed, the resource block must set a wall-time limit." These are best expressed as custom lint rules rather than validators, because the linter already sees the full resolved database:
 
 ```python
 def lint_bash_requires_wall_time(engine: PolicyEngine) -> list[LintWarning]:
     bash_allowed = engine.check(type="tool", id="Bash", allow="true")
-    wall_time = engine.resolve(type="resource", id="wall-time", property="limit")
+    wall_time = engine.resolve(type="resource", id="resource", property="wall-time")
     if bash_allowed and wall_time is None:
         return [LintWarning(
             smell="missing_constraint",
             severity="warning",
-            description="tool#Bash is allowed but resource#wall-time has no limit",
-            entities=("tool#Bash", "resource#wall-time"),
+            description="tool#Bash is allowed but resource has no wall-time limit",
+            entities=("tool#Bash", "resource"),
             property=None,
         )]
     return []

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -1,0 +1,419 @@
+# PolicyEngine
+
+The PolicyEngine is the consumer-facing Python API for querying resolved policy. It compiles a world file and a stylesheet into an in-memory SQLite database, resolves the CSS cascade, and answers questions about the result.
+
+**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it.
+
+## Quick start
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+
+# What's the resolved value of a property?
+engine.resolve(type="tool", id="Bash", property="visible")  # → "true"
+
+# Get all resolved properties for an entity
+engine.resolve(type="tool", id="Bash")  # → {"visible": "true", "max-level": "3", ...}
+
+# Does the policy match what we expect?
+engine.check(type="tool", id="Bash", visible="true")  # → True
+
+# Enforce it — raises PolicyDenied on mismatch
+engine.require(type="tool", id="Bash", visible="true")
+```
+
+## Three constructors
+
+PolicyEngine has three ways to create an instance, corresponding to three points in the lifecycle:
+
+### Author time: `from_files()`
+
+Compile from source files. Parses the world YAML, parses the stylesheet, builds the full compiled database.
+
+```python
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+```
+
+Use this when you have the original source files and want the full compilation pipeline — parsing, vocabulary registration, cascade resolution, projection views.
+
+### Consumer time: `from_db()`
+
+Load a pre-compiled database. No parsing, no compilation. The database is copied into memory (copy-on-write semantics — the original file is never modified).
+
+```python
+engine = PolicyEngine.from_db("compiled.duckdb")
+```
+
+Use this in consumers that receive a compiled policy database. Kibitzer loads its policy this way — the compilation happened at authoring time, and Kibitzer just queries the result.
+
+### Runtime: programmatic builder
+
+Build an engine incrementally from Python data structures. Useful for testing, runtime composition, and consumers that construct policy dynamically.
+
+```python
+engine = PolicyEngine()
+engine.add_entities([
+    {"type": "tool", "id": "Read", "classes": ["safe"]},
+    {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    {"type": "mode", "id": "implement"},
+])
+engine.add_stylesheet("""
+    tool { visible: true; allow: true; }
+    tool.dangerous { max-level: 3; }
+""")
+```
+
+Compilation is lazy — the engine compiles on first query, not on construction. You can call `add_entities()` and `add_stylesheet()` multiple times before querying.
+
+## Query modes
+
+### resolve — what does the policy say?
+
+```python
+# Single property
+value = engine.resolve(type="tool", id="Bash", property="max-level")
+# → "3" or None if no rule matches
+
+# All properties for an entity
+props = engine.resolve(type="tool", id="Bash")
+# → {"visible": "true", "allow": "true", "max-level": "3"}
+
+# All entities of a type with their properties
+all_tools = engine.resolve_all(type="tool")
+# → [{"entity_id": "Read", "type_name": "tool", "classes": [...], "properties": {...}}, ...]
+```
+
+All values are strings. The cascade resolves to string values; your consumer interprets them. `"true"` is the string `"true"`, not the Python boolean `True`. This is intentional — umwelt is a specification engine, not a runtime.
+
+### trace — why does the policy say that?
+
+```python
+from umwelt.policy import TraceResult, Candidate
+
+result: TraceResult = engine.trace(
+    type="tool", id="Bash", property="max-level",
+)
+
+print(f"Winner: {result.value}")  # → "3"
+
+for c in result.candidates:
+    marker = "✓" if c.won else " "
+    print(f"  [{marker}] {c.value}  spec={c.specificity}  "
+          f"rule={c.rule_index}  {c.source_file}:{c.source_line}")
+```
+
+Output:
+
+```
+Winner: 3
+  [✓] 3  spec=[0,1,1]  rule=2  policy.umw:3
+  [ ] 5  spec=[0,0,1]  rule=1  policy.umw:1
+```
+
+Trace shows every cascade candidate that competed for a property, ordered by specificity (highest first). The winner is marked with `won=True`. This is how you debug "why did my tool get max-level 3 instead of 5?" — you can see which rule won and why.
+
+### lint — are there policy smells?
+
+```python
+from umwelt.policy import LintWarning
+
+warnings: list[LintWarning] = engine.lint()
+
+for w in warnings:
+    print(f"[{w.severity}] {w.smell}: {w.description}")
+```
+
+Five smell detectors:
+
+| Smell | Severity | What it catches |
+|---|---|---|
+| `narrow_win` | warning | Winner beat runner-up by specificity margin of 1 — fragile |
+| `shadowed_rule` | info | A rule that never wins for any entity — dead code |
+| `conflicting_intent` | warning | Same specificity, opposite values — winner decided by source order alone |
+| `uncovered_entity` | info | An entity with no resolved properties — nothing matches it |
+| `specificity_escalation` | warning | 3+ specificity levels for one property — possible escalation war |
+
+Lint is useful for policy authors debugging their stylesheets. Consumers can also use it to report warnings to users.
+
+### check and require — enforce constraints
+
+```python
+# Soft check: returns True/False
+if not engine.check(type="tool", id="Bash", visible="true", allow="true"):
+    print("Policy violation")
+
+# Hard check: raises PolicyDenied
+try:
+    engine.require(type="tool", id="Bash", visible="true")
+except PolicyDenied as e:
+    print(f"Denied: {e.entity} {e.property}={e.actual} (expected {e.expected})")
+```
+
+`check()` tests multiple properties at once — all must match for it to return `True`. `require()` raises `PolicyDenied` on the first mismatch.
+
+## COW extend — fork and specialize
+
+`extend()` produces a new engine with additional entities and/or stylesheet rules. The original engine is never modified.
+
+```python
+base = PolicyEngine.from_files(world="base.world.yml", stylesheet="base.umw")
+
+# Fork with additional rules
+strict = base.extend(stylesheet="tool.dangerous { allow: false; }")
+
+# Fork with additional entities
+expanded = base.extend(entities=[
+    {"type": "tool", "id": "NewTool", "classes": ["experimental"]},
+])
+
+# Fork with both
+custom = base.extend(
+    entities=[{"type": "mode", "id": "review"}],
+    stylesheet="mode#review tool { max-level: 2; }",
+)
+
+# The original is untouched
+base.resolve(type="tool", id="Bash", property="allow")     # → "true"
+strict.resolve(type="tool", id="Bash", property="allow")   # → "false"
+```
+
+This is implemented via SQLite `backup()` — the entire compiled database is copied into a new in-memory connection, then the new entities/rules are compiled on top. The cost is proportional to database size (typically <1ms for reasonable policy sizes).
+
+Use cases:
+
+- **Mode switching**: fork with a mode-specific stylesheet overlay
+- **Per-request specialization**: add context-specific entities before querying
+- **Testing**: create a base engine in a fixture, extend per test
+
+## Persistence
+
+### Save to file
+
+```python
+engine.save("compiled.duckdb")
+```
+
+Writes the compiled SQLite database to a file. Another consumer can load it with `from_db()`. The database contains everything: entities, cascade candidates, resolved properties, projection views, compilation metadata.
+
+### Round-trip export
+
+```python
+engine.to_files(world="exported.world.yml", stylesheet="exported.umw")
+```
+
+Best-effort export back to source files. The world YAML is reconstructed from the entities table. The stylesheet is copied from the original source (if tracked in compilation metadata) or reconstructed as a comment block.
+
+## Raw SQL escape hatch
+
+The compiled database is a SQLite database with a well-defined schema. If the query API doesn't cover your use case, you can run SQL directly:
+
+```python
+rows = engine.execute(
+    "SELECT entity_id, type_name FROM entities WHERE type_name = ?",
+    ("tool",),
+)
+```
+
+### Database schema
+
+| Table | Purpose |
+|---|---|
+| `entities` | All declared entities (type, id, classes, attributes as JSON) |
+| `selectors` | Compiled selector rules |
+| `cascade_candidates` | Every (entity, property, value) candidate before resolution |
+| `property_types` | Registered property schemas (type, comparison semantics) |
+| `resolved_properties` | **The resolution result** — winning value per (entity, property) |
+| `compilation_meta` | Provenance: source files, timestamps, counts |
+
+### Projection views
+
+The compiled database also contains vocabulary-driven SQL views:
+
+| View | What it provides |
+|---|---|
+| `resolved_entities` | All entities with their resolved properties as a JSON object |
+| `tools` | Pivot view: one row per tool, one column per tool property |
+| `modes` | Pivot view for modes |
+| (per entity type) | One pivot view per registered entity type with properties |
+
+These views are generated from the vocabulary registry — whatever entity types and properties are registered get their own pivot view. A consumer can query `SELECT * FROM tools WHERE visible = 'true'` directly.
+
+## Observability
+
+PolicyEngine logs to `umwelt.policy` via Python's standard `logging`:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+| Level | What's logged |
+|---|---|
+| `INFO` | `compile` (source files, entity count), `resolve` (entity, property, value), `resolve_all`, `extend` |
+| `WARNING` | `require_denied` (entity, property, expected vs actual), lint warnings |
+| `DEBUG` | `trace` (entity, property, candidate count), vocabulary/projection skip reasons |
+
+All log entries include structured `extra` fields for machine consumption.
+
+## Error handling
+
+```python
+from umwelt.errors import PolicyDenied, PolicyError, UmweltError
+
+# PolicyDenied — raised by require()
+# PolicyError — base class for all policy errors
+# UmweltError — base class for all umwelt errors
+```
+
+`PolicyDenied` has structured fields:
+
+```python
+try:
+    engine.require(type="tool", id="Bash", visible="false")
+except PolicyDenied as e:
+    e.entity    # "tool#Bash"
+    e.property  # "visible"
+    e.expected  # "false"
+    e.actual    # "true"
+```
+
+## Worked example: a Kibitzer-style consumer
+
+Kibitzer is a semantic-altitude tool that observes and coaches an AI agent during a session. It needs to know which tools are visible, what their max computation level is, and whether specific modes are active. Here's how it integrates:
+
+```python
+from umwelt.policy import PolicyEngine, PolicyDenied
+
+class KibitzerSession:
+    def __init__(self, policy_db: str):
+        self.engine = PolicyEngine.from_db(policy_db)
+
+    def is_tool_allowed(self, tool_name: str) -> bool:
+        return self.engine.check(type="tool", id=tool_name, allow="true")
+
+    def get_tool_config(self, tool_name: str) -> dict:
+        props = self.engine.resolve(type="tool", id=tool_name)
+        if props is None:
+            return {"visible": False, "allowed": False}
+        return {
+            "visible": props.get("visible") == "true",
+            "allowed": props.get("allow") == "true",
+            "max_level": int(props.get("max-level", "8")),
+            "patterns": props.get("allow-pattern", "").split(","),
+        }
+
+    def get_visible_tools(self) -> list[str]:
+        all_tools = self.engine.resolve_all(type="tool")
+        return [
+            t["entity_id"]
+            for t in all_tools
+            if t["properties"].get("visible") == "true"
+        ]
+
+    def enforce_tool_call(self, tool_name: str):
+        """Raise if tool is not allowed by policy."""
+        self.engine.require(type="tool", id=tool_name, allow="true")
+
+    def switch_mode(self, mode_name: str) -> "KibitzerSession":
+        """Fork the engine with a mode-specific overlay."""
+        child_engine = self.engine.extend(
+            entities=[{"type": "mode", "id": mode_name}],
+        )
+        session = KibitzerSession.__new__(KibitzerSession)
+        session.engine = child_engine
+        return session
+```
+
+The key pattern: Kibitzer never interprets CSS selectors or cascade rules. It asks the PolicyEngine "what does the resolved policy say about tool X?" and acts on the answer. umwelt handles the compilation; Kibitzer handles the enforcement.
+
+## Worked example: a Lackpy-style namespace builder
+
+Lackpy restricts which tools an AI agent can call at the language level. It builds a Python namespace from resolved policy:
+
+```python
+from umwelt.policy import PolicyEngine
+
+def build_tool_namespace(engine: PolicyEngine) -> dict:
+    """Build a tool restriction namespace from resolved policy."""
+    all_tools = engine.resolve_all(type="tool")
+    namespace = {}
+
+    for tool in all_tools:
+        name = tool["entity_id"]
+        props = tool["properties"]
+
+        if props.get("allow") != "true":
+            continue
+
+        entry = {"name": name}
+
+        if "max-level" in props:
+            entry["max_level"] = int(props["max-level"])
+
+        if "allow-pattern" in props:
+            entry["patterns"] = [
+                p.strip() for p in props["allow-pattern"].split(",")
+            ]
+
+        namespace[name] = entry
+
+    return namespace
+
+# Usage
+engine = PolicyEngine.from_db("compiled.duckdb")
+ns = build_tool_namespace(engine)
+# → {"Read": {"name": "Read"}, "Bash": {"name": "Bash", "max_level": 3, "patterns": ["git *"]}}
+```
+
+## Worked example: policy-aware test fixture
+
+Use PolicyEngine in tests to verify that your policy produces the expected results:
+
+```python
+import pytest
+from umwelt.policy import PolicyEngine
+
+@pytest.fixture
+def engine():
+    e = PolicyEngine()
+    e.add_entities([
+        {"type": "tool", "id": "Read", "classes": ["safe"]},
+        {"type": "tool", "id": "Bash", "classes": ["dangerous"]},
+    ])
+    e.add_stylesheet("""
+        tool { visible: true; allow: true; }
+        tool.dangerous { max-level: 3; }
+        tool.safe { max-level: 8; }
+    """)
+    return e
+
+def test_dangerous_tools_are_capped(engine):
+    assert engine.resolve(type="tool", id="Bash", property="max-level") == "3"
+
+def test_safe_tools_are_uncapped(engine):
+    assert engine.resolve(type="tool", id="Read", property="max-level") == "8"
+
+def test_all_tools_visible(engine):
+    for tool in engine.resolve_all(type="tool"):
+        assert tool["properties"].get("visible") == "true"
+
+def test_policy_has_no_smells(engine):
+    warnings = engine.lint()
+    errors = [w for w in warnings if w.severity == "warning"]
+    assert errors == [], f"Policy smells: {[w.description for w in errors]}"
+```
+
+## Next steps
+
+- [World Files](world-files.md) — declare the entities your policy matches against
+- [Writing Views](writing-views.md) — write the stylesheets
+- [Plugins](plugins.md) — extend the vocabulary with custom entity types and properties
+- [How It Works](how-it-works.md) — understand the architecture

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -49,7 +49,7 @@ Use this when you have the original source files and want the full compilation p
 Load a pre-compiled database. No parsing, no compilation. The database is copied into memory (copy-on-write semantics — the original file is never modified).
 
 ```python
-engine = PolicyEngine.from_db("compiled.duckdb")
+engine = PolicyEngine.from_db("compiled.db")
 ```
 
 Use this in consumers that receive a compiled policy database. Kibitzer loads its policy this way — the compilation happened at authoring time, and Kibitzer just queries the result.
@@ -198,7 +198,7 @@ Use cases:
 ### Save to file
 
 ```python
-engine.save("compiled.duckdb")
+engine.save("compiled.db")
 ```
 
 Writes the compiled SQLite database to a file. Another consumer can load it with `from_db()`. The database contains everything: entities, cascade candidates, resolved properties, projection views, compilation metadata.
@@ -368,7 +368,7 @@ def build_tool_namespace(engine: PolicyEngine) -> dict:
     return namespace
 
 # Usage
-engine = PolicyEngine.from_db("compiled.duckdb")
+engine = PolicyEngine.from_db("compiled.db")
 ns = build_tool_namespace(engine)
 # → {"Read": {"name": "Read"}, "Bash": {"name": "Bash", "max_level": 3, "patterns": ["git *"]}}
 ```
@@ -402,7 +402,7 @@ def build_nsjail_config(engine: PolicyEngine) -> dict:
 
     return config
 
-engine = PolicyEngine.from_db("compiled.duckdb")
+engine = PolicyEngine.from_db("compiled.db")
 nsjail = build_nsjail_config(engine)
 # → {"mounts": [{"src": "src/", "dst": "src/", "rw": true}],
 #    "exec_paths": ["/bin/bash", "/usr/bin/git"]}

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -1,8 +1,8 @@
 # PolicyEngine
 
-The PolicyEngine is the consumer-facing Python API for querying resolved policy. It compiles a world file and a stylesheet into an in-memory SQLite database, resolves the CSS cascade, and answers questions about the result.
+The PolicyEngine is the primary API for consumers integrating with umwelt. It's the only interface most plugins need — the parser, selector engine, cascade resolver, and SQL compiler are internal implementation details that consumers never touch directly.
 
-**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it.
+**umwelt declares, consumers enforce.** The PolicyEngine tells you what the policy says. Your tool — Kibitzer, Lackpy, a custom hook, an agent framework — decides what to do about it. The parsing and compilation pipeline is an internal concern; consumers interact with the PolicyEngine, not with the parser or compiler.
 
 ## Quick start
 
@@ -372,6 +372,43 @@ engine = PolicyEngine.from_db("compiled.duckdb")
 ns = build_tool_namespace(engine)
 # → {"Read": {"name": "Read"}, "Bash": {"name": "Bash", "max_level": 3, "patterns": ["git *"]}}
 ```
+
+## Worked example: a sandbox builder querying exec policy
+
+A sandbox builder like nsjail reads exec and dir policy — a completely different slice of the same compiled database. It doesn't care about tools or modes:
+
+```python
+from umwelt.policy import PolicyEngine
+
+def build_nsjail_config(engine: PolicyEngine) -> dict:
+    """Build nsjail mount and exec configuration from resolved policy."""
+    config = {"mounts": [], "exec_paths": []}
+
+    for exe in engine.resolve_all(type="exec"):
+        props = exe["properties"]
+        path = props.get("path")
+        if path:
+            config["exec_paths"].append(path)
+            if props.get("search-path"):
+                config["search_paths"] = props["search-path"].split(":")
+
+    for d in engine.resolve_all(type="dir"):
+        props = d["properties"]
+        config["mounts"].append({
+            "src": props.get("path", ""),
+            "dst": props.get("path", ""),
+            "rw": props.get("writable") == "true",
+        })
+
+    return config
+
+engine = PolicyEngine.from_db("compiled.duckdb")
+nsjail = build_nsjail_config(engine)
+# → {"mounts": [{"src": "src/", "dst": "src/", "rw": true}],
+#    "exec_paths": ["/bin/bash", "/usr/bin/git"]}
+```
+
+This consumer never queries tool or mode entities. Kibitzer queries tools; the sandbox builder queries execs and dirs. Same database, different consumers reading different slices — that's the "umwelt declares, consumers enforce" pattern in practice.
 
 ## Worked example: policy-aware test fixture
 

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -145,6 +145,80 @@ projections:
 
 Projections are stored separately from entities — they represent what the environment *will* provide, not what the world file *declares*. In the compiled database, projections appear in the entities table with `provenance: projected`.
 
+## Tools vs executables
+
+A `tool` is a first-class capability provided to the inferencer — an MCP tool like Read, Edit, or Bash. An `exec` is an executable binary that exists in the environment — `bash`, `python3`, `git`. These are independent concepts: `tool#Bash` describes a capability the agent can invoke, but says nothing about how it's implemented. It might call `/bin/bash`, it might be a Python reimplementation, it might delegate to a WASM sandbox. The exec entities describe what binaries the environment provides, regardless of which tools use them.
+
+```yaml
+entities:
+  # Tools — what the inferencer can call
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+
+  # Executables — what runs in the environment
+  - type: exec
+    id: bash
+    attributes:
+      path: /bin/bash
+  - type: exec
+    id: git
+    attributes:
+      path: /usr/bin/git
+  - type: exec
+    id: python3
+    attributes:
+      path: /usr/bin/python3
+```
+
+These are independent entity types in different taxa — `tool` lives in `capability`, `exec` lives in `world`. They don't need to reference each other. A consumer like nsjail queries exec policy to build its sandbox configuration; a consumer like Kibitzer queries tool policy to decide what to show the agent. Each consumer reads the slice of policy it cares about.
+
+```css
+/* Tool-level: what the agent sees */
+tool#Bash { allow: true; max-level: 3; }
+
+/* Executable-level: what the sandbox restricts */
+exec#bash    { path: "/bin/bash"; }
+exec#git     { path: "/usr/bin/git"; }
+exec#python3 { path: "/usr/bin/python3"; search-path: "/usr/bin:/usr/local/bin"; }
+```
+
+The relationship between `tool#Bash` and the executables it invokes is a consumer concern — umwelt doesn't model it. The tool entity describes what the inferencer can call; the exec entities describe what binaries exist in the environment. Different consumers enforce different parts of this policy independently.
+
+## Directories and files
+
+The world taxon includes `dir` and `file` entities for filesystem structure:
+
+```yaml
+entities:
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+      name: "src"
+  - type: dir
+    id: tests
+    attributes:
+      path: "tests/"
+      name: "tests"
+  - type: file
+    id: auth.py
+    attributes:
+      path: "src/auth/auth.py"
+      name: "auth.py"
+      language: "python"
+```
+
+`file` is a child of `dir` in the world hierarchy, so descendant selectors work:
+
+```css
+dir[name="src"] file { editable: true; }       /* files under src/ */
+dir[name="tests"] file { editable: false; }     /* tests are read-only */
+file[path$=".py"] { visible: true; }            /* all Python files visible */
+```
+
+In practice, file and directory entities are often populated by projections or filesystem matchers rather than declared by hand in the world file.
+
 ## Combining everything
 
 A realistic world file for a code editing session:
@@ -174,6 +248,16 @@ entities:
     classes: [dangerous]
     attributes:
       description: "Overwrite entire files"
+
+  - type: exec
+    id: bash
+    attributes:
+      path: /bin/bash
+
+  - type: exec
+    id: git
+    attributes:
+      path: /usr/bin/git
 
 projections:
   - type: dir

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -49,11 +49,11 @@ Available shorthands (from the sandbox vocabulary):
 | `modes` | `mode` | list | `modes: [implement, review]` |
 | `principal` | `principal` | scalar | `principal: Teague` |
 | `inferencer` | `inferencer` | scalar | `inferencer: claude-sonnet` |
-| `resources` | `resource` | map | `resources: {memory: 512MB, wall-time: 5m}` |
+| `resources` | `resource` | block | `resources: {memory: 512MB, wall-time: 5m}` |
 
-### Map shorthands
+### Block shorthands
 
-Map shorthands create entities with an attribute set from the value:
+Block shorthands create a single entity with all key-value pairs as attributes:
 
 ```yaml
 resources:
@@ -61,7 +61,14 @@ resources:
   wall-time: 5m
 ```
 
-This creates two `resource` entities: `resource#memory` with `limit: 512MB` and `resource#wall-time` with `limit: 5m`. The `limit` attribute is configured by the shorthand's `attribute_key`.
+This creates one `resource` entity with attributes `{memory: "512MB", "wall-time": "5m"}`. The stylesheet then sets policy on the resource block as properties:
+
+```css
+resource { memory: 512MB; wall-time: 5m; }
+mode#implement resource { memory: 1GB; }
+```
+
+Each limit resolves independently in the cascade ��� you can override one without touching the others. This mirrors how Kubernetes, slurm, and nsjail model resource blocks.
 
 ## Explicit entities
 
@@ -276,8 +283,7 @@ tool#Bash { allow-pattern: "git *"; allow-pattern: "pytest *"; }
 
 mode#implement tool { max-level: 5; }
 
-resource#memory { limit: 1GB; }
-resource#wall-time { limit: 10m; }
+resource { memory: 1GB; wall-time: 10m; }
 ```
 
 Compile and query:

--- a/docs/guide/world-files.md
+++ b/docs/guide/world-files.md
@@ -1,0 +1,273 @@
+# World Files
+
+A world file (`.world.yml`) declares the entities that exist in an agent's environment — the tools it can call, the modes it operates in, the resources it has access to. It's the DOM that stylesheets match against.
+
+## Your first world file
+
+```yaml
+# env.world.yml
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Edit
+  - type: mode
+    id: implement
+```
+
+Three entities. Two tools and a mode. A stylesheet can now match these:
+
+```css
+tool#Read { visible: true; }
+tool#Edit { visible: true; allow: true; }
+mode#implement tool { max-level: 5; }
+```
+
+Inspect it:
+
+```bash
+umwelt materialize env.world.yml
+```
+
+## Shorthand syntax
+
+Writing `entities:` blocks for every tool gets tedious. Shorthand keys expand into entities via the vocabulary registry:
+
+```yaml
+# Same result, less typing
+tools: [Read, Edit]
+modes: [implement]
+```
+
+`tools: [Read, Edit]` expands to two `tool` entities. `modes: [implement]` expands to one `mode` entity. The shorthand registry knows which entity type each key maps to.
+
+Available shorthands (from the sandbox vocabulary):
+
+| Key | Entity type | Form | Example |
+|---|---|---|---|
+| `tools` | `tool` | list | `tools: [Read, Edit, Bash]` |
+| `modes` | `mode` | list | `modes: [implement, review]` |
+| `principal` | `principal` | scalar | `principal: Teague` |
+| `inferencer` | `inferencer` | scalar | `inferencer: claude-sonnet` |
+| `resources` | `resource` | map | `resources: {memory: 512MB, wall-time: 5m}` |
+
+### Map shorthands
+
+Map shorthands create entities with an attribute set from the value:
+
+```yaml
+resources:
+  memory: 512MB
+  wall-time: 5m
+```
+
+This creates two `resource` entities: `resource#memory` with `limit: 512MB` and `resource#wall-time` with `limit: 5m`. The `limit` attribute is configured by the shorthand's `attribute_key`.
+
+## Explicit entities
+
+For entities that need classes, attributes, or parent references, use the full `entities:` block:
+
+```yaml
+tools: [Read, Edit, Bash]
+
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell]
+    attributes:
+      description: "Execute shell commands"
+
+  - type: tool
+    id: Read
+    attributes:
+      description: "Read files from the filesystem"
+```
+
+### Merge semantics
+
+When a shorthand and an explicit entry declare the same `(type, id)` pair, the explicit entry wins. In the example above, `Bash` appears in both `tools:` and `entities:` — the explicit entry with classes and attributes is kept; the shorthand version is discarded.
+
+This lets you use shorthands for the common case and override specific entities when you need more detail.
+
+## Classes
+
+Classes work exactly like CSS classes. An entity can have zero or more:
+
+```yaml
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous, shell, system]
+```
+
+Stylesheets match classes with `.`:
+
+```css
+tool.dangerous { max-level: 3; }
+tool.shell { allow-pattern: "echo *"; }
+```
+
+## Attributes
+
+Attributes are key-value metadata on an entity:
+
+```yaml
+entities:
+  - type: tool
+    id: Read
+    attributes:
+      description: "Read files from the filesystem"
+      kit: "filesystem"
+```
+
+Stylesheets match attributes with `[]`:
+
+```css
+tool[kit="filesystem"] { visible: true; }
+```
+
+## Projections
+
+Projections declare entities that will be populated by external systems (filesystem discovery, runtime state, etc.):
+
+```yaml
+projections:
+  - type: dir
+    id: node_modules
+    attributes:
+      path: "node_modules/"
+
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+```
+
+Projections are stored separately from entities — they represent what the environment *will* provide, not what the world file *declares*. In the compiled database, projections appear in the entities table with `provenance: projected`.
+
+## Combining everything
+
+A realistic world file for a code editing session:
+
+```yaml
+# delegate.world.yml
+principal: Teague
+inferencer: claude-sonnet
+
+tools: [Read, Edit, Bash, Grep, Glob, Write]
+modes: [implement]
+
+resources:
+  memory: 1GB
+  wall-time: 10m
+  max-fds: 256
+
+entities:
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+    attributes:
+      description: "Execute shell commands"
+
+  - type: tool
+    id: Write
+    classes: [dangerous]
+    attributes:
+      description: "Overwrite entire files"
+
+projections:
+  - type: dir
+    id: src
+    attributes:
+      path: "src/"
+```
+
+Pair it with a stylesheet:
+
+```css
+/* policy.umw */
+tool { visible: true; allow: true; }
+tool.dangerous { max-level: 3; }
+tool#Bash { allow-pattern: "git *"; allow-pattern: "pytest *"; }
+
+mode#implement tool { max-level: 5; }
+
+resource#memory { limit: 1GB; }
+resource#wall-time { limit: 10m; }
+```
+
+Compile and query:
+
+```bash
+umwelt compile --target sqlite -o world.db policy.umw --world delegate.world.yml
+```
+
+Or use the Python API:
+
+```python
+from umwelt.policy import PolicyEngine
+
+engine = PolicyEngine.from_files(
+    world="delegate.world.yml",
+    stylesheet="policy.umw",
+)
+engine.resolve(type="tool", id="Bash", property="max-level")  # → "3"
+```
+
+## Materialization
+
+`umwelt materialize` renders a world file at three detail levels:
+
+```bash
+# Full: all entities with all attributes
+umwelt materialize env.world.yml --level full
+
+# Outline: entities with classes but no attributes
+umwelt materialize env.world.yml --level outline
+
+# Summary: just counts by type
+umwelt materialize env.world.yml --level summary
+```
+
+Write to a file:
+
+```bash
+umwelt materialize env.world.yml -o snapshot.yml
+```
+
+This is useful for inspecting what the world file produces after shorthand expansion — the materialized output shows every entity that will enter the compiled database.
+
+## Vocabulary validation
+
+When the sandbox vocabulary is registered, the parser validates entity types against the registry:
+
+```yaml
+entities:
+  - type: frobnitz    # ← unknown type
+    id: X
+```
+
+This produces a warning (not an error): `unknown entity type 'frobnitz' (not in registered vocabulary)`. Unknown types are allowed for forward compatibility — you can declare entities for vocabulary that hasn't been registered yet.
+
+## Future keys
+
+Some keys are parsed and stored but produce warnings because they aren't implemented yet:
+
+| Key | Status | Purpose |
+|---|---|---|
+| `discover:` | Phase 2 | Filesystem/runtime entity discovery |
+| `overrides:` | Phase 2 | Per-environment overrides |
+| `fixed:` | Phase 2 | Immutable constraints |
+| `include:` | Phase 2 | Include other world files |
+| `exclude:` | Phase 2 | Exclude entities from included files |
+| `vars:` | Reserved | Template variables |
+| `when:` | Reserved | Conditional blocks |
+| `version:` | Reserved | Schema versioning |
+
+These keys are stored on the `WorldFile` dataclass so future versions can process them without re-parsing.
+
+## Next steps
+
+- [PolicyEngine](policy-engine.md) — query resolved policy from Python
+- [Writing Views](writing-views.md) — write stylesheets that match world entities
+- [Plugins](plugins.md) — extend the vocabulary with your own entity types

--- a/docs/guide/writing-views.md
+++ b/docs/guide/writing-views.md
@@ -112,11 +112,13 @@ After the agent modifies any file, these commands run in order. If one fails, th
 ## Resource limits
 
 ```css
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
-resource[kind="cpu-time"]  { limit: 3m; }
-resource[kind="max-fds"]   { limit: 128; }
-resource[kind="tmpfs"]     { limit: 64MB; }
+resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+```
+
+Each limit is a property on a single `resource` entity — the cascade resolves them independently. Override specific limits per mode or environment:
+
+```css
+mode#implement resource { memory: 1GB; wall-time: 30m; }
 ```
 
 These compile to nsjail rlimits, bwrap wrappers (prlimit/timeout), or equivalent mechanisms on other targets. Missing limits mean "tool default."
@@ -156,13 +158,12 @@ hook[event="after-change"] { run: "ruff check src/"; }
 /* Development: everything editable, Bash allowed */
 world#dev file { editable: true; }
 world#dev tool[name="Bash"] { allow: true; max-level: 4; }
-world#dev resource[kind="wall-time"] { limit: 30m; }
+world#dev resource { wall-time: 30m; }
 
 /* CI: read-only, tight limits */
 world#ci file { editable: false; }
 world#ci tool[name="Bash"] { allow: true; max-level: 2; }
-world#ci resource[kind="memory"] { limit: 512MB; }
-world#ci resource[kind="wall-time"] { limit: 5m; }
+world#ci resource { memory: 512MB; wall-time: 5m; }
 
 /* Exploration: read-only, no editing tools */
 world#explore tool { allow: false; }
@@ -212,7 +213,7 @@ For common patterns, umwelt supports at-rule shorthand that desugars to entity s
 | `@tools { allow: Read, Edit; deny: Bash; }` | `tool[name="Read"] { allow: true; }` `tool[name="Edit"] { allow: true; }` `tool[name="Bash"] { allow: false; }` |
 | `@after-change { test: pytest; }` | `hook[event="after-change"] { run: "pytest"; }` |
 | `@network { deny: *; }` | `network { deny: "*"; }` |
-| `@budget { memory: 512MB; }` | `resource[kind="memory"] { limit: 512MB; }` |
+| `@budget { memory: 512MB; }` | `resource { memory: 512MB; }` |
 | `@env { allow: CI; }` | `env[name="CI"] { allow: true; }` |
 
 Both forms are first-class. Mix them freely. The @ syntax is shorter for simple cases; the entity-selector form is more powerful (compound selectors, named environments, fine-grained attribute matching).
@@ -230,8 +231,7 @@ world#auth-fix {
   tool[name="Edit"]  { allow: true; }
   tool[name="Bash"]  { allow: false; }
 
-  resource[kind="memory"]    { limit: 512MB; }
-  resource[kind="wall-time"] { limit: 5m; }
+  resource { memory: 512MB; wall-time: 5m; }
   network { deny: "*"; }
 
   hook[event="after-change"] {

--- a/docs/guide/writing-views.md
+++ b/docs/guide/writing-views.md
@@ -112,7 +112,7 @@ After the agent modifies any file, these commands run in order. If one fails, th
 ## Resource limits
 
 ```css
-resource { memory: 512MB; wall-time: 5m; cpu: 3; max-fds: 128; }
+resource { memory: 512MB; wall-time: 5m; cpu-time: 30s; max-fds: 128; }
 ```
 
 Each limit is a property on a single `resource` entity — the cascade resolves them independently. Override specific limits per mode or environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ world#auth-fix {
   tool[name="Read"]        { allow: true; }
   tool[name="Bash"]        { allow: false; }
   network                  { deny: "*"; }
-  resource[kind="memory"]  { limit: 512MB; }
+  resource                 { memory: 512MB; wall-time: 5m; }
   hook[event="after-change"] { run: "pytest tests/auth/"; }
 }
 ```

--- a/docs/superpowers/plans/2026-04-26-plugin-api-gaps.md
+++ b/docs/superpowers/plans/2026-04-26-plugin-api-gaps.md
@@ -1,0 +1,2486 @@
+# Plugin API Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close seven plugin API gaps that block multi-tool coexistence in the retritis ecosystem, implementing P0 through P3 features with a commit per feature.
+
+**Architecture:** Each feature is additive — P0 items unblock P1 items (CompositeMatcher enables collections, fixed constraints enable world composition). Features are isolated enough to implement and commit independently. TDD throughout: failing test first, minimal implementation, verify, commit.
+
+**Tech Stack:** Python 3.10+, pytest, sqlite3, PyYAML, tinycss2
+
+---
+
+### Task 1: P0 — CompositeMatcher
+
+**Files:**
+- Modify: `src/umwelt/registry/matchers.py:1-88`
+- Modify: `src/umwelt/registry/__init__.py` (export CompositeMatcher)
+- Modify: `tests/core/test_registry_matchers.py:1-67`
+
+- [ ] **Step 1: Write failing tests for CompositeMatcher**
+
+Add to `tests/core/test_registry_matchers.py`:
+
+```python
+from umwelt.registry.matchers import CompositeMatcher
+
+
+class CountingMatcher:
+    """A matcher that returns entities from a fixed list, for composition tests."""
+
+    def __init__(self, entities: list, id_attr: str = "id"):
+        self._entities = entities
+        self._id_attr = id_attr
+
+    def match_type(self, type_name: str, context=None) -> list:
+        return [e for e in self._entities if getattr(e, "type_name", None) == type_name or type_name == "*"]
+
+    def children(self, parent, child_type: str) -> list:
+        return []
+
+    def condition_met(self, selector, context=None) -> bool:
+        return any(getattr(e, "active", False) for e in self._entities)
+
+    def get_attribute(self, entity, name: str):
+        return getattr(entity, name, None)
+
+    def get_id(self, entity) -> str | None:
+        return getattr(entity, self._id_attr, None)
+
+
+class _SimpleEntity:
+    def __init__(self, type_name, id, active=False, **attrs):
+        self.type_name = type_name
+        self.id = id
+        self.active = active
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def test_composite_match_type_unions_results():
+    m1 = CountingMatcher([_SimpleEntity("tool", "Bash")])
+    m2 = CountingMatcher([_SimpleEntity("tool", "Read")])
+    composite = CompositeMatcher(m1, m2)
+    results = composite.match_type("tool")
+    ids = [composite.get_id(e) for e in results]
+    assert ids == ["Bash", "Read"]
+
+
+def test_composite_children_unions_results():
+    m1 = CountingMatcher([])
+    m2 = CountingMatcher([])
+    composite = CompositeMatcher(m1, m2)
+    assert composite.children(None, "x") == []
+
+
+def test_composite_condition_met_is_or():
+    m1 = CountingMatcher([_SimpleEntity("tool", "a", active=False)])
+    m2 = CountingMatcher([_SimpleEntity("tool", "b", active=True)])
+    composite = CompositeMatcher(m1, m2)
+    assert composite.condition_met(None) is True
+
+
+def test_composite_condition_met_all_false():
+    m1 = CountingMatcher([_SimpleEntity("tool", "a", active=False)])
+    m2 = CountingMatcher([_SimpleEntity("tool", "b", active=False)])
+    composite = CompositeMatcher(m1, m2)
+    assert composite.condition_met(None) is False
+
+
+def test_composite_get_id_first_non_none_wins():
+    m1 = CountingMatcher([], id_attr="nonexistent")
+    m2 = CountingMatcher([])
+    entity = _SimpleEntity("tool", "Bash")
+    composite = CompositeMatcher(m1, m2)
+    assert composite.get_id(entity) is None
+    # m1 returns None (no "nonexistent" attr), m2 returns "Bash"
+    m1_returns_none = CountingMatcher([])
+    m1_returns_none.get_id = lambda e: None
+    m2_returns_val = CountingMatcher([])
+    m2_returns_val.get_id = lambda e: "found"
+    composite2 = CompositeMatcher(m1_returns_none, m2_returns_val)
+    assert composite2.get_id(entity) == "found"
+
+
+def test_composite_get_attribute_first_non_none_wins():
+    m1 = CountingMatcher([])
+    m1.get_attribute = lambda e, n: None
+    m2 = CountingMatcher([])
+    m2.get_attribute = lambda e, n: "val2"
+    composite = CompositeMatcher(m1, m2)
+    assert composite.get_attribute(None, "x") == "val2"
+
+
+def test_composite_add_appends_delegate():
+    m1 = CountingMatcher([_SimpleEntity("tool", "A")])
+    composite = CompositeMatcher(m1)
+    assert len(composite.match_type("tool")) == 1
+    m2 = CountingMatcher([_SimpleEntity("tool", "B")])
+    composite.add(m2)
+    assert len(composite.match_type("tool")) == 2
+
+
+def test_register_matcher_auto_composes_on_collision():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        m1 = NullMatcher()
+        m2 = NullMatcher()
+        register_matcher(taxon="world", matcher=m1)
+        register_matcher(taxon="world", matcher=m2)
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
+
+
+def test_register_matcher_triple_composition():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        m1 = NullMatcher()
+        m2 = NullMatcher()
+        m3 = NullMatcher()
+        register_matcher(taxon="world", matcher=m1)
+        register_matcher(taxon="world", matcher=m2)
+        register_matcher(taxon="world", matcher=m3)
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
+        assert len(result._delegates) == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_registry_matchers.py -v`
+Expected: ImportError for CompositeMatcher, failures on auto-composition tests
+
+- [ ] **Step 3: Implement CompositeMatcher and change register_matcher**
+
+In `src/umwelt/registry/matchers.py`, add CompositeMatcher class and modify `register_matcher`:
+
+```python
+"""Matcher protocol and registration.
+
+A matcher is the consumer-supplied bridge between a `ComplexSelector`
+and the consumer's world. The parser, selector engine, and cascade
+resolver are matcher-agnostic — they know how to call these methods
+but not what the implementation does. A filesystem matcher walks
+real paths; an in-memory test matcher walks a dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from umwelt.errors import RegistryError
+from umwelt.registry.taxa import _current_state, get_taxon, resolve_taxon
+
+
+@runtime_checkable
+class MatcherProtocol(Protocol):
+    """Consumer-supplied access to a world for selector evaluation.
+
+    The protocol is deliberately thin. Each method takes selector-space
+    inputs and returns opaque entity handles that only the matcher knows
+    how to interpret — the core selector engine treats them as tokens.
+    """
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        """Return all entities of this type in the matcher's world.
+
+        For structural lookups where no parent entity is pre-selected,
+        this returns every entity of the type.
+        """
+        ...
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        """Return `child_type` entities that are descendants of `parent`.
+
+        Used for within-taxon structural descendant selectors (e.g.,
+        `dir[name="src"] file[name$=".py"]` — the matcher walks the
+        dir -> file parent-child relationship).
+        """
+        ...
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        """Return True if a cross-taxon context qualifier is satisfied.
+
+        Called by the selector engine when a compound selector crosses
+        taxa (`tool[name="Bash"] file[...]`). The qualifier taxon's
+        matcher is consulted with the qualifier selector to determine
+        whether the rule's context condition holds.
+        """
+        ...
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        """Return the value of an attribute on an entity, or None if absent.
+
+        Used by the selector match engine to evaluate attribute filters.
+        """
+        ...
+
+    def get_id(self, entity: Any) -> str | None:
+        """Return the entity's identity value (used by `#id` selectors).
+
+        Return None when the entity has no natural identity; `#id` selectors
+        won't match such entities.
+        """
+        ...
+
+
+class CompositeMatcher:
+    """Delegates to multiple matchers for the same taxon.
+
+    Auto-created when register_matcher() is called twice for the same taxon.
+    Union semantics for match_type/children, OR for condition_met,
+    first-non-None for get_id/get_attribute.
+    """
+
+    def __init__(self, *delegates: MatcherProtocol):
+        self._delegates: list[MatcherProtocol] = list(delegates)
+
+    def add(self, matcher: MatcherProtocol) -> None:
+        self._delegates.append(matcher)
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        results: list[Any] = []
+        for d in self._delegates:
+            results.extend(d.match_type(type_name, context))
+        return results
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        results: list[Any] = []
+        for d in self._delegates:
+            results.extend(d.children(parent, child_type))
+        return results
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        return any(d.condition_met(selector, context) for d in self._delegates)
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        for d in self._delegates:
+            val = d.get_attribute(entity, name)
+            if val is not None:
+                return val
+        return None
+
+    def get_id(self, entity: Any) -> str | None:
+        for d in self._delegates:
+            val = d.get_id(entity)
+            if val is not None:
+                return val
+        return None
+
+
+def register_matcher(*, taxon: str, matcher: MatcherProtocol) -> None:
+    """Register a matcher for a taxon. Auto-composes on collision."""
+    get_taxon(taxon)  # raises if unknown
+    canonical = resolve_taxon(taxon)
+    state = _current_state()
+    if canonical in state.matchers:
+        existing = state.matchers[canonical]
+        if isinstance(existing, CompositeMatcher):
+            existing.add(matcher)
+        else:
+            state.matchers[canonical] = CompositeMatcher(existing, matcher)
+    else:
+        state.matchers[canonical] = matcher
+
+
+def get_matcher(taxon: str) -> MatcherProtocol:
+    """Look up the matcher for a taxon. Resolves taxon aliases."""
+    state = _current_state()
+    canonical = resolve_taxon(taxon)
+    try:
+        return state.matchers[canonical]
+    except KeyError as exc:
+        raise RegistryError(f"no matcher registered for taxon {taxon!r}") from exc
+```
+
+- [ ] **Step 4: Update registry __init__.py exports**
+
+Add `CompositeMatcher` to imports and `__all__` in `src/umwelt/registry/__init__.py`:
+
+```python
+from umwelt.registry.matchers import (
+    CompositeMatcher,
+    MatcherProtocol,
+    get_matcher,
+    register_matcher,
+)
+```
+
+And add `"CompositeMatcher"` to the `__all__` list.
+
+- [ ] **Step 5: Fix the existing duplicate-matcher test**
+
+The test `test_duplicate_matcher_raises` in `tests/core/test_registry_matchers.py` currently expects `RegistryError` on duplicate registration. Change it to expect auto-composition:
+
+```python
+def test_duplicate_matcher_auto_composes():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        register_matcher(taxon="world", matcher=NullMatcher())
+        register_matcher(taxon="world", matcher=NullMatcher())
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/core/test_registry_matchers.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Run full test suite to check for regressions**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures beyond the pre-existing 34
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/umwelt/registry/matchers.py src/umwelt/registry/__init__.py tests/core/test_registry_matchers.py
+git commit -m "feat(registry): add CompositeMatcher for multi-matcher per taxon
+
+register_matcher() auto-composes on collision instead of raising.
+Union semantics for match_type/children, OR for condition_met,
+first-non-None for get_id/get_attribute."
+```
+
+---
+
+### Task 2: P0 — Fixed Constraints (Post-Cascade Clamping)
+
+**Files:**
+- Modify: `src/umwelt/compilers/sql/schema.py:14-112`
+- Modify: `src/umwelt/compilers/sql/populate.py:142-211`
+- Modify: `src/umwelt/policy/queries.py:10-36`
+- Modify: `src/umwelt/policy/lint.py:13-28`
+- Modify: `src/umwelt/world/parser.py:76-91`
+- Create: `tests/policy/test_fixed_constraints.py`
+
+- [ ] **Step 1: Write failing tests for fixed constraints**
+
+Create `tests/policy/test_fixed_constraints.py`:
+
+```python
+"""Tests for fixed constraint processing and effective_properties view."""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.schema import EXPECTED_TABLES, create_schema
+
+
+def _make_db():
+    dialect = SQLiteDialect()
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    return con, dialect
+
+
+def test_fixed_constraints_table_exists():
+    con, _ = _make_db()
+    tables = [r[0] for r in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()]
+    assert "fixed_constraints" in tables
+
+
+def test_effective_properties_view_exists():
+    con, _ = _make_db()
+    views = [r[0] for r in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='view'"
+    ).fetchall()]
+    assert "effective_properties" in views
+
+
+def test_fixed_constraint_overrides_cascade():
+    """Fixed constraint value wins over cascade-resolved value."""
+    con, dialect = _make_db()
+
+    # Insert an entity
+    con.execute(
+        "INSERT INTO entities (taxon, type_name, entity_id, depth) VALUES ('cap', 'tool', 'Bash', 0)"
+    )
+    entity_id = con.execute("SELECT id FROM entities WHERE entity_id = 'Bash'").fetchone()[0]
+
+    # Insert a cascade candidate and create resolution views
+    con.execute(
+        "INSERT INTO cascade_candidates (entity_id, property_name, property_value, comparison, specificity, rule_index) "
+        "VALUES (?, 'available', 'true', 'exact', '[0,0,1]', 0)",
+        (entity_id,),
+    )
+    from umwelt.compilers.sql.resolution import create_resolution_views
+    create_resolution_views(con, dialect)
+    con.commit()
+
+    # Verify cascade says 'true'
+    row = con.execute(
+        "SELECT property_value FROM resolved_properties WHERE entity_id = ? AND property_name = 'available'",
+        (entity_id,),
+    ).fetchone()
+    assert row[0] == "true"
+
+    # Insert fixed constraint
+    con.execute(
+        "INSERT INTO fixed_constraints (entity_id, property_name, property_value, selector) "
+        "VALUES (?, 'available', 'false', 'tool#Bash')",
+        (entity_id,),
+    )
+    con.commit()
+
+    # Effective properties should show 'false' with source='fixed'
+    row = con.execute(
+        "SELECT effective_value, source FROM effective_properties "
+        "WHERE entity_id = ? AND property_name = 'available'",
+        (entity_id,),
+    ).fetchone()
+    assert row[0] == "false"
+    assert row[1] == "fixed"
+
+
+def test_effective_properties_passthrough_without_fixed():
+    """Without a fixed constraint, effective_properties passes through cascade value."""
+    con, dialect = _make_db()
+
+    con.execute(
+        "INSERT INTO entities (taxon, type_name, entity_id, depth) VALUES ('cap', 'tool', 'Read', 0)"
+    )
+    entity_id = con.execute("SELECT id FROM entities WHERE entity_id = 'Read'").fetchone()[0]
+
+    con.execute(
+        "INSERT INTO cascade_candidates (entity_id, property_name, property_value, comparison, specificity, rule_index) "
+        "VALUES (?, 'available', 'true', 'exact', '[0,0,1]', 0)",
+        (entity_id,),
+    )
+    from umwelt.compilers.sql.resolution import create_resolution_views
+    create_resolution_views(con, dialect)
+    con.commit()
+
+    row = con.execute(
+        "SELECT effective_value, source FROM effective_properties "
+        "WHERE entity_id = ? AND property_name = 'available'",
+        (entity_id,),
+    ).fetchone()
+    assert row[0] == "true"
+    assert row[1] == "cascade"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/policy/test_fixed_constraints.py -v`
+Expected: FAIL — no `fixed_constraints` table, no `effective_properties` view
+
+- [ ] **Step 3: Add fixed_constraints table and effective_properties view to schema**
+
+In `src/umwelt/compilers/sql/schema.py`, add to `EXPECTED_TABLES`:
+
+```python
+EXPECTED_TABLES = [
+    "taxa",
+    "entity_types",
+    "property_types",
+    "entities",
+    "entity_closure",
+    "cascade_candidates",
+    "fixed_constraints",
+]
+```
+
+And add new sections at the end of `create_schema()`, before the `return` statement:
+
+```python
+    # -- Fixed constraints (post-cascade clamping)
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS fixed_constraints (
+    id              {autoincrement if is_sqlite else f'{int_type} PRIMARY KEY DEFAULT nextval(\\'fc_seq\\')'},
+    entity_id       {int_type} REFERENCES entities(id),
+    property_name   {text_type} NOT NULL,
+    property_value  {text_type} NOT NULL,
+    selector        {text_type} NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fc_entity_prop ON fixed_constraints(entity_id, property_name);""")
+```
+
+Note: the autoincrement handling needs to match the existing pattern. Here is the precise replacement — add after the cascade_candidates section (line ~110), before `return`:
+
+```python
+    # -- Fixed constraints (post-cascade clamping)
+    fc_pk = autoincrement if is_sqlite else f"{int_type} PRIMARY KEY"
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS fixed_constraints (
+    id              {fc_pk},
+    entity_id       {int_type} REFERENCES entities(id),
+    property_name   {text_type} NOT NULL,
+    property_value  {text_type} NOT NULL,
+    selector        {text_type} NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fc_entity_prop ON fixed_constraints(entity_id, property_name);""")
+
+    # -- Effective properties (fixed constraints override cascade)
+    sections.append("""
+CREATE VIEW IF NOT EXISTS effective_properties AS
+SELECT
+    rp.entity_id,
+    rp.property_name,
+    COALESCE(fc.property_value, rp.property_value) AS effective_value,
+    CASE WHEN fc.id IS NOT NULL THEN 'fixed' ELSE 'cascade' END AS source,
+    rp.specificity,
+    rp.rule_index,
+    rp.source_file,
+    rp.source_line
+FROM resolved_properties rp
+LEFT JOIN fixed_constraints fc
+    ON fc.entity_id = rp.entity_id
+    AND fc.property_name = rp.property_name;""")
+```
+
+Important: The `effective_properties` view references `resolved_properties` which is created later by `create_resolution_views()`. The view is defined as `IF NOT EXISTS`, so if `resolved_properties` doesn't exist yet at schema creation time, this view creation will fail. We need to move the effective_properties view creation into `resolution.py` instead, appended after `resolved_properties` is created.
+
+**Revised approach:** Add only the `fixed_constraints` table to `schema.py`. Add the `effective_properties` view to `resolution.py` at the end of `_resolution_ddl()`.
+
+In `src/umwelt/compilers/sql/schema.py`, add only:
+
+```python
+    # -- Fixed constraints (post-cascade clamping)
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS fixed_constraints (
+    id              {autoincrement},
+    entity_id       {int_type} REFERENCES entities(id),
+    property_name   {text_type} NOT NULL,
+    property_value  {text_type} NOT NULL,
+    selector        {text_type} NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fc_entity_prop ON fixed_constraints(entity_id, property_name);""")
+```
+
+In `src/umwelt/compilers/sql/resolution.py`, append the effective_properties view at the end of `_resolution_ddl()`:
+
+```python
+    effective_view_prefix = "CREATE VIEW IF NOT EXISTS" if is_sqlite else "CREATE OR REPLACE VIEW"
+    effective_view = f"""
+{effective_view_prefix} effective_properties AS
+SELECT
+    rp.entity_id,
+    rp.property_name,
+    COALESCE(fc.property_value, rp.property_value) AS effective_value,
+    CASE WHEN fc.id IS NOT NULL THEN 'fixed' ELSE 'cascade' END AS source,
+    rp.specificity,
+    rp.rule_index,
+    rp.source_file,
+    rp.source_line
+FROM resolved_properties rp
+LEFT JOIN fixed_constraints fc
+    ON fc.entity_id = rp.entity_id
+    AND fc.property_name = rp.property_name;"""
+
+    return "\n".join([exact_view, cap_view, pattern_view, resolved_view, effective_view])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/policy/test_fixed_constraints.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Write tests for fixed constraint processing from world files**
+
+Add to `tests/policy/test_fixed_constraints.py`:
+
+```python
+def test_populate_fixed_constraints_from_world():
+    """populate_from_world processes fixed_raw into fixed_constraints table."""
+    from umwelt.compilers.sql.populate import populate_from_world
+    from umwelt.compilers.sql.resolution import create_resolution_views
+    from umwelt.registry import register_entity, register_taxon, registry_scope
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.world.model import DeclaredEntity, Provenance, WorldFile
+
+    con, dialect = _make_db()
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(
+            taxon="capability", name="tool",
+            attributes={"name": AttrSchema(type=str)},
+            description="a tool",
+        )
+
+        world = WorldFile(
+            entities=(
+                DeclaredEntity(type="tool", id="Bash", provenance=Provenance.EXPLICIT),
+                DeclaredEntity(type="tool", id="Read", provenance=Provenance.EXPLICIT),
+            ),
+            projections=(),
+            warnings=(),
+            fixed_raw={"tool#Bash": {"available": "false"}},
+        )
+        populate_from_world(con, world)
+
+        rows = con.execute("SELECT entity_id, property_name, property_value FROM fixed_constraints").fetchall()
+        assert len(rows) == 1
+        eid = con.execute("SELECT id FROM entities WHERE entity_id = 'Bash'").fetchone()[0]
+        assert rows[0] == (eid, "available", "false")
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `pytest tests/policy/test_fixed_constraints.py::test_populate_fixed_constraints_from_world -v`
+Expected: FAIL — populate_from_world doesn't process fixed_raw
+
+- [ ] **Step 7: Implement fixed constraint processing in populate.py**
+
+Add to `src/umwelt/compilers/sql/populate.py`, at the end of `populate_from_world()` (before `con.commit()`):
+
+```python
+def populate_from_world(con: Any, world: Any) -> None:
+    """Insert DeclaredEntity instances from a WorldFile into the entities table.
+
+    World file entities win on (type_name, entity_id) collision with
+    existing matcher-discovered entities.
+    """
+    for entity in world.entities:
+        _upsert_declared_entity(con, entity)
+
+    for proj in world.projections:
+        _upsert_projection(con, proj)
+
+    # Process fixed constraints
+    fixed_raw = getattr(world, "fixed_raw", {})
+    if fixed_raw:
+        _process_fixed_constraints(con, fixed_raw)
+
+    con.commit()
+    _rebuild_closure(con)
+
+
+def _process_fixed_constraints(con: Any, fixed_raw: dict) -> None:
+    """Insert fixed constraints by matching selectors against entities."""
+    for selector_str, props in fixed_raw.items():
+        if not isinstance(props, dict):
+            continue
+        # Parse selector: support type#id and type forms
+        matching_ids = _match_fixed_selector(con, selector_str)
+        for entity_pk in matching_ids:
+            for prop_name, prop_value in props.items():
+                con.execute(
+                    "INSERT INTO fixed_constraints (entity_id, property_name, property_value, selector) "
+                    "VALUES (?, ?, ?, ?)",
+                    (entity_pk, prop_name, str(prop_value), selector_str),
+                )
+
+
+def _match_fixed_selector(con: Any, selector_str: str) -> list[int]:
+    """Match a fixed constraint selector against entities. Supports type#id and type."""
+    if "#" in selector_str:
+        type_name, entity_id = selector_str.split("#", 1)
+        rows = con.execute(
+            "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+            (type_name, entity_id),
+        ).fetchall()
+    else:
+        rows = con.execute(
+            "SELECT id FROM entities WHERE type_name = ?",
+            (selector_str,),
+        ).fetchall()
+    return [r[0] for r in rows]
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pytest tests/policy/test_fixed_constraints.py -v`
+Expected: All PASS
+
+- [ ] **Step 9: Write test for queries using effective_properties**
+
+Add to `tests/policy/test_fixed_constraints.py`:
+
+```python
+def test_resolve_entity_uses_effective_properties():
+    """PolicyEngine.resolve() returns fixed-clamped values."""
+    from umwelt.compilers.sql.compiler import compile_view
+    from umwelt.compilers.sql.populate import populate_from_world
+    from umwelt.compilers.sql.resolution import create_resolution_views
+    from umwelt.parser import parse as parse_css
+    from umwelt.registry import (
+        register_entity,
+        register_matcher,
+        register_property,
+        register_taxon,
+        registry_scope,
+    )
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.policy.queries import resolve_entity
+    from umwelt.world.model import DeclaredEntity, Provenance, WorldFile
+
+    con, dialect = _make_db()
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(
+            taxon="capability", name="tool",
+            attributes={"name": AttrSchema(type=str)},
+            description="a tool",
+        )
+        register_property(
+            taxon="capability", entity="tool", name="available",
+            value_type=str, description="whether available",
+        )
+
+        world = WorldFile(
+            entities=(
+                DeclaredEntity(type="tool", id="Bash", provenance=Provenance.EXPLICIT),
+            ),
+            projections=(),
+            warnings=(),
+            fixed_raw={"tool#Bash": {"available": "false"}},
+        )
+        populate_from_world(con, world)
+
+        view = parse_css("tool { available: true; }", validate=False)
+        compile_view(con, view, dialect)
+
+        # Without fixed constraints, cascade says 'true'
+        # With fixed constraints, effective value should be 'false'
+        result = resolve_entity(con, type="tool", id="Bash", property="available")
+        assert result == "false"
+```
+
+- [ ] **Step 10: Run test to verify it fails**
+
+Run: `pytest tests/policy/test_fixed_constraints.py::test_resolve_entity_uses_effective_properties -v`
+Expected: FAIL — resolve_entity reads `resolved_properties`, not `effective_properties`
+
+- [ ] **Step 11: Update queries.py to read effective_properties**
+
+In `src/umwelt/policy/queries.py`, replace all references to `resolved_properties` with `effective_properties`:
+
+Line 24-25: Change:
+```python
+        row = con.execute(
+            "SELECT property_value FROM resolved_properties "
+```
+To:
+```python
+        row = con.execute(
+            "SELECT effective_value FROM effective_properties "
+```
+
+Line 31-32: Change:
+```python
+    rows = con.execute(
+        "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+```
+To:
+```python
+    rows = con.execute(
+        "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
+```
+
+Line 52-53: Change:
+```python
+        props_rows = con.execute(
+            "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+```
+To:
+```python
+        props_rows = con.execute(
+            "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
+```
+
+Line 83-88 (trace_entity): Change:
+```python
+    winner_row = con.execute(
+        "SELECT property_value, specificity, rule_index "
+        "FROM resolved_properties "
+```
+To:
+```python
+    winner_row = con.execute(
+        "SELECT effective_value, specificity, rule_index "
+        "FROM effective_properties "
+```
+
+Note: `trace_entity` still reads `cascade_candidates` for all candidates. The winner check reads `effective_properties` to pick up fixed-clamped winners. However, when a fixed constraint overrides, the winner_row from `effective_properties` will have a different value than any cascade candidate. We need to handle this in trace output.
+
+Add to trace_entity, after building candidates list:
+
+```python
+    # Check if a fixed constraint overrode the cascade winner
+    if winning_value is not None:
+        fc_row = con.execute(
+            "SELECT property_value, selector FROM fixed_constraints "
+            "WHERE entity_id = ? AND property_name = ?",
+            (entity_pk, property),
+        ).fetchone()
+        if fc_row and fc_row[0] != winning_value:
+            # Fixed constraint is active but value matches override
+            pass  # The effective_properties already has the right value
+```
+
+Actually, the simpler approach: keep trace reading from both. The TraceResult.value already reflects the effective value. Candidates show what the cascade computed. The trace consumer sees the discrepancy (value != winning candidate's value) and knows a fixed constraint intervened.
+
+For now, just update the winner_row query and leave the candidates from cascade_candidates. This is enough for P0.
+
+- [ ] **Step 12: Remove "not yet implemented" warning for fixed key in parser.py**
+
+In `src/umwelt/world/parser.py`, change the Phase 2-3 key handling so `fixed` doesn't emit a warning:
+
+```python
+    for key in _PHASE2_KEYS:
+        if key in data:
+            if key != "fixed":
+                warnings.append(WorldWarning(
+                    message=f"'{key}' is not yet implemented (Phase 2-3)",
+                    key=key,
+                ))
+```
+
+- [ ] **Step 13: Run tests to verify they pass**
+
+Run: `pytest tests/policy/test_fixed_constraints.py -v`
+Expected: All PASS
+
+- [ ] **Step 14: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures. Some existing tests may read `resolved_properties` directly — check for breakage in lint.py tests.
+
+Note: `lint.py` reads `resolved_properties` directly for shadowed_rule detection and `cascade_candidates` for other checks. It does NOT read `effective_properties`. This is correct — lint analyzes cascade behavior, not fixed-clamped results. No changes needed to lint.py for P0.
+
+- [ ] **Step 15: Add lint warning for fixed-clamped rules**
+
+Add to `src/umwelt/policy/lint.py`:
+
+```python
+def _detect_fixed_override(con: sqlite3.Connection) -> list[LintWarning]:
+    """Warn when cascade-resolved value is overridden by a fixed constraint."""
+    warnings: list[LintWarning] = []
+    try:
+        rows = con.execute("""
+            SELECT ep.entity_id, ep.property_name, rp.property_value AS cascade_value,
+                   fc.property_value AS fixed_value
+            FROM effective_properties ep
+            JOIN resolved_properties rp ON rp.entity_id = ep.entity_id AND rp.property_name = ep.property_name
+            JOIN fixed_constraints fc ON fc.entity_id = ep.entity_id AND fc.property_name = ep.property_name
+            WHERE ep.source = 'fixed'
+        """).fetchall()
+    except Exception:
+        return warnings
+
+    for entity_pk, prop_name, cascade_val, fixed_val in rows:
+        entity_name = _entity_name(con, entity_pk)
+        warnings.append(LintWarning(
+            smell="fixed_override",
+            severity="info",
+            description=(
+                f"{entity_name} '{prop_name}': cascade resolved to '{cascade_val}'"
+                f" but fixed constraint clamps to '{fixed_val}'"
+            ),
+            entities=(entity_name,),
+            property=prop_name,
+        ))
+    return warnings
+```
+
+And add it to `run_lint()`:
+
+```python
+def run_lint(con: sqlite3.Connection) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+    warnings.extend(_detect_narrow_win(con))
+    warnings.extend(_detect_shadowed_rule(con))
+    warnings.extend(_detect_conflicting_intent(con))
+    warnings.extend(_detect_uncovered_entity(con))
+    warnings.extend(_detect_specificity_escalation(con))
+    warnings.extend(_detect_fixed_override(con))
+    # ...
+```
+
+- [ ] **Step 16: Run all tests**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add src/umwelt/compilers/sql/schema.py src/umwelt/compilers/sql/resolution.py \
+  src/umwelt/compilers/sql/populate.py src/umwelt/policy/queries.py \
+  src/umwelt/policy/lint.py src/umwelt/world/parser.py \
+  tests/policy/test_fixed_constraints.py
+git commit -m "feat(policy): add fixed constraints for post-cascade clamping
+
+World files declare fixed: blocks with selector-keyed property overrides.
+Fixed values win over cascade-resolved values via effective_properties view.
+Lint warns when cascade rules are clamped by fixed constraints."
+```
+
+---
+
+### Task 3: P1 — Plugin Autodiscovery
+
+**Files:**
+- Create: `src/umwelt/registry/plugins.py`
+- Modify: `src/umwelt/registry/taxa.py:60-74`
+- Modify: `src/umwelt/registry/__init__.py`
+- Modify: `src/umwelt/policy/engine.py:445-451`
+- Modify: `pyproject.toml`
+- Create: `tests/registry/test_plugins.py`
+
+- [ ] **Step 1: Write failing tests for plugin discovery and idempotent registration**
+
+Create `tests/registry/test_plugins.py`:
+
+```python
+"""Tests for plugin autodiscovery and idempotent taxon registration."""
+from __future__ import annotations
+
+import pytest
+
+from umwelt.errors import RegistryError
+from umwelt.registry import register_taxon, registry_scope
+from umwelt.registry.plugins import discover_plugins
+
+
+def test_idempotent_register_taxon_same_description():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        register_taxon(name="world", description="w")  # should not raise
+
+
+def test_idempotent_register_taxon_different_description_raises():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        with pytest.raises(RegistryError, match="conflicting"):
+            register_taxon(name="world", description="different")
+
+
+def test_discover_plugins_returns_list():
+    with registry_scope():
+        result = discover_plugins()
+        assert isinstance(result, list)
+
+
+def test_discover_plugins_loads_sandbox_entry_point(monkeypatch):
+    """If sandbox entry point is registered, it gets loaded."""
+    loaded = []
+
+    class FakeEntryPoint:
+        name = "test_plugin"
+        def load(self):
+            def register():
+                loaded.append("called")
+            return register
+
+    monkeypatch.setattr(
+        "umwelt.registry.plugins.entry_points",
+        lambda group: [FakeEntryPoint()],
+    )
+
+    with registry_scope():
+        names = discover_plugins()
+    assert "test_plugin" in names
+    assert loaded == ["called"]
+
+
+def test_discover_plugins_survives_broken_plugin(monkeypatch):
+    """A broken plugin doesn't take down discovery."""
+    class BrokenEntryPoint:
+        name = "broken"
+        def load(self):
+            raise ImportError("bad plugin")
+
+    class GoodEntryPoint:
+        name = "good"
+        def load(self):
+            return lambda: None
+
+    monkeypatch.setattr(
+        "umwelt.registry.plugins.entry_points",
+        lambda group: [BrokenEntryPoint(), GoodEntryPoint()],
+    )
+
+    with registry_scope():
+        names = discover_plugins()
+    assert "good" in names
+    assert "broken" not in names
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/registry/test_plugins.py -v`
+Expected: ImportError for `umwelt.registry.plugins`, failure on idempotent registration
+
+- [ ] **Step 3: Make register_taxon idempotent**
+
+In `src/umwelt/registry/taxa.py`, change `register_taxon`:
+
+```python
+def register_taxon(
+    *,
+    name: str,
+    description: str,
+    ma_concept: str | None = None,
+) -> None:
+    """Register a taxon with the active registry scope.
+
+    Idempotent: re-registration with matching description is a no-op.
+    Raises on conflicting re-registration (same name, different description).
+    """
+    state = _current_state()
+    if name in state.taxa:
+        existing = state.taxa[name]
+        if existing.description == description:
+            return  # idempotent
+        raise RegistryError(
+            f"taxon {name!r} already registered with conflicting description"
+        )
+    state.taxa[name] = TaxonSchema(
+        name=name,
+        description=description,
+        ma_concept=ma_concept,
+    )
+```
+
+- [ ] **Step 4: Create plugins.py**
+
+Create `src/umwelt/registry/plugins.py`:
+
+```python
+"""Plugin autodiscovery via entry points."""
+from __future__ import annotations
+
+import logging
+
+from importlib.metadata import entry_points
+
+logger = logging.getLogger("umwelt.registry")
+
+ENTRY_POINT_GROUP = "umwelt.plugins"
+
+
+def discover_plugins() -> list[str]:
+    """Load all registered umwelt plugins. Returns names of loaded plugins."""
+    loaded: list[str] = []
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        try:
+            register_fn = ep.load()
+            register_fn()
+            loaded.append(ep.name)
+        except Exception:
+            logger.debug("plugin %s failed to load", ep.name, exc_info=True)
+    return loaded
+```
+
+- [ ] **Step 5: Update registry __init__.py**
+
+Add to imports in `src/umwelt/registry/__init__.py`:
+
+```python
+from umwelt.registry.plugins import discover_plugins
+```
+
+Add `"discover_plugins"` to `__all__`.
+
+- [ ] **Step 6: Update _load_default_vocabulary in engine.py**
+
+In `src/umwelt/policy/engine.py`, change `_load_default_vocabulary`:
+
+```python
+def _load_default_vocabulary() -> None:
+    from umwelt.registry.plugins import discover_plugins
+    discover_plugins()
+```
+
+- [ ] **Step 7: Add sandbox entry point to pyproject.toml**
+
+Add to `pyproject.toml`:
+
+```toml
+[project.entry-points."umwelt.plugins"]
+sandbox = "umwelt.sandbox.vocabulary:register_sandbox_vocabulary"
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `pytest tests/registry/test_plugins.py -v`
+Expected: All PASS
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures. The idempotent register_taxon should fix some existing tests that used `contextlib.suppress(RegistryError)` around duplicate registrations.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/umwelt/registry/plugins.py src/umwelt/registry/taxa.py \
+  src/umwelt/registry/__init__.py src/umwelt/policy/engine.py \
+  pyproject.toml tests/registry/test_plugins.py
+git commit -m "feat(registry): add plugin autodiscovery via entry points
+
+discover_plugins() loads umwelt.plugins entry point group.
+register_taxon() is now idempotent on matching description.
+_load_default_vocabulary() delegates to discover_plugins()."
+```
+
+---
+
+### Task 4: P1 — Cross-Taxon Validators
+
+**Files:**
+- Modify: `src/umwelt/registry/validators.py:1-34`
+- Modify: `src/umwelt/registry/taxa.py:30-50`
+- Modify: `src/umwelt/registry/__init__.py`
+- Modify: `src/umwelt/validate.py:1-33`
+- Create: `tests/registry/test_cross_validators.py`
+
+- [ ] **Step 1: Write failing tests for cross-taxon validators**
+
+Create `tests/registry/test_cross_validators.py`:
+
+```python
+"""Tests for cross-taxon validator protocol, registration, and dispatch."""
+from __future__ import annotations
+
+from tests.core.helpers.toy_taxonomy import install_toy_taxonomy
+from umwelt.parser import parse
+from umwelt.registry import registry_scope
+from umwelt.registry.validators import (
+    CrossTaxonValidatorProtocol,
+    get_cross_taxon_validators,
+    register_cross_taxon_validator,
+)
+
+
+class _RecordingCrossValidator:
+    """Records the full view it receives."""
+
+    def __init__(self):
+        self.views_seen: list = []
+
+    def validate(self, view, warnings):
+        self.views_seen.append(view)
+
+
+def test_cross_validator_protocol_is_runtime_checkable():
+    assert isinstance(_RecordingCrossValidator(), CrossTaxonValidatorProtocol)
+
+
+def test_register_and_retrieve_cross_validator():
+    with registry_scope():
+        v = _RecordingCrossValidator()
+        register_cross_taxon_validator(v)
+        assert v in get_cross_taxon_validators()
+
+
+def test_cross_validator_receives_full_view():
+    with registry_scope():
+        install_toy_taxonomy()
+        v = _RecordingCrossValidator()
+        register_cross_taxon_validator(v)
+        parse("thing { paint: red; } actor { allowed: true; }")
+    assert len(v.views_seen) == 1
+    view = v.views_seen[0]
+    assert len(view.rules) == 2
+
+
+def test_cross_validator_runs_after_per_taxon():
+    """Cross-taxon validators see rules from all taxa."""
+    with registry_scope():
+        install_toy_taxonomy()
+        order = []
+
+        class PerTaxon:
+            def validate(self, rules, warnings):
+                order.append("per-taxon")
+
+        class CrossTaxon:
+            def validate(self, view, warnings):
+                order.append("cross-taxon")
+
+        from umwelt.registry import register_validator
+        register_validator(taxon="shapes", validator=PerTaxon())
+        register_cross_taxon_validator(CrossTaxon())
+        parse("thing { paint: red; }")
+
+    assert order == ["per-taxon", "cross-taxon"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/registry/test_cross_validators.py -v`
+Expected: ImportError for CrossTaxonValidatorProtocol, get_cross_taxon_validators
+
+- [ ] **Step 3: Add CrossTaxonValidatorProtocol and registration**
+
+In `src/umwelt/registry/validators.py`:
+
+```python
+"""Validator protocol and registration."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from umwelt.registry.taxa import _current_state, get_taxon, resolve_taxon
+
+
+@runtime_checkable
+class ValidatorProtocol(Protocol):
+    """A validator inspects rules in its taxon and emits warnings or errors.
+
+    `rules` is the full list of RuleBlocks whose target_taxon equals the
+    validator's registered taxon. The validator mutates the shared `warnings`
+    list for soft findings and raises ViewValidationError for hard failures.
+    """
+
+    def validate(self, rules: list[Any], warnings: list[Any]) -> None:
+        ...
+
+
+@runtime_checkable
+class CrossTaxonValidatorProtocol(Protocol):
+    """A validator that receives the full View across all taxa."""
+
+    def validate(self, view: Any, warnings: list[Any]) -> None:
+        ...
+
+
+def register_validator(*, taxon: str, validator: ValidatorProtocol) -> None:
+    get_taxon(taxon)
+    canonical = resolve_taxon(taxon)
+    state = _current_state()
+    state.validators.setdefault(canonical, []).append(validator)
+
+
+def get_validators(taxon: str) -> list[ValidatorProtocol]:
+    state = _current_state()
+    canonical = resolve_taxon(taxon)
+    return list(state.validators.get(canonical, []))
+
+
+def register_cross_taxon_validator(validator: CrossTaxonValidatorProtocol) -> None:
+    state = _current_state()
+    state.cross_validators.append(validator)
+
+
+def get_cross_taxon_validators() -> list[CrossTaxonValidatorProtocol]:
+    state = _current_state()
+    return list(state.cross_validators)
+```
+
+- [ ] **Step 4: Add cross_validators to RegistryState**
+
+In `src/umwelt/registry/taxa.py`, add to `RegistryState`:
+
+```python
+@dataclass
+class RegistryState:
+    taxa: dict[str, TaxonSchema] = field(default_factory=dict)
+    taxon_aliases: dict[str, str] = field(default_factory=dict)
+    entities: dict[tuple[str, str], EntitySchema] = field(default_factory=dict)
+    properties: dict[tuple[str, str, str], PropertySchema] = field(default_factory=dict)
+    matchers: dict[str, MatcherProtocol] = field(default_factory=dict)
+    validators: dict[str, list[ValidatorProtocol]] = field(default_factory=dict)
+    shorthands: dict[str, Any] = field(default_factory=dict)
+    cross_validators: list[Any] = field(default_factory=list)
+```
+
+- [ ] **Step 5: Update validate.py to dispatch cross-taxon validators**
+
+In `src/umwelt/validate.py`:
+
+```python
+"""Dispatch registered per-taxon validators over a parsed view."""
+
+from __future__ import annotations
+
+from umwelt.ast import ParseWarning, RuleBlock, View
+from umwelt.registry import get_validators, list_taxa
+from umwelt.registry.validators import get_cross_taxon_validators
+
+
+def validate(view: View) -> View:
+    """Run every registered validator over its taxon's rules.
+
+    Returns a new `View` with any accumulated warnings attached. Hard
+    failures raise ViewValidationError from the validator itself.
+    """
+    warnings_list: list[ParseWarning] = list(view.warnings)
+    # Group rules by the rightmost selector's target_taxon.
+    grouped: dict[str, list[RuleBlock]] = {}
+    for rule in view.rules:
+        for sel in rule.selectors:
+            grouped.setdefault(sel.target_taxon, []).append(rule)
+            break  # One rule -> one taxon group per rule; use first selector's taxon.
+    for taxon in list_taxa():
+        rules = grouped.get(taxon.name, [])
+        for validator in get_validators(taxon.name):
+            validator.validate(rules, warnings_list)
+
+    # Cross-taxon validators receive the full view
+    for validator in get_cross_taxon_validators():
+        validator.validate(view, warnings_list)
+
+    return View(
+        rules=view.rules,
+        unknown_at_rules=view.unknown_at_rules,
+        warnings=tuple(warnings_list),
+        source_text=view.source_text,
+        source_path=view.source_path,
+    )
+```
+
+- [ ] **Step 6: Update registry __init__.py exports**
+
+Add to `src/umwelt/registry/__init__.py`:
+
+```python
+from umwelt.registry.validators import (
+    CrossTaxonValidatorProtocol,
+    ValidatorProtocol,
+    get_cross_taxon_validators,
+    get_validators,
+    register_cross_taxon_validator,
+    register_validator,
+)
+```
+
+Add `"CrossTaxonValidatorProtocol"`, `"get_cross_taxon_validators"`, `"register_cross_taxon_validator"` to `__all__`.
+
+- [ ] **Step 7: Run tests**
+
+Run: `pytest tests/registry/test_cross_validators.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/umwelt/registry/validators.py src/umwelt/registry/taxa.py \
+  src/umwelt/registry/__init__.py src/umwelt/validate.py \
+  tests/registry/test_cross_validators.py
+git commit -m "feat(registry): add cross-taxon validator protocol
+
+CrossTaxonValidatorProtocol receives full View for multi-taxon invariants.
+Dispatched after per-taxon validators in validate()."
+```
+
+---
+
+### Task 5: P1 — World File Composition (require/include/exclude)
+
+**Files:**
+- Create: `src/umwelt/registry/collections.py`
+- Modify: `src/umwelt/world/model.py:20-25`
+- Modify: `src/umwelt/world/parser.py:20-111`
+- Modify: `src/umwelt/registry/__init__.py`
+- Modify: `src/umwelt/registry/taxa.py:30-50`
+- Create: `tests/world/test_composition.py`
+
+- [ ] **Step 1: Write failing tests for collection registry**
+
+Create `tests/world/test_composition.py`:
+
+```python
+"""Tests for world file composition: require, include, exclude."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from umwelt.registry import registry_scope
+from umwelt.registry.collections import (
+    register_collection,
+    require_collection,
+    get_collection_entities,
+)
+from umwelt.world.model import DeclaredEntity, Provenance
+
+
+def _tool_entity(name):
+    return DeclaredEntity(type="tool", id=name, provenance=Provenance.REQUIRED)
+
+
+def test_register_and_require_collection():
+    with registry_scope():
+        register_collection(
+            name="executables",
+            loader=lambda: [_tool_entity("Bash"), _tool_entity("Read")],
+        )
+        require_collection("executables")
+        entities = get_collection_entities()
+        ids = [e.id for e in entities]
+        assert "Bash" in ids
+        assert "Read" in ids
+
+
+def test_require_is_idempotent():
+    with registry_scope():
+        call_count = 0
+        def loader():
+            nonlocal call_count
+            call_count += 1
+            return [_tool_entity("Bash")]
+
+        register_collection(name="executables", loader=loader)
+        require_collection("executables")
+        require_collection("executables")
+        assert call_count == 1
+
+
+def test_require_unknown_collection_raises():
+    with registry_scope():
+        with pytest.raises(KeyError, match="ghost"):
+            require_collection("ghost")
+
+
+def test_provenance_is_required():
+    with registry_scope():
+        register_collection(
+            name="executables",
+            loader=lambda: [_tool_entity("Bash")],
+        )
+        require_collection("executables")
+        entities = get_collection_entities()
+        assert entities[0].provenance == Provenance.REQUIRED
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/world/test_composition.py -v`
+Expected: ImportError for collections module
+
+- [ ] **Step 3: Add Provenance.REQUIRED to model**
+
+In `src/umwelt/world/model.py`, add to Provenance enum:
+
+```python
+class Provenance(Enum):
+    EXPLICIT = "explicit"
+    DISCOVERED = "discovered"
+    PROJECTED = "projected"
+    INCLUDED = "included"
+    REQUIRED = "required"
+```
+
+- [ ] **Step 4: Create collections.py**
+
+Create `src/umwelt/registry/collections.py`:
+
+```python
+"""Collection registry for named entity bundles.
+
+Collections group entities (and optionally matchers) that a world file
+can require by name. require("filesystem") loads file/dir entities and
+the WorldMatcher. The default world is empty until collections are required.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from umwelt.registry.taxa import _current_state
+
+if TYPE_CHECKING:
+    from umwelt.registry.matchers import MatcherProtocol
+    from umwelt.world.model import DeclaredEntity
+
+
+def register_collection(
+    name: str,
+    loader: Callable[[], list[DeclaredEntity]],
+    matcher_factory: Callable[[], MatcherProtocol] | None = None,
+) -> None:
+    """Register a named collection of entities with an optional matcher factory."""
+    state = _current_state()
+    state.collections[name] = _CollectionDef(
+        name=name,
+        loader=loader,
+        matcher_factory=matcher_factory,
+    )
+
+
+def require_collection(name: str) -> None:
+    """Activate a named collection. Idempotent — second call is a no-op."""
+    state = _current_state()
+    if name in state.required_collections:
+        return
+    if name not in state.collections:
+        raise KeyError(f"unknown collection {name!r}")
+    defn = state.collections[name]
+    entities = defn.loader()
+    state.collection_entities.extend(entities)
+    if defn.matcher_factory is not None:
+        from umwelt.registry.matchers import register_matcher
+        matcher = defn.matcher_factory()
+        taxon = _infer_taxon(entities)
+        if taxon:
+            register_matcher(taxon=taxon, matcher=matcher)
+    state.required_collections.add(name)
+
+
+def get_collection_entities() -> list[DeclaredEntity]:
+    """Return all entities loaded by required collections."""
+    state = _current_state()
+    return list(state.collection_entities)
+
+
+def _infer_taxon(entities: list[DeclaredEntity]) -> str | None:
+    """Infer taxon from entity types via the entity registry."""
+    if not entities:
+        return None
+    try:
+        from umwelt.registry.entities import resolve_entity_type
+        taxa = resolve_entity_type(entities[0].type)
+        return taxa[0] if taxa else None
+    except Exception:
+        return None
+
+
+class _CollectionDef:
+    __slots__ = ("name", "loader", "matcher_factory")
+
+    def __init__(
+        self,
+        name: str,
+        loader: Callable[[], list[Any]],
+        matcher_factory: Callable[[], Any] | None,
+    ):
+        self.name = name
+        self.loader = loader
+        self.matcher_factory = matcher_factory
+```
+
+- [ ] **Step 5: Add collection state to RegistryState**
+
+In `src/umwelt/registry/taxa.py`, add to `RegistryState`:
+
+```python
+@dataclass
+class RegistryState:
+    taxa: dict[str, TaxonSchema] = field(default_factory=dict)
+    taxon_aliases: dict[str, str] = field(default_factory=dict)
+    entities: dict[tuple[str, str], EntitySchema] = field(default_factory=dict)
+    properties: dict[tuple[str, str, str], PropertySchema] = field(default_factory=dict)
+    matchers: dict[str, MatcherProtocol] = field(default_factory=dict)
+    validators: dict[str, list[ValidatorProtocol]] = field(default_factory=dict)
+    shorthands: dict[str, Any] = field(default_factory=dict)
+    cross_validators: list[Any] = field(default_factory=list)
+    collections: dict[str, Any] = field(default_factory=dict)
+    collection_entities: list[Any] = field(default_factory=list)
+    required_collections: set[str] = field(default_factory=set)
+```
+
+- [ ] **Step 6: Run collection tests**
+
+Run: `pytest tests/world/test_composition.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Write failing tests for include and exclude in parser**
+
+Add to `tests/world/test_composition.py`:
+
+```python
+import yaml
+
+
+def test_include_loads_entities_from_file(tmp_path):
+    """include: loads entities from another world file."""
+    from umwelt.registry import register_entity, register_taxon
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.world.parser import load_world
+
+    base = tmp_path / "base.world.yml"
+    base.write_text(yaml.dump({
+        "entities": [
+            {"type": "tool", "id": "Bash"},
+            {"type": "tool", "id": "Read"},
+        ]
+    }))
+
+    main = tmp_path / "main.world.yml"
+    main.write_text(yaml.dump({
+        "include": ["./base.world.yml"],
+        "entities": [
+            {"type": "tool", "id": "Edit"},
+        ],
+    }))
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(taxon="capability", name="tool",
+                       attributes={"name": AttrSchema(type=str)}, description="t")
+        world = load_world(main)
+    ids = [e.id for e in world.entities]
+    assert "Bash" in ids
+    assert "Read" in ids
+    assert "Edit" in ids
+
+
+def test_include_later_overrides_earlier(tmp_path):
+    """Later include files override earlier ones on (type, id) collision."""
+    base1 = tmp_path / "base1.world.yml"
+    base1.write_text(yaml.dump({
+        "entities": [{"type": "tool", "id": "Bash", "attributes": {"level": "1"}}]
+    }))
+    base2 = tmp_path / "base2.world.yml"
+    base2.write_text(yaml.dump({
+        "entities": [{"type": "tool", "id": "Bash", "attributes": {"level": "2"}}]
+    }))
+    main = tmp_path / "main.world.yml"
+    main.write_text(yaml.dump({
+        "include": ["./base1.world.yml", "./base2.world.yml"],
+    }))
+
+    from umwelt.registry import register_entity, register_taxon
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.world.parser import load_world
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(taxon="capability", name="tool",
+                       attributes={"name": AttrSchema(type=str)}, description="t")
+        world = load_world(main)
+    bash = [e for e in world.entities if e.id == "Bash"][0]
+    assert bash.attributes.get("level") == "2"
+
+
+def test_exclude_removes_entities(tmp_path):
+    """exclude: removes matching entities."""
+    main = tmp_path / "main.world.yml"
+    main.write_text(yaml.dump({
+        "entities": [
+            {"type": "tool", "id": "Bash"},
+            {"type": "tool", "id": "Read"},
+            {"type": "tool", "id": "Edit"},
+        ],
+        "exclude": ["tool#Bash"],
+    }))
+
+    from umwelt.registry import register_entity, register_taxon
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.world.parser import load_world
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(taxon="capability", name="tool",
+                       attributes={"name": AttrSchema(type=str)}, description="t")
+        world = load_world(main)
+    ids = [e.id for e in world.entities]
+    assert "Bash" not in ids
+    assert "Read" in ids
+    assert "Edit" in ids
+
+
+def test_include_cycle_detection(tmp_path):
+    """Circular includes are detected and skipped."""
+    a = tmp_path / "a.world.yml"
+    b = tmp_path / "b.world.yml"
+    a.write_text(yaml.dump({"include": ["./b.world.yml"], "entities": [{"type": "tool", "id": "A"}]}))
+    b.write_text(yaml.dump({"include": ["./a.world.yml"], "entities": [{"type": "tool", "id": "B"}]}))
+
+    from umwelt.registry import register_entity, register_taxon
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.world.parser import load_world
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(taxon="capability", name="tool",
+                       attributes={"name": AttrSchema(type=str)}, description="t")
+        world = load_world(a)
+    ids = [e.id for e in world.entities]
+    assert "A" in ids
+    assert "B" in ids
+    assert any("cycle" in w.message.lower() or "skip" in w.message.lower() for w in world.warnings)
+
+
+def test_require_in_world_file(tmp_path):
+    """require: activates named collections."""
+    main = tmp_path / "main.world.yml"
+    main.write_text(yaml.dump({
+        "require": ["test_tools"],
+        "entities": [{"type": "tool", "id": "Extra"}],
+    }))
+
+    from umwelt.registry import register_entity, register_taxon
+    from umwelt.registry.entities import AttrSchema
+    from umwelt.registry.collections import register_collection
+    from umwelt.world.parser import load_world
+
+    with registry_scope():
+        register_taxon(name="capability", description="cap")
+        register_entity(taxon="capability", name="tool",
+                       attributes={"name": AttrSchema(type=str)}, description="t")
+        register_collection(
+            name="test_tools",
+            loader=lambda: [_tool_entity("Bash"), _tool_entity("Read")],
+        )
+        world = load_world(main)
+    ids = [e.id for e in world.entities]
+    assert "Bash" in ids
+    assert "Read" in ids
+    assert "Extra" in ids
+```
+
+- [ ] **Step 8: Run tests to verify they fail**
+
+Run: `pytest tests/world/test_composition.py -v`
+Expected: Failures on include/exclude/require tests — parser doesn't process them
+
+- [ ] **Step 9: Implement include/exclude/require processing in parser.py**
+
+Update `src/umwelt/world/parser.py` to add `require` to structural keys, add a `_PHASE2_KEYS` adjustment, and implement processing:
+
+```python
+"""YAML parser for .world.yml files.
+
+Reads a world file, expands shorthand keys into ``DeclaredEntity`` instances,
+merges shorthand-derived entities with explicit ``entities:`` block entries
+(explicit wins on ``(type, id)`` collision), and processes composition
+directives (require, include, exclude).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from umwelt.errors import WorldParseError
+from umwelt.world.model import DeclaredEntity, Projection, Provenance, WorldFile, WorldWarning
+from umwelt.world.shorthands import get_shorthand
+
+_STRUCTURAL_KEYS = frozenset({"entities", "discover", "projections", "overrides", "fixed", "include", "exclude", "require"})
+_RESERVED_KEYS = frozenset({"vars", "when", "version"})
+_PHASE2_KEYS = frozenset({"discover", "overrides"})
+
+
+def load_world(path: str | Path, *, _seen: frozenset[str] | None = None) -> WorldFile:
+    """Parse a .world.yml file and return a :class:`WorldFile`."""
+    path = Path(path).resolve()
+    if _seen is None:
+        _seen = frozenset()
+
+    text = path.read_text()
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorldParseError(f"invalid YAML: {exc}") from exc
+    if data is None:
+        data = {}
+
+    warnings: list[WorldWarning] = []
+
+    # --- 1. require: collections (idempotent, unordered) ---
+    require_raw: tuple[str, ...] = ()
+    if "require" in data:
+        raw = data["require"]
+        if isinstance(raw, list):
+            require_raw = tuple(str(x) for x in raw)
+            _process_requires(require_raw, warnings)
+
+    # --- 2. include: files (ordered, later overrides earlier) ---
+    include_raw: tuple[str, ...] = ()
+    included_entities: list[DeclaredEntity] = []
+    if "include" in data:
+        raw = data["include"]
+        if isinstance(raw, list):
+            include_raw = tuple(str(x) for x in raw)
+            included_entities, inc_warnings = _process_includes(
+                include_raw, path.parent, _seen | {str(path)}
+            )
+            warnings.extend(inc_warnings)
+
+    # --- 3. Expand shorthands ---
+    shorthand_entities, sh_warnings = _expand_shorthands(data)
+    warnings.extend(sh_warnings)
+
+    # --- 4. Parse explicit entities block ---
+    explicit_entities: list[DeclaredEntity] = []
+    if "entities" in data:
+        raw = data["entities"]
+        if isinstance(raw, list):
+            for item in raw:
+                explicit_entities.append(_parse_entity_dict(item))
+
+    # --- 5. Merge: require → include → shorthand → explicit (later wins) ---
+    from umwelt.registry.collections import get_collection_entities
+    collection_entities = get_collection_entities()
+
+    merged: dict[tuple[str, str], DeclaredEntity] = {}
+    for e in collection_entities:
+        merged[(e.type, e.id)] = e
+    for e in included_entities:
+        merged[(e.type, e.id)] = e
+    for e in shorthand_entities:
+        merged[(e.type, e.id)] = e
+    for e in explicit_entities:
+        merged[(e.type, e.id)] = e
+
+    # --- 6. exclude: removals applied last ---
+    exclude_raw: tuple[str, ...] = ()
+    if "exclude" in data:
+        raw = data["exclude"]
+        if isinstance(raw, list):
+            exclude_raw = tuple(str(x) for x in raw)
+            merged = _apply_excludes(merged, exclude_raw, warnings)
+
+    # Parse projections block
+    projections: list[Projection] = []
+    if "projections" in data:
+        raw = data["projections"]
+        if isinstance(raw, list):
+            projections = _parse_projections(raw)
+
+    # Handle Phase 2-3 keys: stash raw values + emit warnings
+    discover_raw: tuple[dict[str, Any], ...] = ()
+    overrides_raw: dict[str, Any] = {}
+    fixed_raw: dict[str, Any] = {}
+
+    for key in _PHASE2_KEYS:
+        if key in data:
+            warnings.append(WorldWarning(
+                message=f"'{key}' is not yet implemented (Phase 2-3)",
+                key=key,
+            ))
+            if key == "discover":
+                discover_raw = tuple(data[key]) if isinstance(data[key], list) else ()
+            elif key == "overrides":
+                overrides_raw = data[key] if isinstance(data[key], dict) else {}
+
+    if "fixed" in data:
+        fixed_raw = data["fixed"] if isinstance(data["fixed"], dict) else {}
+
+    # Warn on reserved and unknown keys
+    known_keys = _STRUCTURAL_KEYS | _RESERVED_KEYS
+    for key in data:
+        if key in _RESERVED_KEYS:
+            warnings.append(WorldWarning(message=f"'{key}' is a reserved key", key=key))
+        elif key not in known_keys and get_shorthand(key) is None:
+            warnings.append(WorldWarning(message=f"unknown key '{key}'", key=key))
+
+    return WorldFile(
+        entities=tuple(merged.values()),
+        projections=tuple(projections),
+        warnings=tuple(warnings),
+        source_path=str(path),
+        discover_raw=discover_raw,
+        overrides_raw=overrides_raw,
+        fixed_raw=fixed_raw,
+        include_raw=include_raw,
+        exclude_raw=exclude_raw,
+    )
+
+
+def _process_requires(names: tuple[str, ...], warnings: list[WorldWarning]) -> None:
+    """Activate named collections."""
+    from umwelt.registry.collections import require_collection
+    for name in names:
+        try:
+            require_collection(name)
+        except KeyError:
+            warnings.append(WorldWarning(
+                message=f"unknown collection '{name}'",
+                key="require",
+            ))
+
+
+def _process_includes(
+    paths: tuple[str, ...],
+    base_dir: Path,
+    seen: frozenset[str],
+) -> tuple[list[DeclaredEntity], list[WorldWarning]]:
+    """Load entities from included world files, in order."""
+    entities: list[DeclaredEntity] = []
+    warnings: list[WorldWarning] = []
+    for rel_path in paths:
+        abs_path = (base_dir / rel_path).resolve()
+        if str(abs_path) in seen:
+            warnings.append(WorldWarning(
+                message=f"skipping circular include: {rel_path}",
+                key="include",
+            ))
+            continue
+        try:
+            included = load_world(abs_path, _seen=seen)
+            for e in included.entities:
+                entities.append(DeclaredEntity(
+                    type=e.type,
+                    id=e.id,
+                    classes=e.classes,
+                    attributes=e.attributes,
+                    parent=e.parent,
+                    provenance=Provenance.INCLUDED,
+                ))
+            warnings.extend(included.warnings)
+        except FileNotFoundError:
+            warnings.append(WorldWarning(
+                message=f"included file not found: {rel_path}",
+                key="include",
+            ))
+    return entities, warnings
+
+
+def _apply_excludes(
+    merged: dict[tuple[str, str], DeclaredEntity],
+    selectors: tuple[str, ...],
+    warnings: list[WorldWarning],
+) -> dict[tuple[str, str], DeclaredEntity]:
+    """Remove entities matching exclude selectors."""
+    for sel_str in selectors:
+        if "[" in sel_str:
+            warnings.append(WorldWarning(
+                message=f"attribute selectors in exclude not yet supported: {sel_str}",
+                key="exclude",
+            ))
+            continue
+        if "#" in sel_str:
+            type_name, entity_id = sel_str.split("#", 1)
+            key = (type_name, entity_id)
+            merged.pop(key, None)
+        else:
+            to_remove = [k for k in merged if k[0] == sel_str]
+            for k in to_remove:
+                del merged[k]
+    return merged
+
+
+# ... rest of file unchanged (_parse_entity_dict, _expand_shorthands, _parse_projections)
+```
+
+- [ ] **Step 10: Add `require` to WorldFile model**
+
+In `src/umwelt/world/model.py`, add `require_raw` field to `WorldFile`:
+
+```python
+@dataclass(frozen=True)
+class WorldFile:
+    entities: tuple[DeclaredEntity, ...]
+    projections: tuple[Projection, ...]
+    warnings: tuple[WorldWarning, ...]
+    source_path: str | None = None
+    discover_raw: tuple[dict[str, Any], ...] = ()
+    overrides_raw: dict[str, Any] = field(default_factory=dict)
+    fixed_raw: dict[str, Any] = field(default_factory=dict)
+    include_raw: tuple[str, ...] = ()
+    exclude_raw: tuple[str, ...] = ()
+    require_raw: tuple[str, ...] = ()
+```
+
+Update the `return WorldFile(...)` in parser.py to include `require_raw=require_raw`.
+
+- [ ] **Step 11: Update registry __init__.py**
+
+Add to `src/umwelt/registry/__init__.py`:
+
+```python
+from umwelt.registry.collections import (
+    get_collection_entities,
+    register_collection,
+    require_collection,
+)
+```
+
+Add all three to `__all__`.
+
+- [ ] **Step 12: Run tests**
+
+Run: `pytest tests/world/test_composition.py -v`
+Expected: All PASS
+
+- [ ] **Step 13: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures. Parser changes are backward-compatible — files without require/include/exclude work as before.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/umwelt/registry/collections.py src/umwelt/world/model.py \
+  src/umwelt/world/parser.py src/umwelt/registry/__init__.py \
+  src/umwelt/registry/taxa.py tests/world/test_composition.py
+git commit -m "feat(world): add require/include/exclude world file composition
+
+Collections bundle entities + optional matchers. require: activates them.
+include: loads entities from other world files with cycle detection.
+exclude: removes entities by type or type#id selector."
+```
+
+---
+
+### Task 6: P2 — Shared Event Schema
+
+**Files:**
+- Modify: `src/umwelt/sandbox/vocabulary.py`
+- Create: `tests/sandbox/test_event_schema.py`
+
+- [ ] **Step 1: Write failing test for extended audit vocabulary**
+
+Create `tests/sandbox/test_event_schema.py`:
+
+```python
+"""Tests for shared event schema on the audit taxon's observation entity."""
+from __future__ import annotations
+
+from umwelt.registry import get_property, list_properties, registry_scope
+
+
+def test_observation_has_event_properties():
+    with registry_scope():
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+        register_sandbox_vocabulary()
+
+        props = list_properties("audit", "observation")
+        prop_names = {p.name for p in props}
+        assert "type" in prop_names
+        assert "timestamp" in prop_names
+        assert "session_id" in prop_names
+        assert "severity" in prop_names
+        assert "tags" in prop_names
+        assert "payload" in prop_names
+
+
+def test_observation_event_property_types():
+    with registry_scope():
+        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+        register_sandbox_vocabulary()
+
+        assert get_property("audit", "observation", "type").value_type == str
+        assert get_property("audit", "observation", "timestamp").value_type == str
+        assert get_property("audit", "observation", "session_id").value_type == str
+        assert get_property("audit", "observation", "severity").value_type == str
+        assert get_property("audit", "observation", "tags").value_type == str
+        assert get_property("audit", "observation", "payload").value_type == str
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/sandbox/test_event_schema.py -v`
+Expected: FAIL — missing properties on observation
+
+- [ ] **Step 3: Add event properties to observation in vocabulary.py**
+
+In `src/umwelt/sandbox/vocabulary.py`, find the section that registers audit/observation properties and add:
+
+```python
+    # Event schema properties on observation
+    register_property(
+        taxon="audit", entity="observation", name="type",
+        value_type=str, description="event category: tool_call, build_run, failure, etc.",
+    )
+    register_property(
+        taxon="audit", entity="observation", name="timestamp",
+        value_type=str, description="ISO 8601 timestamp",
+    )
+    register_property(
+        taxon="audit", entity="observation", name="session_id",
+        value_type=str, description="Claude Code session ID",
+    )
+    register_property(
+        taxon="audit", entity="observation", name="severity",
+        value_type=str, description="info, warning, error, critical",
+    )
+    register_property(
+        taxon="audit", entity="observation", name="tags",
+        value_type=str, description="classification tags: repeated_pattern, permission_denial, etc.",
+    )
+    register_property(
+        taxon="audit", entity="observation", name="payload",
+        value_type=str, description="JSON blob with tool-specific structure",
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/sandbox/test_event_schema.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/umwelt/sandbox/vocabulary.py tests/sandbox/test_event_schema.py
+git commit -m "feat(audit): add shared event schema to observation entity
+
+Six new properties: type, timestamp, session_id, severity, tags, payload.
+Common vocabulary for tool observation events across all consumer plugins."
+```
+
+---
+
+### Task 7: P3 — Compiler Options (Bless **kwargs)
+
+**Files:**
+- Modify: `src/umwelt/compilers/protocol.py:20-36`
+- Create: `tests/core/test_compiler_options.py`
+
+- [ ] **Step 1: Write failing test for compiler protocol with options**
+
+Create `tests/core/test_compiler_options.py`:
+
+```python
+"""Tests for compiler protocol with **options support."""
+from __future__ import annotations
+
+from typing import Any
+
+from umwelt.cascade.resolver import ResolvedView
+from umwelt.compilers.protocol import Compiler
+
+
+class OptionsCapturingCompiler:
+    target_name = "test"
+    target_format = "json"
+    altitude = "semantic"
+
+    def __init__(self):
+        self.last_options: dict = {}
+
+    def compile(self, view: ResolvedView, **options: Any) -> dict[str, Any]:
+        self.last_options = options
+        return {"options": options}
+
+
+def test_compiler_with_options_satisfies_protocol():
+    c = OptionsCapturingCompiler()
+    assert isinstance(c, Compiler)
+
+
+def test_compiler_receives_options():
+    c = OptionsCapturingCompiler()
+    c.compile(ResolvedView(), workspace_root="/workspace", mode="implement")
+    assert c.last_options == {"workspace_root": "/workspace", "mode": "implement"}
+
+
+def test_compiler_works_without_options():
+    c = OptionsCapturingCompiler()
+    c.compile(ResolvedView())
+    assert c.last_options == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_compiler_options.py -v`
+Expected: Possible failure on protocol check if Compiler protocol doesn't accept **options, or PASS if Protocol matching is structural and already accepts it
+
+- [ ] **Step 3: Update Compiler protocol signature**
+
+In `src/umwelt/compilers/protocol.py`, change the compile method:
+
+```python
+    def compile(self, view: ResolvedView, **options: Any) -> str | list[str] | dict[str, Any]:
+        ...
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/core/test_compiler_options.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/umwelt/compilers/protocol.py tests/core/test_compiler_options.py
+git commit -m "feat(compilers): bless **options in Compiler protocol
+
+Compiler.compile() now explicitly accepts **options for caller context
+(workspace_root, mode, etc.). Backward compatible — existing compilers
+already use **kwargs."
+```
+
+---
+
+### Task 8: P3 — Altitude Filtering (Core Enforcement)
+
+**Files:**
+- Modify: `src/umwelt/registry/properties.py:22-37`
+- Modify: `src/umwelt/compilers/protocol.py:1-67`
+- Modify: `src/umwelt/policy/lint.py`
+- Create: `tests/core/test_altitude_filtering.py`
+
+- [ ] **Step 1: Write failing tests for altitude on PropertySchema**
+
+Create `tests/core/test_altitude_filtering.py`:
+
+```python
+"""Tests for altitude filtering: PropertySchema.altitude, pre-filtering, linting."""
+from __future__ import annotations
+
+import pytest
+
+from umwelt.compilers.protocol import Altitude, _ALTITUDE_RANK, _filter_by_altitude
+from umwelt.registry import register_entity, register_property, register_taxon, registry_scope
+from umwelt.registry.entities import AttrSchema
+from umwelt.registry.properties import PropertySchema
+
+
+def test_property_schema_has_altitude():
+    schema = PropertySchema(
+        name="editable", taxon="world", entity="file",
+        value_type=bool, altitude="os",
+    )
+    assert schema.altitude == "os"
+
+
+def test_property_schema_altitude_defaults_to_none():
+    schema = PropertySchema(
+        name="editable", taxon="world", entity="file",
+        value_type=bool,
+    )
+    assert schema.altitude is None
+
+
+def test_altitude_ranking():
+    assert _ALTITUDE_RANK["os"] < _ALTITUDE_RANK["language"]
+    assert _ALTITUDE_RANK["language"] < _ALTITUDE_RANK["semantic"]
+    assert _ALTITUDE_RANK["semantic"] < _ALTITUDE_RANK["conversational"]
+
+
+def test_register_property_with_altitude():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        register_entity(taxon="world", name="file",
+                       attributes={"path": AttrSchema(type=str)}, description="f")
+        register_property(
+            taxon="world", entity="file", name="editable",
+            value_type=bool, description="can edit",
+            altitude="os",
+        )
+        from umwelt.registry import get_property
+        prop = get_property("world", "file", "editable")
+        assert prop.altitude == "os"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_altitude_filtering.py -v`
+Expected: FAIL — PropertySchema has no altitude field, no _ALTITUDE_RANK or _filter_by_altitude
+
+- [ ] **Step 3: Add altitude to PropertySchema**
+
+In `src/umwelt/registry/properties.py`, add to PropertySchema:
+
+```python
+@dataclass(frozen=True)
+class PropertySchema:
+    """Metadata for a registered declaration property."""
+
+    name: str
+    taxon: str
+    entity: str
+    value_type: type
+    comparison: Comparison = "exact"
+    restrictive_direction: RestrictiveDirection | None = None
+    value_attribute: str | None = None
+    value_unit: str | None = None
+    value_range: tuple[Any, Any] | None = None
+    description: str = ""
+    category: str | None = None
+    altitude: str | None = None
+```
+
+Add `altitude` parameter to `register_property()`:
+
+```python
+def register_property(
+    *,
+    taxon: str,
+    entity: str,
+    name: str,
+    value_type: type,
+    description: str,
+    comparison: Comparison = "exact",
+    restrictive_direction: RestrictiveDirection | None = None,
+    value_attribute: str | None = None,
+    value_unit: str | None = None,
+    value_range: tuple[Any, Any] | None = None,
+    category: str | None = None,
+    altitude: str | None = None,
+) -> None:
+    """Register a property on a (taxon, entity) pair."""
+    get_entity(taxon, entity)
+    canonical = resolve_taxon(taxon)
+    state = _current_state()
+    key = (canonical, entity, name)
+    if key in state.properties:
+        raise RegistryError(
+            f"property {name!r} already registered on {taxon}.{entity}"
+        )
+    state.properties[key] = PropertySchema(
+        name=name,
+        taxon=canonical,
+        entity=entity,
+        value_type=value_type,
+        comparison=comparison,
+        restrictive_direction=restrictive_direction,
+        value_attribute=value_attribute,
+        value_unit=value_unit,
+        value_range=value_range,
+        description=description,
+        category=category,
+        altitude=altitude,
+    )
+```
+
+- [ ] **Step 4: Add altitude ranking and filter to protocol.py**
+
+In `src/umwelt/compilers/protocol.py`, add:
+
+```python
+_ALTITUDE_RANK: dict[str, int] = {
+    "os": 0,
+    "language": 1,
+    "semantic": 2,
+    "conversational": 3,
+}
+
+
+def _filter_by_altitude(view: ResolvedView, max_altitude: Altitude) -> ResolvedView:
+    """Return a ResolvedView containing only properties at or below max_altitude."""
+    from umwelt.registry.properties import get_property
+
+    max_rank = _ALTITUDE_RANK[max_altitude]
+    filtered = ResolvedView()
+
+    for taxon in view.taxa():
+        for entity_id, props in view.entries(taxon):
+            kept: dict[str, str] = {}
+            for prop_name, prop_value in props.items():
+                try:
+                    schema = get_property(taxon, entity_id.split("#")[0] if "#" in entity_id else "*", prop_name)
+                    prop_altitude = schema.altitude
+                except Exception:
+                    prop_altitude = None
+
+                if prop_altitude is None or _ALTITUDE_RANK.get(prop_altitude, 0) <= max_rank:
+                    kept[prop_name] = prop_value
+            if kept:
+                filtered.add(taxon, entity_id, kept)
+
+    return filtered
+```
+
+Note: `ResolvedView` has `taxa() -> list[str]`, `entries(taxon) -> Iterator[(entity, dict)]`, `add(taxon, entity, props)`. The entity is an opaque handle (not a string ID). To look up property schemas, we need the entity's type_name, which requires asking the matcher or inspecting the entity. For P3, a pragmatic approach: look up altitude from `(taxon, type_name, prop_name)` where type_name comes from `getattr(entity, 'type_name', None)` or from the entity_type registry. If lookup fails, include the property (conservative default).
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/core/test_altitude_filtering.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Add linter warning for unrealizable rules**
+
+Add to `src/umwelt/policy/lint.py`:
+
+```python
+def _detect_unrealizable_altitude(con: sqlite3.Connection) -> list[LintWarning]:
+    """Warn when a resolved property is at an altitude no compiler handles."""
+    warnings: list[LintWarning] = []
+    try:
+        from umwelt.compilers.protocol import _ALTITUDE_RANK, available
+        from umwelt.registry.properties import get_property
+
+        registered = available()
+        if not registered:
+            return warnings
+
+        from umwelt.compilers.protocol import get as get_compiler
+        compiler_altitudes = set()
+        for name in registered:
+            try:
+                c = get_compiler(name)
+                compiler_altitudes.add(c.altitude)
+            except Exception:
+                continue
+
+        if not compiler_altitudes:
+            return warnings
+
+        max_rank = max(_ALTITUDE_RANK.get(a, 0) for a in compiler_altitudes)
+
+        rows = con.execute(
+            "SELECT DISTINCT property_name FROM resolved_properties"
+        ).fetchall()
+
+        for (prop_name,) in rows:
+            try:
+                # Try to find property schema — best effort
+                state_rows = con.execute(
+                    "SELECT DISTINCT e.type_name, e.taxon FROM entities e "
+                    "JOIN resolved_properties rp ON e.id = rp.entity_id "
+                    "WHERE rp.property_name = ? LIMIT 1",
+                    (prop_name,),
+                ).fetchall()
+                if not state_rows:
+                    continue
+                type_name, taxon = state_rows[0]
+                schema = get_property(taxon, type_name, prop_name)
+                if schema.altitude and _ALTITUDE_RANK.get(schema.altitude, 0) > max_rank:
+                    warnings.append(LintWarning(
+                        smell="unrealizable_altitude",
+                        severity="warning",
+                        description=(
+                            f"Property '{prop_name}' ({schema.altitude}) has no compiler "
+                            f"at that altitude"
+                        ),
+                        entities=(),
+                        property=prop_name,
+                    ))
+            except Exception:
+                continue
+    except ImportError:
+        pass
+    return warnings
+```
+
+Add it to `run_lint()`:
+
+```python
+    warnings.extend(_detect_unrealizable_altitude(con))
+```
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: No new failures
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/umwelt/registry/properties.py src/umwelt/compilers/protocol.py \
+  src/umwelt/policy/lint.py tests/core/test_altitude_filtering.py
+git commit -m "feat(compilers): add altitude filtering with core enforcement
+
+PropertySchema gains altitude field. _filter_by_altitude() pre-filters
+ResolvedView before passing to compilers. Linter warns on unrealizable
+altitude properties."
+```
+
+---
+
+### Task 9: Push all changes
+
+- [ ] **Step 1: Push**
+
+```bash
+git push origin main
+```

--- a/docs/superpowers/specs/2026-04-26-plugin-api-gaps-design.md
+++ b/docs/superpowers/specs/2026-04-26-plugin-api-gaps-design.md
@@ -1,0 +1,554 @@
+# Plugin API Gaps — Design Specification
+
+*Addressing seven gaps in the umwelt plugin API that block multi-tool coexistence in the retritis ecosystem.*
+
+## Context
+
+umwelt's plugin API provides registration surfaces for taxa, entities, properties, matchers, validators, compilers, and world-file shorthands. The sandbox consumer demonstrates the pattern. But when blq, kibitzer, jetsam, fledgling, and squackit all need to coexist as plugins, seven gaps emerge — ranging from hard blockers (one matcher per taxon) to missing contracts (altitude filtering).
+
+This spec designs solutions for all seven, prioritized by impact.
+
+### Consumer tools and their needs
+
+| Tool | Purpose | Key entity types | Taxon needs |
+|------|---------|-----------------|-------------|
+| blq | Build/test event capture and query | build-run, build-command, build-error | state |
+| kibitzer | Tool call observation, mode enforcement | mode, hook, tool-call, path-restriction | state, capability |
+| jetsam | Git workflow with confirmation plans | git-operation, branch, git-plan | state, world |
+| fledgling | DuckDB code analysis and conversation audit | ast-node, definition, conversation-message | audit, world |
+| squackit | MCP server wrapping fledgling/sitting_duck | query, cache-entry, response | state |
+| pluckit | Code mutation chains with CSS selectors | selector, mutation, chain | capability, world |
+
+---
+
+## P0: CompositeMatcher — Multi-Matcher Per Taxon
+
+### Problem
+
+`registry/matchers.py:75` raises `RegistryError` if a second matcher is registered for the same taxon. Storage is `dict[str, MatcherProtocol]`. blq, kibitzer, and sandbox all need to provide entities in the `state` taxon.
+
+### Design
+
+Add `CompositeMatcher` to `umwelt.registry.matchers` that delegates to an ordered list of child matchers:
+
+```python
+class CompositeMatcher:
+    """Delegates to multiple matchers for the same taxon."""
+    
+    def __init__(self, *delegates: MatcherProtocol):
+        self._delegates = list(delegates)
+    
+    def add(self, matcher: MatcherProtocol) -> None:
+        self._delegates.append(matcher)
+    
+    def match_type(self, type_name, context=None):
+        results = []
+        for d in self._delegates:
+            results.extend(d.match_type(type_name, context))
+        return results
+    
+    def children(self, parent, child_type):
+        results = []
+        for d in self._delegates:
+            results.extend(d.children(parent, child_type))
+        return results
+    
+    def condition_met(self, selector, context=None):
+        return any(d.condition_met(selector, context) for d in self._delegates)
+    
+    def get_attribute(self, entity, name):
+        for d in self._delegates:
+            val = d.get_attribute(entity, name)
+            if val is not None:
+                return val
+        return None
+    
+    def get_id(self, entity):
+        for d in self._delegates:
+            val = d.get_id(entity)
+            if val is not None:
+                return val
+        return None
+```
+
+### Auto-composition on collision
+
+Change `register_matcher()` behavior: instead of raising on duplicate, wrap in a CompositeMatcher:
+
+```python
+def register_matcher(*, taxon: str, matcher: MatcherProtocol) -> None:
+    canonical = resolve_taxon(taxon)
+    state = _current_state()
+    if canonical in state.matchers:
+        existing = state.matchers[canonical]
+        if isinstance(existing, CompositeMatcher):
+            existing.add(matcher)
+        else:
+            state.matchers[canonical] = CompositeMatcher(existing, matcher)
+    else:
+        state.matchers[canonical] = matcher
+```
+
+Consumers call `register_matcher()` independently. Order is registration order. No coordination required.
+
+### Semantics
+
+- `match_type()`: union of all delegates' results
+- `condition_met()`: OR — any delegate satisfied means the gate passes
+- `get_id()` / `get_attribute()`: first non-None wins (registration order)
+- `children()`: union of all delegates' results
+
+### Files changed
+
+- `src/umwelt/registry/matchers.py` — add CompositeMatcher class, change register_matcher
+- Tests for CompositeMatcher behavior and auto-composition
+
+---
+
+## P0: Fixed Constraints — Post-Cascade Clamping
+
+### Problem
+
+World files can declare `fixed:` blocks but they're captured as raw dicts and never processed. Without this, there's no way to express hard boundaries that policy cannot override.
+
+### Design
+
+#### New SQL table
+
+```sql
+CREATE TABLE fixed_constraints (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER REFERENCES entities(id),
+    property_name TEXT NOT NULL,
+    property_value TEXT NOT NULL,
+    selector TEXT NOT NULL
+);
+```
+
+#### Processing — two phases
+
+**Phase A (during entity population):** After entities are inserted into the database but before cascade resolution, process `fixed_raw`:
+
+1. For each selector string in `fixed_raw`, compile to SQL WHERE clause (reuse `compile_selector()` from the SQL compiler)
+2. Query matching entity IDs
+3. For each property in the constraint dict, INSERT into `fixed_constraints`
+
+**Phase B (after cascade resolution):** The `effective_properties` view reads from both `resolved_properties` (cascade output) and `fixed_constraints`, with fixed values winning via COALESCE. This view is created as part of the schema, not as a processing step — it's always available once the tables exist.
+
+#### Effective properties view
+
+```sql
+CREATE VIEW effective_properties AS
+SELECT 
+    rp.entity_id,
+    rp.property_name,
+    COALESCE(fc.property_value, rp.resolved_value) AS effective_value,
+    CASE WHEN fc.id IS NOT NULL THEN 'fixed' ELSE 'cascade' END AS source
+FROM resolved_properties rp
+LEFT JOIN fixed_constraints fc 
+    ON fc.entity_id = rp.entity_id 
+    AND fc.property_name = rp.property_name;
+```
+
+#### PolicyEngine integration
+
+- `resolve()` and `resolve_all()` read from `effective_properties` instead of `resolved_properties`
+- `trace()` includes fixed constraints in output — when a fixed constraint overrides the cascade, the trace shows both the cascade winner and the fixed clamp
+- `lint()` warns when a cascade-resolved value is overridden by a fixed constraint (informational, not an error — the author should know their rule is being clamped)
+
+#### Parser changes
+
+Remove "not yet implemented" warning for `fixed:` key in `parser.py`.
+
+### Files changed
+
+- `src/umwelt/compilers/sql/schema.py` — add fixed_constraints table, effective_properties view
+- `src/umwelt/compilers/sql/populate.py` — process fixed_raw in populate_from_world()
+- `src/umwelt/policy/queries.py` — read effective_properties
+- `src/umwelt/policy/engine.py` — trace includes fixed constraints
+- `src/umwelt/world/parser.py` — remove warning for fixed key
+- Tests for fixed constraint processing, clamping, and trace output
+
+---
+
+## P1: Plugin Autodiscovery
+
+### Problem
+
+CLI hardcodes `from umwelt.sandbox.vocabulary import register_sandbox_vocabulary`. Third-party plugins can't register without explicit import code.
+
+### Design
+
+#### Entry point group
+
+Single group: `umwelt.plugins`. Each plugin provides one callable that does all registration.
+
+```toml
+# umwelt's pyproject.toml:
+[project.entry-points."umwelt.plugins"]
+sandbox = "umwelt.sandbox.vocabulary:register_sandbox_vocabulary"
+
+# blq's pyproject.toml (example):
+[project.entry-points."umwelt.plugins"]
+blq = "blq.umwelt_plugin:register"
+```
+
+#### Discovery function
+
+```python
+# umwelt/registry/plugins.py
+def discover_plugins() -> list[str]:
+    """Load all registered umwelt plugins. Returns names of loaded plugins."""
+    from importlib.metadata import entry_points
+    loaded = []
+    for ep in entry_points(group="umwelt.plugins"):
+        try:
+            register_fn = ep.load()
+            register_fn()
+            loaded.append(ep.name)
+        except Exception:
+            pass  # broken plugin doesn't take down the CLI
+    return loaded
+```
+
+#### CLI integration
+
+`_load_default_vocabulary()` calls `discover_plugins()` instead of hardcoded imports. Existing `try/except ImportError` fallback stays for environments without working entry points.
+
+#### Idempotent registration
+
+`register_taxon()` changes: if called with a name that's already registered with matching description, silently return. Raise only on conflicting re-registration (same name, different description). This enables plugins to `require` dependencies without worrying about load order.
+
+### Files changed
+
+- New file: `src/umwelt/registry/plugins.py`
+- `src/umwelt/registry/taxa.py` — idempotent register_taxon
+- `src/umwelt/cli.py` — use discover_plugins()
+- `pyproject.toml` — add sandbox entry point
+- Tests for discovery, idempotent registration, broken plugin handling
+
+---
+
+## P1: Cross-Taxon Validators
+
+### Problem
+
+Validators receive only rules for their taxon. Invariants spanning multiple taxa (e.g., "if tool#Bash is allowed, resource#wall-time must have a limit") can't be expressed.
+
+### Design
+
+#### New protocol
+
+```python
+class CrossTaxonValidatorProtocol(Protocol):
+    def validate(self, view: View, warnings: list) -> None: ...
+```
+
+Receives the full View — all rules across all taxa.
+
+#### Registration
+
+```python
+def register_cross_taxon_validator(validator: CrossTaxonValidatorProtocol) -> None:
+    state = _current_state()
+    state.cross_validators.append(validator)
+```
+
+Storage: `cross_validators: list[CrossTaxonValidatorProtocol]` on RegistryState.
+
+#### Dispatch
+
+In `validate.py`, after the existing per-taxon pass:
+
+```python
+# Existing: per-taxon validators
+for taxon in list_taxa():
+    rules = grouped.get(taxon.name, [])
+    for validator in get_validators(taxon.name):
+        validator.validate(rules, warnings_list)
+
+# New: cross-taxon validators
+for validator in get_cross_taxon_validators():
+    validator.validate(view, warnings_list)
+```
+
+#### No first-party validators initially
+
+The infrastructure ships empty. The linter spec describes the cross-taxon checks; those become validators once consumers implement them.
+
+### Files changed
+
+- `src/umwelt/registry/validators.py` — new protocol, registration, retrieval
+- `src/umwelt/registry/taxa.py` — add cross_validators to RegistryState
+- `src/umwelt/validate.py` — add cross-taxon dispatch pass
+- Tests for cross-taxon validator registration and dispatch
+
+---
+
+## P1: World File Composition — `require:`, `include:`, `exclude:`
+
+### Problem
+
+Every delegation needs a complete world file. Can't compose from reusable components or layer project-specific overrides.
+
+### Design
+
+#### Three mechanisms
+
+- **`require: [filesystem, executables, resources]`** — Named collections. Idempotent. Order-independent.
+- **`include: [./team-tools.world.yml, ./project.world.yml]`** — File paths relative to including file. Ordered (later overrides earlier).
+- **`exclude: [tool#Bash, file#/etc/passwd]`** — Selector-based entity removal. Applied after all requires and includes. For v1, supports type selectors (`tool`), ID selectors (`tool#Bash`), and type+ID combinations. Attribute selectors (`file[path^="src/"]`) are deferred — emit a warning and skip.
+
+#### Merge order
+
+```
+1. require: collections loaded (idempotent, unordered)
+2. include: files loaded (ordered, later overrides earlier)  
+3. own entities (override everything)
+4. exclude: removals applied last
+```
+
+Keyed by `(type, id)` — same merge logic as existing shorthand/explicit merge.
+
+#### Collection registry
+
+```python
+# umwelt/registry/collections.py
+def register_collection(
+    name: str, 
+    loader: Callable[[], list[DeclaredEntity]],
+    matcher_factory: Callable[[], MatcherProtocol] | None = None,
+) -> None: ...
+
+def require_collection(name: str) -> None: ...  # idempotent
+```
+
+Collections bundle:
+- Entities (the things that exist when this collection is active)
+- Optionally a matcher factory (activated when the collection is required)
+
+Sandbox registers collections instead of bulk-loading everything:
+- `filesystem` — file, dir entities + WorldMatcher
+- `executables` — tool entities for Bash, subprocess + CapabilityMatcher
+- `mcp-tools` — tool entities for MCP server tools
+- `resources` — memory, wall-time, CPU budget entities
+- `networking` — network, endpoint entities
+- `inferencers` — model/inferencer entities + ActorMatcher
+- `principals` — user/agent entities + PrincipalMatcher
+- `modes` — mode entities + StateMatcher for modes
+- `hooks` — hook entities + StateMatcher for hooks
+
+#### Default world is empty
+
+`register_sandbox_vocabulary()` registers taxa, entity types, and property schemas. It does NOT register matchers or populate entities. Collections do that. A world file with no `require:` has an empty entity graph.
+
+#### Matchers follow collections
+
+When `require("filesystem")` is called, it loads the file/dir entities AND registers the WorldMatcher. No collection required = no matcher = empty results.
+
+Multiple collections may register matchers for the same taxon (e.g., `modes` and `hooks` both register state-taxon matchers). The CompositeMatcher from the P0 design handles this — auto-composition on collision means collections don't need to coordinate.
+
+#### Cycle detection for include
+
+Track resolved absolute paths during recursive loading. Skip on cycle, emit warning.
+
+#### Provenance
+
+- Required entities: `provenance: Provenance.REQUIRED` with collection name
+- Included entities: `provenance: Provenance.INCLUDED` with source path
+- Excluded entities: removed entirely (not marked)
+
+#### Fragment references deferred
+
+`file.yml#section` syntax is not in scope. Plain file paths only. Warning on fragment syntax.
+
+### Files changed
+
+- New file: `src/umwelt/registry/collections.py`
+- `src/umwelt/world/model.py` — add Provenance.REQUIRED, Provenance.INCLUDED
+- `src/umwelt/world/parser.py` — process require/include/exclude, remove warnings
+- `src/umwelt/sandbox/vocabulary.py` — register collections instead of bulk registration
+- Tests for composition, merge order, cycle detection, provenance
+
+---
+
+## P2: Shared Event Schema
+
+### Problem
+
+Seven tools emit observations with no common schema. The audit taxon registers only minimal observation entities.
+
+### Design
+
+#### Extended audit vocabulary
+
+Properties on the `observation` entity:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `source` | str | Which tool produced it (existing) |
+| `enabled` | bool | Whether active (existing) |
+| `type` | str | Event category: tool_call, build_run, failure, etc. |
+| `timestamp` | str | ISO 8601 |
+| `session_id` | str | Claude Code session ID |
+| `severity` | str | info, warning, error, critical |
+| `tags` | list | Classification: repeated_pattern, permission_denial, etc. |
+| `payload` | str | JSON blob with tool-specific structure |
+
+#### Sub-types via classes
+
+`observation.kibitzer`, `observation.blq`, `observation.ratchet` — classes distinguish the source while sharing the schema.
+
+#### Collection registration
+
+Audit vocabulary becomes a collection: `require("audit")`. Tools that emit observations require it.
+
+#### Write protocol
+
+Lives outside umwelt core (in `retritis.substrate` or similar):
+
+```python
+def emit_observation(
+    source: str, type: str, payload: dict,
+    severity: str = "info", tags: list[str] = (),
+    session_id: str | None = None,
+) -> None: ...
+```
+
+Backed by the DuckDB append-only store from the integration-layer-plan.
+
+#### Umwelt's role
+
+Umwelt owns the vocabulary (what observations look like). The substrate owns storage. The ratchet owns consumption. Clear separation.
+
+### Files changed
+
+- `src/umwelt/sandbox/vocabulary.py` — extend audit entity properties
+- Substrate package (outside umwelt) — write protocol and DuckDB storage
+- Tests for extended vocabulary registration
+
+---
+
+## P3: Compiler Options — Bless `**kwargs`
+
+### Problem
+
+`compile(view: ResolvedView)` has no options channel. Compilers hack `**kwargs`.
+
+### Design
+
+#### Protocol change
+
+```python
+class Compiler(Protocol):
+    target_name: str
+    target_format: str
+    altitude: Altitude
+    
+    def compile(self, view: ResolvedView, **options: Any) -> str | list[str] | dict[str, Any]: ...
+```
+
+#### Backward compatible
+
+Existing compilers already accept `**kwargs`. This change documents the convention.
+
+#### Caller changes
+
+CLI, check_util, and audit pass relevant context through:
+
+```python
+compiler.compile(resolved_view, workspace_root="/workspace", mode="implement")
+```
+
+#### Documentation
+
+Compiler protocol docstring explains: compilers accept `**kwargs`, document which options they use, silently ignore unknown options.
+
+### Files changed
+
+- `src/umwelt/compilers/protocol.py` — update protocol signature and docstring
+- Minimal caller updates to pass options through
+
+---
+
+## P3: Altitude Filtering — Core Enforcement
+
+### Problem
+
+Altitude is declared on compilers but never used for filtering. A property meant for the conversational layer could silently end up as a no-op in an OS compiler config with no feedback to the author.
+
+### Design
+
+#### Altitude on PropertySchema
+
+```python
+@dataclass(frozen=True)
+class PropertySchema:
+    # ... existing fields ...
+    altitude: Altitude | None = None
+```
+
+When a property is registered with an altitude, it participates in enforcement.
+
+#### Altitude ordering
+
+```
+os < language < semantic < conversational
+```
+
+A compiler at `language` altitude receives OS and language properties. A compiler at `conversational` receives everything. Lower altitudes are always realizable at higher ones.
+
+#### Pre-filtering in compilation pipeline
+
+Before calling `compile()`, the pipeline filters the `ResolvedView`:
+
+```python
+def _filter_by_altitude(view: ResolvedView, max_altitude: Altitude) -> ResolvedView:
+    """Return a ResolvedView containing only properties at or below max_altitude."""
+    filtered = ResolvedView()
+    rank = _ALTITUDE_RANK[max_altitude]
+    for taxon in view.taxa():
+        for entity, props in view.entries(taxon):
+            kept = {k: v for k, v in props.items() 
+                    if _property_altitude_rank(taxon, entity, k) <= rank}
+            if kept:
+                filtered.add(taxon, entity, kept)
+    return filtered
+```
+
+Compilers receive pre-filtered views. No more self-filtering contract.
+
+#### Unrealizable rule warnings
+
+The linter warns when a rule sets a property at an altitude no registered compiler can handle:
+
+> "Rule sets `coaching-message` (conversational) but no conversational compiler is registered."
+
+#### Default altitude
+
+Properties registered without an explicit altitude default to the lowest altitude of their taxon. For the sandbox vocabulary: world-taxon properties default to `os`, capability-taxon properties default to `semantic`, state-taxon properties default to `semantic`, audit-taxon properties default to `conversational`.
+
+### Files changed
+
+- `src/umwelt/registry/properties.py` — add altitude to PropertySchema
+- `src/umwelt/compilers/protocol.py` — add _filter_by_altitude, altitude ranking
+- `src/umwelt/sandbox/vocabulary.py` — declare altitude on property registrations
+- `src/umwelt/policy/lint.py` — unrealizable rule warning
+- Tests for altitude filtering, ordering, default inference, linter warning
+
+---
+
+## Implementation Roadmap
+
+| Priority | Gap | Estimated effort | Key risk |
+|----------|-----|-----------------|----------|
+| P0 | CompositeMatcher | ~80 lines | Delegation semantics for get_id/get_attribute need care |
+| P0 | Fixed constraints | ~200 lines | Selector-to-SQL reuse may need refactoring |
+| P1 | Plugin autodiscovery | ~60 lines | Idempotent registration edge cases |
+| P1 | Cross-taxon validators | ~50 lines | Low risk — purely additive |
+| P1 | World composition | ~400 lines | Collection registry + include recursion + merge logic |
+| P2 | Shared event schema | ~80 lines (umwelt side) | Substrate is separate package |
+| P3 | Compiler options | ~20 lines | Backward-compatible by construction |
+| P3 | Altitude filtering | ~150 lines | Default altitude inference, taxon-level defaults |
+
+Total: ~1,040 lines of new code across 7 features.

--- a/docs/vision/entity-model.md
+++ b/docs/vision/entity-model.md
@@ -60,7 +60,7 @@ The W-axis entities. Files, directories, code nodes, mounts, env vars, network e
 | `mount` | — | `src`, `dst`, `type`, `writable` | A bind mount in the workspace. |
 | `env` | — | `name`, `value` (write-only — reading value from a view is disallowed for safety) | An environment variable. |
 | `network` | — | `host`, `port`, `protocol` | A network endpoint. v1 supports `*` wildcard only; explicit hosts are v1.1+. |
-| `resource` | — | `kind`, `unit`, `limit` | A runtime resource: memory, cpu, wall-time, cpu-time, tmpfs, max-fds. |
+| `resource` | — | `memory`, `cpu-time`, `wall-time`, `tmpfs`, `max-fds` | A runtime resource. Each limit dimension is a property on the entity: `memory`, `cpu-time`, `wall-time`, `tmpfs`, `max-fds`. |
 
 #### Structural relationships
 
@@ -75,8 +75,7 @@ dir[name="src"] dir[name="test"] file      { editable: false; }
 file:glob("src/**/*.py")                    { editable: true; }
 file[path^="src/auth/"] node[kind="function"][name="authenticate"] { show: body; }
 
-resource[kind="memory"]                    { limit: 512MB; }
-resource[kind="wall-time"]                 { limit: 60s; }
+resource                                   { memory: 512MB; wall-time: 60s; }
 network                                    { deny: "*"; }
 env[name="CI"]                             { allow: true; }
 env[name="PYTHONPATH"]                     { allow: true; }
@@ -273,7 +272,7 @@ tool[name="Bash"] file[path^="src/auth/"] node[kind="function"][name="protected"
 actor#delegate file[path^="secrets/"] { visible: false; }
           /* delegate actors cannot see files in secrets/ */
 
-job[delegate="true"] resource[kind="memory"] { max-limit: 256MB; }
+job[delegate="true"] resource { max-memory: 256MB; }
           /* sub-delegate jobs have a tighter memory cap than the parent */
 
 hook[event="before-call"] tool[name="Bash"] { allow-pattern: "git *", "pytest *"; }
@@ -410,7 +409,7 @@ Both selectors have `file` as the entity type, but they resolve to different tax
 @world {
   file[path^="src/"]       { editable: true; }
   file[path$=".md"]        { editable: false; }
-  resource[kind="memory"]  { limit: 512MB; }
+  resource                 { memory: 512MB; }
   network                  { deny: "*"; }
 }
 
@@ -619,7 +618,7 @@ The existing v1 sandbox at-rules (`@source`, `@tools`, `@after-change`, `@networ
 | `@source("src/auth") { .fn#authenticate { show: body; editable: true; } }` | `file[path^="src/auth/"] node[kind="function"][name="authenticate"] { show: body; editable: true; }` |
 | `@tools { allow: Read, Edit; deny: Bash; kit: python-dev; }` | `tool[name="Read"] { allow: true; } tool[name="Edit"] { allow: true; } tool[name="Bash"] { allow: false; } kit[name="python-dev"] { allow: true; }` |
 | `@network { deny: *; }` | `network { deny: "*"; }` |
-| `@budget { memory: 512MB; wall-time: 60s; }` | `resource[kind="memory"] { limit: 512MB; } resource[kind="wall-time"] { limit: 60s; }` |
+| `@budget { memory: 512MB; wall-time: 60s; }` | `resource { memory: 512MB; wall-time: 60s; }` |
 | `@env { allow: CI, PYTHONPATH; deny: *; }` | `env[name="CI"] { allow: true; } env[name="PYTHONPATH"] { allow: true; } env { allow: false; }` (with cascade: specific wins over `*`) |
 | `@after-change { test: pytest tests/; lint: ruff check src/; }` | `hook[event="after-change"] { run: "pytest tests/"; run: "ruff check src/"; }` |
 
@@ -647,10 +646,10 @@ blq's `SandboxSpec` has eight dimensions. Here's how each one maps to the entity
 |---|---|---|
 | `network` | `none`, `localhost`, `allowed_hosts`, `unrestricted` | `network { deny: "*" }` / `network[host="localhost"] { allow: true }` / etc. |
 | `filesystem` | `readonly`, `workspace_only`, `scoped_write`, `unrestricted` | `file { editable: false }` (readonly) / `file:glob("workspace/**") { editable: true }` (workspace_only) / (unrestricted = omit) |
-| `timeout` | duration | `resource[kind="wall-time"] { limit: <duration>; }` |
-| `memory` | size | `resource[kind="memory"] { limit: <size>; }` |
-| `cpu` | duration | `resource[kind="cpu-time"] { limit: <duration>; }` |
-| `processes` | `isolated`, `visible` | `resource[kind="pids"] { isolation: <mode>; }` (or cleaner: `tool { max-level: 4; }` to block level 7 subprocess spawn) |
+| `timeout` | duration | `resource { wall-time: <duration>; }` |
+| `memory` | size | `resource { memory: <size>; }` |
+| `cpu` | duration | `resource { cpu-time: <duration>; }` |
+| `processes` | `isolated`, `visible` | `resource { pids: <mode>; }` (or cleaner: `tool { max-level: 4; }` to block level 7 subprocess spawn) |
 | `tmpfs` | size | `mount[dst="/tmp"] { type: "tmpfs"; size: <size>; }` |
 | `paths_hidden` | list | `dir[path="/home"] { visible: false; } dir[path="/var"] { visible: false; } ...` |
 
@@ -716,7 +715,7 @@ The validator receives the parsed rules for its taxon and returns a list of warn
 - Globs are well-formed.
 - Known entity types and property names are used correctly.
 
-Cross-taxon invariants (e.g., "if `tool[name="Bash"] { allow: true }` then `resource[kind="wall-time"]` must set a limit") are not in v1. They would require a whole-view validator that sees multiple taxa at once; deferred.
+Cross-taxon invariants (e.g., "if `tool[name="Bash"] { allow: true }` then `resource` must set a `wall-time` limit") are not in v1. They would require a whole-view validator that sees multiple taxa at once; deferred.
 
 Unknown at-rules, unknown entity types, and unknown declarations are always preserved with warnings, following the forward-compatibility principle from the policy-layer doc. A view can reference taxa that aren't currently registered; the view parses fine, and compilers that understand those taxa produce output for them while compilers that don't silently skip. This is how views written for a future vocabulary degrade on older umwelt installations.
 
@@ -740,7 +739,7 @@ world (4 rules)
   file[path^="src/auth/"]            editable=true
   file                                editable=false
   network                             deny="*"
-  resource[kind="memory"]             limit=512MB
+  resource                            memory=512MB
 
 capability (2 rules)
   tool                                max-level=2

--- a/docs/vision/notes/roadmap-additions.md
+++ b/docs/vision/notes/roadmap-additions.md
@@ -67,7 +67,7 @@ A visual (and textual) browser/editor for umwelt views. DevTools for policy.
         ▸ file[name="oauth.py"]     ← EDITABLE
       ▾ dir[name="common"]
         ▸ file[name="util.py"]      ← read-only
-  ▸ resource[kind="memory"]          512MB
+  ▸ resource                          memory=512MB
   ▸ network                          BLOCKED
   ▸ env[name="CI"]                   allowed
 

--- a/docs/vision/notes/selector-semantics.md
+++ b/docs/vision/notes/selector-semantics.md
@@ -17,7 +17,7 @@ file[path^="src/auth/"]     { editable: true; }
 tool[name="Bash"]            { allow: false; }
 hook[event="after-change"]   { run: "pytest"; }
 network                      { deny: "*"; }
-resource[kind="memory"]      { limit: 512MB; }
+resource                     { memory: 512MB; }
 ```
 
 **Rationale**:

--- a/docs/vision/package-design.md
+++ b/docs/vision/package-design.md
@@ -20,7 +20,7 @@
 - **Enforcement itself.** umwelt emits configs; it does not run delegates or gate tool calls. Runners are a thin convenience layer over subprocess invocation, not a core feature.
 - **Authoring tools.** v1 is read-only for the format. Programmatic view construction (AST → text) comes in v1.1 alongside the ratchet utility and view bank.
 - **Full `actor` and `policy` taxa.** v1 ships minimal `actor` entities (just `inferencer` and `executor`) and an empty `policy` taxon slot; full treatment is v1.1+.
-- **Cross-taxon validation invariants.** v1 validators run per-taxon. Rules like "if `tool[name='Bash']` is allowed then `resource[kind='wall-time']` must set a limit" are v1.1+.
+- **Cross-taxon validation invariants.** v1 validators run per-taxon. Rules like "if `tool[name='Bash']` is allowed then `resource` must declare a `wall-time` limit" are v1.1+.
 - **LLM-based anything.** No trained judgment anywhere in the package. The ratchet is specified end-to-end.
 
 ## The core / sandbox split

--- a/docs/vision/view-format.md
+++ b/docs/vision/view-format.md
@@ -27,8 +27,7 @@ tool[name="Bash"]  { allow: false; }
 
 network { deny: "*"; }
 
-resource[kind="memory"]   { limit: 512MB; }
-resource[kind="wall-time"]{ limit: 60s; }
+resource { memory: 512MB; wall-time: 60s; }
 
 hook[event="after-change"] {
   run: "pytest tests/test_auth.py";
@@ -226,7 +225,7 @@ tool[name="Bash"] file[path^="src/auth/"] { editable: false; }
 actor#delegate file[path^="secrets/"] { visible: false; }
           /* sub-delegate actors cannot see secrets */
 
-job[delegate="true"] resource[kind="memory"] { max-limit: 256MB; }
+job[delegate="true"] resource { max-memory: 256MB; }
           /* delegated jobs have a tighter memory cap than their parent */
 ```
 
@@ -274,7 +273,7 @@ Examples:
 
 ```
 tool          { max-level: 2; }             /* tools capped at computation level ≤ 2 */
-resource[kind="memory"] { max-limit: 512MB; }    /* memory cap at most 512MB */
+resource { max-memory: 512MB; }                  /* memory cap at most 512MB */
 tool          { only-kits: python-dev, rust-dev; }   /* only these kits allowed */
 ```
 
@@ -436,7 +435,7 @@ network                              { deny: "*"; }
 
 ### `@budget { ... }`
 
-Desugars to one `resource[kind=...] { limit: N }` rule per dimension.
+Desugars to a single `resource { ... }` rule with each dimension as a property.
 
 ```
 @budget {
@@ -451,11 +450,13 @@ Desugars to one `resource[kind=...] { limit: N }` rule per dimension.
 equivalent to:
 
 ```
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 60s;   }
-resource[kind="cpu-time"]  { limit: 30s;   }
-resource[kind="max-fds"]   { limit: 128;   }
-resource[kind="tmpfs"]     { limit: 64MB;  }
+resource {
+  memory:    512MB;
+  wall-time: 60s;
+  cpu-time:  30s;
+  max-fds:   128;
+  tmpfs:     64MB;
+}
 ```
 
 ### `@env { ... }`
@@ -499,7 +500,7 @@ tool[name="Grep"]   { allow: true; }
 tool[name="Glob"]   { allow: true; }
 
 network                  { deny: "*"; }
-resource[kind="wall-time"] { limit: 60s; }
+resource                 { wall-time: 60s; }
 ```
 
 Use case: "look at the codebase and tell me where the auth logic lives." The delegate can't change anything, can't run commands, can't reach the network. It has 60 seconds.
@@ -521,8 +522,7 @@ tool[name="Bash"] { allow: false; }
 tool[name="Write"]{ allow: false; }
 
 network                    { deny: "*"; }
-resource[kind="memory"]    { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
+resource                   { memory: 512MB; wall-time: 5m; }
 
 hook[event="after-change"] {
   run: "pytest tests/auth/ -x";
@@ -566,9 +566,7 @@ tool[name="Read"]     { allow: true; }
 tool[name="Bash"]     { allow: true; max-level: 2; }
 
 network                    { deny: "*"; }
-resource[kind="memory"]    { limit: 1GB; }
-resource[kind="wall-time"] { limit: 10m; }
-resource[kind="tmpfs"]     { limit: 128MB; }
+resource                   { memory: 1GB; wall-time: 10m; tmpfs: 128MB; }
 
 env[name="PYTHONPATH"]     { allow: true; }
 env[name="PYTEST_ADDOPTS"] { allow: true; }
@@ -594,8 +592,7 @@ tool[name="Bash"] {
   deny-pattern:  "rm -rf *", "curl *", "ssh *", "sudo *";
 }
 
-resource[kind="memory"]     { limit: 512MB; }
-resource[kind="wall-time"]  { limit: 5m; }
+resource { memory: 512MB; wall-time: 5m; }
 network { deny: "*"; }
 
 hook[event="after-change"] {
@@ -631,11 +628,13 @@ tool[name="Bash"]       { allow: false; }
 tool[altitude="os"]     { max-level: 4; }
 
 /* Runtime budget */
-resource[kind="memory"]     { limit: 512MB; }
-resource[kind="wall-time"]  { limit: 5m; }
-resource[kind="cpu-time"]   { limit: 3m; }
-resource[kind="max-fds"]    { limit: 128; }
-resource[kind="tmpfs"]      { limit: 64MB; }
+resource {
+  memory:    512MB;
+  wall-time: 5m;
+  cpu-time:  3m;
+  max-fds:   128;
+  tmpfs:     64MB;
+}
 
 /* Network and env */
 network { deny: "*"; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,9 @@ nav:
   - Home: index.md
   - Guide:
     - Writing Views: guide/writing-views.md
+    - World Files: guide/world-files.md
+    - PolicyEngine: guide/policy-engine.md
+    - Plugins: guide/plugins.md
     - Entity Reference: guide/entity-reference.md
     - How It Works: guide/how-it-works.md
     - SQL Compiler:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ Homepage = "https://github.com/teaguesterling/umwelt"
 Source = "https://github.com/teaguesterling/umwelt"
 Issues = "https://github.com/teaguesterling/umwelt/issues"
 
+[project.entry-points."umwelt.plugins"]
+sandbox = "umwelt.sandbox.vocabulary:register_sandbox_vocabulary"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/umwelt"]
 

--- a/src/umwelt/_fixtures/auth-fix.umw
+++ b/src/umwelt/_fixtures/auth-fix.umw
@@ -10,8 +10,7 @@ tool[name="Edit"] { allow: true; }
 tool[name="Grep"] { allow: true; }
 tool[name="Glob"] { allow: true; }
 network { deny: "*"; }
-resource[kind="memory"] { limit: 512MB; }
-resource[kind="wall-time"] { limit: 5m; }
+resource { memory: 512MB; wall-time: 5m; }
 hook[event="after-change"] {
   run: "pytest tests/auth/ -x";
   run: "ruff check src/auth/";

--- a/src/umwelt/_fixtures/lackpy-delegate.umw
+++ b/src/umwelt/_fixtures/lackpy-delegate.umw
@@ -3,8 +3,7 @@
 file[path^="src/"] { editable: false; }
 file[path^="tests/"] { editable: false; }
 network { deny: "*"; }
-resource[kind="memory"] { limit: 256MB; }
-resource[kind="wall-time"] { limit: 2m; }
+resource { memory: 256MB; wall-time: 2m; }
 tool[name="Read"] { allow: true; }
 tool[name="Grep"] { allow: true; }
 tool[name="Glob"] { allow: true; }

--- a/src/umwelt/_fixtures/readonly-exploration.umw
+++ b/src/umwelt/_fixtures/readonly-exploration.umw
@@ -5,4 +5,4 @@ tool[name="Read"] { allow: true; }
 tool[name="Grep"] { allow: true; }
 tool[name="Glob"] { allow: true; }
 network { deny: "*"; }
-resource[kind="wall-time"] { limit: 60s; }
+resource { wall-time: 60s; }

--- a/src/umwelt/compilers/sql/compiler.py
+++ b/src/umwelt/compilers/sql/compiler.py
@@ -168,6 +168,7 @@ def compile_view(
             spec = selector.specificity if hasattr(selector, "specificity") else (0,) * 8
             spec_str = dialect.format_specificity(spec)
             src_line = rule.span.line if hasattr(rule, "span") else 0
+            mode_qual = _extract_mode_qualifier(selector)
 
             for decl in rule.declarations:
                 comparison = _infer_comparison(decl.property_name)
@@ -175,14 +176,26 @@ def compile_view(
                 con.execute(
                     "INSERT INTO cascade_candidates "
                     "(entity_id, property_name, property_value, comparison, "
-                    "specificity, rule_index, source_file, source_line) "
-                    f"SELECT e.id, ?, ?, ?, ?, ?, ?, ? "
+                    "specificity, rule_index, source_file, source_line, mode_qualifier) "
+                    f"SELECT e.id, ?, ?, ?, ?, ?, ?, ?, ? "
                     f"FROM entities e WHERE {where_sql}",
                     (decl.property_name, value, comparison,
-                     spec_str, rule_idx, source_file, src_line),
+                     spec_str, rule_idx, source_file, src_line, mode_qual),
                 )
     con.commit()
     create_resolution_views(con, dialect)
+
+
+def _extract_mode_qualifier(selector: ComplexSelector) -> str | None:
+    """Extract the mode id from a cross-axis mode qualifier, if present."""
+    for part in selector.parts:
+        if (
+            part.selector.type_name == "mode"
+            and part.selector.taxon != selector.target_taxon
+            and part.selector.id_value is not None
+        ):
+            return part.selector.id_value
+    return None
 
 
 def _infer_comparison(property_name: str) -> str:

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -151,6 +151,10 @@ def populate_from_world(con: Any, world: Any) -> None:
     for proj in world.projections:
         _upsert_projection(con, proj)
 
+    fixed_raw = getattr(world, "fixed_raw", {})
+    if fixed_raw:
+        _process_fixed_constraints(con, fixed_raw)
+
     con.commit()
     _rebuild_closure(con)
 
@@ -198,6 +202,35 @@ def _upsert_projection(con: Any, proj: Any) -> None:
             "VALUES (?, ?, ?, ?, 0)",
             (taxon, proj.type, proj.id, attrs_json),
         )
+
+
+def _process_fixed_constraints(con, fixed_raw):
+    for selector_str, props in fixed_raw.items():
+        if not isinstance(props, dict):
+            continue
+        matching_ids = _match_fixed_selector(con, selector_str)
+        for entity_pk in matching_ids:
+            for prop_name, prop_value in props.items():
+                con.execute(
+                    "INSERT INTO fixed_constraints (entity_id, property_name, property_value, selector) "
+                    "VALUES (?, ?, ?, ?)",
+                    (entity_pk, prop_name, str(prop_value), selector_str),
+                )
+
+
+def _match_fixed_selector(con, selector_str):
+    if "#" in selector_str:
+        type_name, entity_id = selector_str.split("#", 1)
+        rows = con.execute(
+            "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",
+            (type_name, entity_id),
+        ).fetchall()
+    else:
+        rows = con.execute(
+            "SELECT id FROM entities WHERE type_name = ?",
+            (selector_str,),
+        ).fetchall()
+    return [r[0] for r in rows]
 
 
 def _guess_taxon(type_name: str) -> str:

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -186,7 +186,10 @@ def _upsert_declared_entity(con: Any, entity: Any) -> None:
 
 
 def _upsert_projection(con: Any, proj: Any) -> None:
-    attrs_json = json.dumps(proj.attributes) if proj.attributes else None
+    attrs = dict(proj.attributes) if proj.attributes else {}
+    if "name" not in attrs:
+        attrs["name"] = proj.id
+    attrs_json = json.dumps(attrs)
 
     existing = con.execute(
         "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",

--- a/src/umwelt/compilers/sql/populate.py
+++ b/src/umwelt/compilers/sql/populate.py
@@ -161,7 +161,10 @@ def populate_from_world(con: Any, world: Any) -> None:
 
 def _upsert_declared_entity(con: Any, entity: Any) -> None:
     classes_json = json.dumps(list(entity.classes)) if entity.classes else None
-    attrs_json = json.dumps(entity.attributes) if entity.attributes else None
+    attrs = dict(entity.attributes) if entity.attributes else {}
+    if "name" not in attrs:
+        attrs["name"] = entity.id
+    attrs_json = json.dumps(attrs)
 
     existing = con.execute(
         "SELECT id FROM entities WHERE type_name = ? AND entity_id = ?",

--- a/src/umwelt/compilers/sql/resolution.py
+++ b/src/umwelt/compilers/sql/resolution.py
@@ -114,4 +114,21 @@ SELECT * FROM _resolved_exact
 {union_keyword} SELECT * FROM _resolved_cap
 {union_keyword} SELECT * FROM _resolved_pattern;"""
 
-    return "\n".join([exact_view, cap_view, pattern_view, resolved_view])
+    effective_view_prefix = "CREATE VIEW IF NOT EXISTS" if is_sqlite else "CREATE OR REPLACE VIEW"
+    effective_view = f"""
+{effective_view_prefix} effective_properties AS
+SELECT
+    rp.entity_id,
+    rp.property_name,
+    COALESCE(fc.property_value, rp.property_value) AS effective_value,
+    CASE WHEN fc.id IS NOT NULL THEN 'fixed' ELSE 'cascade' END AS source,
+    rp.specificity,
+    rp.rule_index,
+    rp.source_file,
+    rp.source_line
+FROM resolved_properties rp
+LEFT JOIN fixed_constraints fc
+    ON fc.entity_id = rp.entity_id
+    AND fc.property_name = rp.property_name;"""
+
+    return "\n".join([exact_view, cap_view, pattern_view, resolved_view, effective_view])

--- a/src/umwelt/compilers/sql/schema.py
+++ b/src/umwelt/compilers/sql/schema.py
@@ -104,7 +104,8 @@ CREATE TABLE IF NOT EXISTS cascade_candidates (
     specificity     {text_type} NOT NULL,
     rule_index      {int_type} NOT NULL,
     source_file     {text_type},
-    source_line     {int_type}
+    source_line     {int_type},
+    mode_qualifier  {text_type}
 );
 
 CREATE INDEX IF NOT EXISTS idx_candidates_entity_prop ON cascade_candidates(entity_id, property_name);

--- a/src/umwelt/compilers/sql/schema.py
+++ b/src/umwelt/compilers/sql/schema.py
@@ -18,6 +18,7 @@ EXPECTED_TABLES = [
     "entities",
     "entity_closure",
     "cascade_candidates",
+    "fixed_constraints",
 ]
 
 
@@ -108,5 +109,17 @@ CREATE TABLE IF NOT EXISTS cascade_candidates (
 
 CREATE INDEX IF NOT EXISTS idx_candidates_entity_prop ON cascade_candidates(entity_id, property_name);
 CREATE INDEX IF NOT EXISTS idx_candidates_comparison ON cascade_candidates(comparison);""")
+
+    # -- Fixed constraints (post-cascade overrides)
+    sections.append(f"""
+CREATE TABLE IF NOT EXISTS fixed_constraints (
+    id              {autoincrement},
+    entity_id       {int_type} REFERENCES entities(id),
+    property_name   {text_type} NOT NULL,
+    property_value  {text_type} NOT NULL,
+    selector        {text_type} NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fc_entity_prop ON fixed_constraints(entity_id, property_name);""")
 
     return "\n".join(sections)

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -443,8 +443,12 @@ class PolicyEngine:
 
 
 def _load_default_vocabulary() -> None:
-    try:
-        from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
-        register_sandbox_vocabulary()
-    except ImportError:
-        pass
+    from umwelt.registry.plugins import discover_plugins
+    loaded = discover_plugins()
+    # Fallback: if sandbox wasn't loaded via entry point, import directly.
+    if "sandbox" not in loaded:
+        try:
+            from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+            register_sandbox_vocabulary()
+        except ImportError:
+            pass

--- a/src/umwelt/policy/engine.py
+++ b/src/umwelt/policy/engine.py
@@ -189,25 +189,26 @@ class PolicyEngine:
         type: str,
         id: str,
         property: str | None = None,
+        mode: str | None = None,
     ) -> str | dict[str, str] | None:
         from umwelt.policy.queries import resolve_entity
 
         con = self._ensure_compiled()
-        result = resolve_entity(con, type=type, id=id, property=property)
+        result = resolve_entity(con, type=type, id=id, property=property, mode=mode)
         logger.info(
             "resolve",
-            extra={"entity": f"{type}#{id}", "property": property, "value": result},
+            extra={"entity": f"{type}#{id}", "property": property, "mode": mode, "value": result},
         )
         return result
 
-    def resolve_all(self, *, type: str) -> list[dict]:
+    def resolve_all(self, *, type: str, mode: str | None = None) -> list[dict]:
         from umwelt.policy.queries import resolve_all_entities
 
         con = self._ensure_compiled()
-        results = resolve_all_entities(con, type=type)
+        results = resolve_all_entities(con, type=type, mode=mode)
         logger.info(
             "resolve_all",
-            extra={"type": type, "result_count": len(results)},
+            extra={"type": type, "mode": mode, "result_count": len(results)},
         )
         return results
 
@@ -217,16 +218,18 @@ class PolicyEngine:
         type: str,
         id: str,
         property: str,
+        mode: str | None = None,
     ) -> TraceResult:
         from umwelt.policy.queries import trace_entity
 
         con = self._ensure_compiled()
-        result = trace_entity(con, type=type, id=id, property=property)
+        result = trace_entity(con, type=type, id=id, property=property, mode=mode)
         logger.debug(
             "trace",
             extra={
                 "entity": f"{type}#{id}",
                 "property": property,
+                "mode": mode,
                 "candidates": len(result.candidates),
             },
         )
@@ -238,16 +241,16 @@ class PolicyEngine:
         con = self._ensure_compiled()
         return run_lint(con)
 
-    def check(self, *, type: str, id: str, **expected: str) -> bool:
+    def check(self, *, type: str, id: str, mode: str | None = None, **expected: str) -> bool:
         for prop_name, expected_val in expected.items():
-            actual = self.resolve(type=type, id=id, property=prop_name)
+            actual = self.resolve(type=type, id=id, property=prop_name, mode=mode)
             if actual != expected_val:
                 return False
         return True
 
-    def require(self, *, type: str, id: str, **expected: str) -> None:
+    def require(self, *, type: str, id: str, mode: str | None = None, **expected: str) -> None:
         for prop_name, expected_val in expected.items():
-            actual = self.resolve(type=type, id=id, property=prop_name)
+            actual = self.resolve(type=type, id=id, property=prop_name, mode=mode)
             if actual != expected_val:
                 logger.warning(
                     "require_denied",

--- a/src/umwelt/policy/lint.py
+++ b/src/umwelt/policy/lint.py
@@ -17,6 +17,7 @@ def run_lint(con: sqlite3.Connection) -> list[LintWarning]:
     warnings.extend(_detect_conflicting_intent(con))
     warnings.extend(_detect_uncovered_entity(con))
     warnings.extend(_detect_specificity_escalation(con))
+    warnings.extend(_detect_fixed_override(con))
 
     for w in warnings:
         logger.warning(
@@ -188,6 +189,38 @@ def _detect_specificity_escalation(con: sqlite3.Connection) -> list[LintWarning]
                 entities=(entity_name,),
                 property=prop_name,
             ))
+    return warnings
+
+
+def _detect_fixed_override(con: sqlite3.Connection) -> list[LintWarning]:
+    """Warn when a fixed constraint overrides a cascade-resolved value."""
+    warnings: list[LintWarning] = []
+
+    try:
+        rows = con.execute("""
+            SELECT fc.entity_id, fc.property_name, fc.property_value, fc.selector,
+                   rp.property_value AS cascade_value
+            FROM fixed_constraints fc
+            JOIN resolved_properties rp
+                ON fc.entity_id = rp.entity_id
+                AND fc.property_name = rp.property_name
+            WHERE fc.property_value != rp.property_value
+        """).fetchall()
+    except sqlite3.OperationalError:
+        return warnings
+
+    for entity_id, prop_name, fixed_val, selector, cascade_val in rows:
+        entity_name = _entity_name(con, entity_id)
+        warnings.append(LintWarning(
+            smell="fixed_override",
+            severity="info",
+            description=(
+                f"{entity_name} '{prop_name}': fixed constraint ({selector}) "
+                f"overrides cascade value '{cascade_val}' with '{fixed_val}'"
+            ),
+            entities=(entity_name,),
+            property=prop_name,
+        ))
     return warnings
 
 

--- a/src/umwelt/policy/queries.py
+++ b/src/umwelt/policy/queries.py
@@ -22,14 +22,14 @@ def resolve_entity(
 
     if property is not None:
         row = con.execute(
-            "SELECT property_value FROM resolved_properties "
+            "SELECT effective_value FROM effective_properties "
             "WHERE entity_id = ? AND property_name = ?",
             (entity_pk, property),
         ).fetchone()
         return row[0] if row else None
 
     rows = con.execute(
-        "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+        "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
         (entity_pk,),
     ).fetchall()
     return {name: value for name, value in rows}
@@ -48,7 +48,7 @@ def resolve_all_entities(
     results = []
     for eid, entity_id, classes_json, attrs_json in entities:
         props_rows = con.execute(
-            "SELECT property_name, property_value FROM resolved_properties WHERE entity_id = ?",
+            "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
             (eid,),
         ).fetchall()
         props = {name: value for name, value in props_rows}
@@ -81,8 +81,8 @@ def trace_entity(
     entity_pk = entity_row[0]
 
     winner_row = con.execute(
-        "SELECT property_value, specificity, rule_index "
-        "FROM resolved_properties "
+        "SELECT effective_value, specificity, rule_index "
+        "FROM effective_properties "
         "WHERE entity_id = ? AND property_name = ?",
         (entity_pk, property),
     ).fetchone()

--- a/src/umwelt/policy/queries.py
+++ b/src/umwelt/policy/queries.py
@@ -93,6 +93,18 @@ def _resolve_with_mode(
         for name, value in rows:
             props[name] = value
 
+    # Fixed constraints override cascade results regardless of mode
+    try:
+        fixed_rows = con.execute(
+            "SELECT property_name, property_value FROM fixed_constraints WHERE entity_id = ?",
+            (entity_pk,),
+        ).fetchall()
+        for name, value in fixed_rows:
+            if name in props:
+                props[name] = value
+    except sqlite3.OperationalError:
+        pass
+
     if property is not None:
         return props.get(property)
     return props

--- a/src/umwelt/policy/queries.py
+++ b/src/umwelt/policy/queries.py
@@ -6,6 +6,40 @@ import sqlite3
 
 from umwelt.policy.engine import Candidate, TraceResult
 
+_MODE_FILTER = "AND (mode_qualifier IS NULL OR mode_qualifier = ?)"
+
+_RESOLVE_MODE_EXACT = """
+SELECT property_name, property_value FROM (
+    SELECT property_name, property_value, ROW_NUMBER() OVER (
+        PARTITION BY property_name
+        ORDER BY specificity DESC, rule_index DESC
+    ) AS _rn
+    FROM cascade_candidates
+    WHERE entity_id = ? AND comparison = 'exact'
+    {mode_clause}
+) WHERE _rn = 1
+"""
+
+_RESOLVE_MODE_CAP = """
+SELECT property_name, property_value FROM (
+    SELECT property_name, property_value, ROW_NUMBER() OVER (
+        PARTITION BY property_name
+        ORDER BY CAST(property_value AS INTEGER) ASC, specificity DESC
+    ) AS _rn
+    FROM cascade_candidates
+    WHERE entity_id = ? AND comparison = '<='
+    {mode_clause}
+) WHERE _rn = 1
+"""
+
+_RESOLVE_MODE_PATTERN = """
+SELECT property_name, GROUP_CONCAT(DISTINCT property_value) AS property_value
+FROM cascade_candidates
+WHERE entity_id = ? AND comparison = 'pattern-in'
+{mode_clause}
+GROUP BY property_name
+"""
+
 
 def resolve_entity(
     con: sqlite3.Connection,
@@ -13,6 +47,7 @@ def resolve_entity(
     type: str,
     id: str,
     property: str | None = None,
+    mode: str | None = None,
 ) -> str | dict[str, str] | None:
     entity_row = _find_entity(con, type=type, id=id)
     if entity_row is None:
@@ -20,6 +55,16 @@ def resolve_entity(
 
     entity_pk = entity_row[0]
 
+    if mode is None:
+        return _resolve_from_view(con, entity_pk, property)
+    return _resolve_with_mode(con, entity_pk, property, mode)
+
+
+def _resolve_from_view(
+    con: sqlite3.Connection,
+    entity_pk: int,
+    property: str | None,
+) -> str | dict[str, str] | None:
     if property is not None:
         row = con.execute(
             "SELECT effective_value FROM effective_properties "
@@ -35,10 +80,29 @@ def resolve_entity(
     return {name: value for name, value in rows}
 
 
+def _resolve_with_mode(
+    con: sqlite3.Connection,
+    entity_pk: int,
+    property: str | None,
+    mode: str,
+) -> str | dict[str, str] | None:
+    props: dict[str, str] = {}
+    for sql_template in (_RESOLVE_MODE_EXACT, _RESOLVE_MODE_CAP, _RESOLVE_MODE_PATTERN):
+        sql = sql_template.format(mode_clause=_MODE_FILTER)
+        rows = con.execute(sql, (entity_pk, mode)).fetchall()
+        for name, value in rows:
+            props[name] = value
+
+    if property is not None:
+        return props.get(property)
+    return props
+
+
 def resolve_all_entities(
     con: sqlite3.Connection,
     *,
     type: str,
+    mode: str | None = None,
 ) -> list[dict]:
     entities = con.execute(
         "SELECT id, entity_id, classes, attributes FROM entities WHERE type_name = ?",
@@ -47,11 +111,15 @@ def resolve_all_entities(
 
     results = []
     for eid, entity_id, classes_json, attrs_json in entities:
-        props_rows = con.execute(
-            "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
-            (eid,),
-        ).fetchall()
-        props = {name: value for name, value in props_rows}
+        if mode is None:
+            props_rows = con.execute(
+                "SELECT property_name, effective_value FROM effective_properties WHERE entity_id = ?",
+                (eid,),
+            ).fetchall()
+            props = {name: value for name, value in props_rows}
+        else:
+            props = _resolve_with_mode(con, eid, None, mode) or {}
+
         results.append({
             "entity_id": entity_id,
             "type_name": type,
@@ -68,6 +136,7 @@ def trace_entity(
     type: str,
     id: str,
     property: str,
+    mode: str | None = None,
 ) -> TraceResult:
     entity_row = _find_entity(con, type=type, id=id)
     if entity_row is None:
@@ -80,33 +149,36 @@ def trace_entity(
 
     entity_pk = entity_row[0]
 
-    winner_row = con.execute(
-        "SELECT effective_value, specificity, rule_index "
-        "FROM effective_properties "
-        "WHERE entity_id = ? AND property_name = ?",
-        (entity_pk, property),
-    ).fetchone()
-    winning_value = winner_row[0] if winner_row else None
-    winning_spec = winner_row[1] if winner_row else None
-    winning_rule_idx = winner_row[2] if winner_row else None
+    if mode is not None:
+        result = _resolve_with_mode(con, entity_pk, property, mode)
+        winning_value = result if isinstance(result, str) else None
+    else:
+        winner_row = con.execute(
+            "SELECT effective_value FROM effective_properties "
+            "WHERE entity_id = ? AND property_name = ?",
+            (entity_pk, property),
+        ).fetchone()
+        winning_value = winner_row[0] if winner_row else None
+
+    mode_clause = ""
+    params: list = [entity_pk, property]
+    if mode is not None:
+        mode_clause = _MODE_FILTER
+        params.append(mode)
 
     rows = con.execute(
         "SELECT property_value, specificity, rule_index, "
         "source_file, source_line "
         "FROM cascade_candidates "
-        "WHERE entity_id = ? AND property_name = ? "
+        f"WHERE entity_id = ? AND property_name = ? {mode_clause} "
         "ORDER BY specificity DESC, rule_index DESC",
-        (entity_pk, property),
+        params,
     ).fetchall()
 
     candidates = []
     winner_marked = False
     for value, spec, rule_idx, src_file, src_line in rows:
-        is_winner = (
-            not winner_marked
-            and spec == winning_spec
-            and rule_idx == winning_rule_idx
-        )
+        is_winner = not winner_marked and value == winning_value
         if is_winner:
             winner_marked = True
         candidates.append(Candidate(

--- a/src/umwelt/registry/__init__.py
+++ b/src/umwelt/registry/__init__.py
@@ -36,6 +36,7 @@ from umwelt.registry.taxa import (
     registry_scope,
     resolve_taxon,
 )
+from umwelt.registry.plugins import discover_plugins
 from umwelt.registry.validators import (
     ValidatorProtocol,
     get_validators,
@@ -45,6 +46,7 @@ from umwelt.registry.validators import (
 __all__ = [
     "AttrSchema",
     "CompositeMatcher",
+    "discover_plugins",
     "EntitySchema",
     "MatcherProtocol",
     "PropertySchema",

--- a/src/umwelt/registry/__init__.py
+++ b/src/umwelt/registry/__init__.py
@@ -14,6 +14,7 @@ from umwelt.registry.entities import (
     resolve_entity_type,
 )
 from umwelt.registry.matchers import (
+    CompositeMatcher,
     MatcherProtocol,
     get_matcher,
     register_matcher,
@@ -43,6 +44,7 @@ from umwelt.registry.validators import (
 
 __all__ = [
     "AttrSchema",
+    "CompositeMatcher",
     "EntitySchema",
     "MatcherProtocol",
     "PropertySchema",

--- a/src/umwelt/registry/matchers.py
+++ b/src/umwelt/registry/matchers.py
@@ -67,14 +67,63 @@ class MatcherProtocol(Protocol):
         ...
 
 
+class CompositeMatcher:
+    """Delegates to multiple matchers for the same taxon.
+
+    Auto-created when register_matcher() is called twice for the same taxon.
+    Union semantics for match_type/children, OR for condition_met,
+    first-non-None for get_id/get_attribute.
+    """
+
+    def __init__(self, *delegates: MatcherProtocol):
+        self._delegates: list[MatcherProtocol] = list(delegates)
+
+    def add(self, matcher: MatcherProtocol) -> None:
+        self._delegates.append(matcher)
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        results: list[Any] = []
+        for d in self._delegates:
+            results.extend(d.match_type(type_name, context))
+        return results
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        results: list[Any] = []
+        for d in self._delegates:
+            results.extend(d.children(parent, child_type))
+        return results
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        return any(d.condition_met(selector, context) for d in self._delegates)
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        for d in self._delegates:
+            val = d.get_attribute(entity, name)
+            if val is not None:
+                return val
+        return None
+
+    def get_id(self, entity: Any) -> str | None:
+        for d in self._delegates:
+            val = d.get_id(entity)
+            if val is not None:
+                return val
+        return None
+
+
 def register_matcher(*, taxon: str, matcher: MatcherProtocol) -> None:
-    """Register a matcher for a taxon. Resolves taxon aliases."""
+    """Register a matcher for a taxon. Auto-composes on collision."""
     get_taxon(taxon)  # raises if unknown
     canonical = resolve_taxon(taxon)
     state = _current_state()
     if canonical in state.matchers:
-        raise RegistryError(f"matcher for taxon {taxon!r} already registered")
-    state.matchers[canonical] = matcher
+        existing = state.matchers[canonical]
+        if isinstance(existing, CompositeMatcher):
+            existing.add(matcher)
+        else:
+            state.matchers[canonical] = CompositeMatcher(existing, matcher)
+    else:
+        state.matchers[canonical] = matcher
 
 
 def get_matcher(taxon: str) -> MatcherProtocol:

--- a/src/umwelt/registry/plugins.py
+++ b/src/umwelt/registry/plugins.py
@@ -1,0 +1,22 @@
+"""Plugin autodiscovery via entry points."""
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+
+logger = logging.getLogger("umwelt.registry")
+
+ENTRY_POINT_GROUP = "umwelt.plugins"
+
+
+def discover_plugins() -> list[str]:
+    """Load all registered umwelt plugins. Returns names of loaded plugins."""
+    loaded: list[str] = []
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        try:
+            register_fn = ep.load()
+            register_fn()
+            loaded.append(ep.name)
+        except Exception:
+            logger.debug("plugin %s failed to load", ep.name, exc_info=True)
+    return loaded

--- a/src/umwelt/registry/taxa.py
+++ b/src/umwelt/registry/taxa.py
@@ -66,7 +66,12 @@ def register_taxon(
     """Register a taxon with the active registry scope."""
     state = _current_state()
     if name in state.taxa:
-        raise RegistryError(f"taxon {name!r} already registered")
+        existing = state.taxa[name]
+        if existing.description == description:
+            return  # idempotent
+        raise RegistryError(
+            f"taxon {name!r} already registered with conflicting description"
+        )
     state.taxa[name] = TaxonSchema(
         name=name,
         description=description,

--- a/src/umwelt/sandbox/compilers/bwrap.py
+++ b/src/umwelt/sandbox/compilers/bwrap.py
@@ -2,7 +2,7 @@
 
 The compiler reads OS-altitude constructs from the resolved view and emits
 a flat list of bwrap command-line flags. Budget enforcement that bwrap
-can't express natively (memory, cpu-time, max-fds) goes into a separate
+can't express natively (memory, cpu, max-fds) goes into a separate
 wrapper command list (prlimit/timeout).
 
 Ordering per bwrap spec:

--- a/src/umwelt/sandbox/compilers/bwrap.py
+++ b/src/umwelt/sandbox/compilers/bwrap.py
@@ -2,7 +2,7 @@
 
 The compiler reads OS-altitude constructs from the resolved view and emits
 a flat list of bwrap command-line flags. Budget enforcement that bwrap
-can't express natively (memory, cpu, max-fds) goes into a separate
+can't express natively (memory, cpu-time, max-fds) goes into a separate
 wrapper command list (prlimit/timeout).
 
 Ordering per bwrap spec:
@@ -152,8 +152,8 @@ class BwrapCompiler:
         if props.get("wall-time"):
             secs = parse_time_seconds(props["wall-time"])
             result.wrapper.extend(["timeout", str(secs)])
-        if props.get("cpu"):
-            secs = parse_time_seconds(props["cpu"])
+        if props.get("cpu-time"):
+            secs = parse_time_seconds(props["cpu-time"])
             result.wrapper.extend(["prlimit", f"--cpu={secs}"])
         if props.get("max-fds"):
             result.wrapper.extend(["prlimit", f"--nofile={int(props['max-fds'])}"])

--- a/src/umwelt/sandbox/compilers/bwrap.py
+++ b/src/umwelt/sandbox/compilers/bwrap.py
@@ -146,23 +146,19 @@ class BwrapCompiler:
         entity: Any,
         props: dict[str, str],
     ) -> None:
-        kind = getattr(entity, "kind", "")
-        limit = props.get("limit", "")
-        if not limit:
-            return
-        if kind == "memory":
-            bytes_val = parse_memory_mb(limit) * 1024 * 1024
+        if props.get("memory"):
+            bytes_val = parse_memory_mb(props["memory"]) * 1024 * 1024
             result.wrapper.extend(["prlimit", f"--as={bytes_val}"])
-        elif kind == "wall-time":
-            secs = parse_time_seconds(limit)
+        if props.get("wall-time"):
+            secs = parse_time_seconds(props["wall-time"])
             result.wrapper.extend(["timeout", str(secs)])
-        elif kind == "cpu-time":
-            secs = parse_time_seconds(limit)
+        if props.get("cpu"):
+            secs = parse_time_seconds(props["cpu"])
             result.wrapper.extend(["prlimit", f"--cpu={secs}"])
-        elif kind == "max-fds":
-            result.wrapper.extend(["prlimit", f"--nofile={int(limit)}"])
-        elif kind == "tmpfs":
-            tmpfs_flags.append(("--tmpfs", "/tmp", f"--size={parse_size_for_tmpfs(limit)}"))
+        if props.get("max-fds"):
+            result.wrapper.extend(["prlimit", f"--nofile={int(props['max-fds'])}"])
+        if props.get("tmpfs"):
+            tmpfs_flags.append(("--tmpfs", "/tmp", f"--size={parse_size_for_tmpfs(props['tmpfs'])}"))
 
     def _collect_network(
         self,

--- a/src/umwelt/sandbox/compilers/nsjail.py
+++ b/src/umwelt/sandbox/compilers/nsjail.py
@@ -133,8 +133,8 @@ class NsjailCompiler:
             cfg.rlimit_as = parse_memory_mb(props["memory"])
         if props.get("wall-time"):
             cfg.time_limit = parse_time_seconds(props["wall-time"])
-        if props.get("cpu"):
-            cfg.rlimit_cpu = parse_time_seconds(props["cpu"])
+        if props.get("cpu-time"):
+            cfg.rlimit_cpu = parse_time_seconds(props["cpu-time"])
         if props.get("max-fds"):
             cfg.rlimit_nofile = int(props["max-fds"])
         if props.get("tmpfs"):

--- a/src/umwelt/sandbox/compilers/nsjail.py
+++ b/src/umwelt/sandbox/compilers/nsjail.py
@@ -129,24 +129,20 @@ class NsjailCompiler:
         entity: Any,
         props: dict[str, str],
     ) -> None:
-        kind = getattr(entity, "kind", "")
-        limit = props.get("limit", "")
-        if not limit:
-            return
-        if kind == "memory":
-            cfg.rlimit_as = parse_memory_mb(limit)
-        elif kind == "wall-time":
-            cfg.time_limit = parse_time_seconds(limit)
-        elif kind == "cpu-time":
-            cfg.rlimit_cpu = parse_time_seconds(limit)
-        elif kind == "max-fds":
-            cfg.rlimit_nofile = int(limit)
-        elif kind == "tmpfs":
+        if props.get("memory"):
+            cfg.rlimit_as = parse_memory_mb(props["memory"])
+        if props.get("wall-time"):
+            cfg.time_limit = parse_time_seconds(props["wall-time"])
+        if props.get("cpu"):
+            cfg.rlimit_cpu = parse_time_seconds(props["cpu"])
+        if props.get("max-fds"):
+            cfg.rlimit_nofile = int(props["max-fds"])
+        if props.get("tmpfs"):
             cfg.mounts.append({
                 "dst": "/tmp",
                 "fstype": "tmpfs",
                 "is_bind": False,
-                "options": f"size={parse_size_for_tmpfs(limit)}",
+                "options": f"size={parse_size_for_tmpfs(props['tmpfs'])}",
             })
 
     def _compile_network(

--- a/src/umwelt/sandbox/desugar.py
+++ b/src/umwelt/sandbox/desugar.py
@@ -270,8 +270,7 @@ def _desugar_network(
 
 # ---------------------------------------------------------------------------
 # @budget { memory: 512MB; wall-time: 60s; }
-# → resource[kind="memory"] { limit: 512MB; }
-# → resource[kind="wall-time"] { limit: 60s; }
+# → resource { memory: 512MB; wall-time: 60s; }
 # ---------------------------------------------------------------------------
 
 def _desugar_budget(
@@ -286,27 +285,28 @@ def _desugar_budget(
     decl_nodes = tinycss2.parse_declaration_list(
         content, skip_comments=True, skip_whitespace=True
     )
-    rules: list[RuleBlock] = []
+    decls: list[Declaration] = []
     for d in decl_nodes:
         if getattr(d, "type", None) != "declaration":
             continue
-        kind = str(getattr(d, "lower_name", None) or getattr(d, "name", ""))
+        prop_name = str(getattr(d, "lower_name", None) or getattr(d, "name", ""))
         raw_val = tinycss2.serialize(list(getattr(d, "value", []) or [])).strip()
-
-        sel_text = f'resource[kind="{kind}"]'
-        selectors = _parse_sel(sel_text, source_path)
-        decl = Declaration(
-            property_name="limit",
+        decls.append(Declaration(
+            property_name=prop_name,
             values=(raw_val,),
             span=_span(d),
-        )
-        rules.append(RuleBlock(
-            selectors=selectors,
-            declarations=(decl,),
-            nested_blocks=(),
-            span=_span(d),
         ))
-    return rules
+
+    if not decls:
+        return []
+
+    selectors = _parse_sel("resource", source_path)
+    return [RuleBlock(
+        selectors=selectors,
+        declarations=tuple(decls),
+        nested_blocks=(),
+        span=_span(node),
+    )]
 
 
 # ---------------------------------------------------------------------------

--- a/src/umwelt/sandbox/entities.py
+++ b/src/umwelt/sandbox/entities.py
@@ -32,9 +32,7 @@ class DirEntity:
 
 @dataclass(frozen=True)
 class ResourceEntity:
-    """A runtime resource (memory, cpu-time, wall-time, etc.)."""
-
-    kind: str
+    """A resource block declaring runtime limits (memory, wall-time, cpu, etc.)."""
 
 
 @dataclass(frozen=True)

--- a/src/umwelt/sandbox/state_matcher.py
+++ b/src/umwelt/sandbox/state_matcher.py
@@ -50,14 +50,21 @@ class StateMatcher:
         return []
 
     def condition_met(self, selector: Any, context: Any = None) -> bool:
-        """Mode selectors are always active in v0.5; other state entities don't qualify.
+        """Check whether a mode qualifier is active.
 
-        v0.5: mode is a compositional class label. Cross-axis rules gated on
-        mode fire unconditionally at view-resolve time. Runtime class filtering
-        (only fire if the current mode matches) is a v0.6 concern coordinated
-        with kibitzer's ChangeToolMode.
+        When context contains {"active_mode": "<id>"}, only mode selectors
+        whose id matches (or bare mode selectors with no id) pass. Without
+        active_mode, all mode selectors pass unconditionally (v0.5 compat).
+        Non-mode state selectors never qualify.
         """
-        return getattr(selector, "type_name", None) == "mode"
+        if getattr(selector, "type_name", None) != "mode":
+            return False
+        if not isinstance(context, dict) or "active_mode" not in context:
+            return True
+        selector_id = getattr(selector, "id_value", None)
+        if selector_id is None:
+            return True
+        return selector_id == context["active_mode"]
 
     def get_attribute(self, entity: Any, name: str) -> Any:
         return getattr(entity, name, None)

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -262,7 +262,7 @@ def _register_world() -> None:
     register_property(taxon="world", entity="dir", name="visible", value_type=bool, restrictive_direction="false", description="Whether the actor can see this dir.")
     register_property(taxon="world", entity="resource", name="memory", value_type=str, restrictive_direction="min", description="Memory limit with unit (e.g. 512MB, 1GB).")
     register_property(taxon="world", entity="resource", name="wall-time", value_type=str, restrictive_direction="min", description="Wall-clock time limit (e.g. 10m, 1h).")
-    register_property(taxon="world", entity="resource", name="cpu", value_type=str, restrictive_direction="min", description="CPU core limit (e.g. 2, 0.5).")
+    register_property(taxon="world", entity="resource", name="cpu-time", value_type=str, restrictive_direction="min", description="CPU time limit (e.g. 30s, 5m).")
     register_property(taxon="world", entity="resource", name="max-fds", value_type=int, restrictive_direction="min", description="Maximum open file descriptors.")
     register_property(taxon="world", entity="resource", name="tmpfs", value_type=str, restrictive_direction="min", description="Tmpfs size for /tmp (e.g. 64MB).")
     register_property(taxon="world", entity="network", name="deny", value_type=str, restrictive_direction="superset", description="Deny pattern ('*' for all).")

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -264,6 +264,7 @@ def _register_world() -> None:
     register_property(taxon="world", entity="resource", name="wall-time", value_type=str, restrictive_direction="min", description="Wall-clock time limit (e.g. 10m, 1h).")
     register_property(taxon="world", entity="resource", name="cpu", value_type=str, restrictive_direction="min", description="CPU core limit (e.g. 2, 0.5).")
     register_property(taxon="world", entity="resource", name="max-fds", value_type=int, restrictive_direction="min", description="Maximum open file descriptors.")
+    register_property(taxon="world", entity="resource", name="tmpfs", value_type=str, restrictive_direction="min", description="Tmpfs size for /tmp (e.g. 64MB).")
     register_property(taxon="world", entity="network", name="deny", value_type=str, restrictive_direction="superset", description="Deny pattern ('*' for all).")
     register_property(taxon="world", entity="network", name="allow", value_type=bool, restrictive_direction="false", description="Whether this endpoint is allowed.")
     register_property(taxon="world", entity="env", name="allow", value_type=bool, restrictive_direction="false", description="Whether this env var is passed through.")

--- a/src/umwelt/sandbox/vocabulary.py
+++ b/src/umwelt/sandbox/vocabulary.py
@@ -214,9 +214,9 @@ def _register_world() -> None:
         taxon="world",
         name="resource",
         attributes={
-            "kind": AttrSchema(type=str, required=True, description="Resource kind: memory, cpu-time, wall-time, max-fds, tmpfs"),
+            "name": AttrSchema(type=str, description="Resource block name"),
         },
-        description="A runtime resource with a limit.",
+        description="A resource block declaring runtime limits (memory, wall-time, cpu, etc.).",
         category="budget",
     )
 
@@ -260,7 +260,10 @@ def _register_world() -> None:
     register_property(taxon="world", entity="file", name="show", value_type=str, description="What to show: body, outline, signature.")
     register_property(taxon="world", entity="dir", name="editable", value_type=bool, restrictive_direction="false", description="Whether the actor may modify files in this dir.")
     register_property(taxon="world", entity="dir", name="visible", value_type=bool, restrictive_direction="false", description="Whether the actor can see this dir.")
-    register_property(taxon="world", entity="resource", name="limit", value_type=str, restrictive_direction="min", description="Resource limit value with unit (e.g. 512MB, 60s).")
+    register_property(taxon="world", entity="resource", name="memory", value_type=str, restrictive_direction="min", description="Memory limit with unit (e.g. 512MB, 1GB).")
+    register_property(taxon="world", entity="resource", name="wall-time", value_type=str, restrictive_direction="min", description="Wall-clock time limit (e.g. 10m, 1h).")
+    register_property(taxon="world", entity="resource", name="cpu", value_type=str, restrictive_direction="min", description="CPU core limit (e.g. 2, 0.5).")
+    register_property(taxon="world", entity="resource", name="max-fds", value_type=int, restrictive_direction="min", description="Maximum open file descriptors.")
     register_property(taxon="world", entity="network", name="deny", value_type=str, restrictive_direction="superset", description="Deny pattern ('*' for all).")
     register_property(taxon="world", entity="network", name="allow", value_type=bool, restrictive_direction="false", description="Whether this endpoint is allowed.")
     register_property(taxon="world", entity="env", name="allow", value_type=bool, restrictive_direction="false", description="Whether this env var is passed through.")
@@ -312,6 +315,8 @@ def _register_capability() -> None:
             "kit": AttrSchema(type=str, description="Kit this tool belongs to"),
             "altitude": AttrSchema(type=str, description="Enforcement altitude: os, language, semantic, conversational"),
             "level": AttrSchema(type=int, description="Computation level 0-8"),
+            "param-count": AttrSchema(type=int, description="Number of parameters (MCP-projected)"),
+            "output-type": AttrSchema(type=str, description="Output format: structured, text, stream (MCP-projected)"),
         },
         description="A tool the actor can call.",
         category="tools",
@@ -447,4 +452,4 @@ def _register_world_shorthands() -> None:
     register_shorthand(key="modes", entity_type="mode", form="list")
     register_shorthand(key="principal", entity_type="principal", form="scalar")
     register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
-    register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+    register_shorthand(key="resources", entity_type="resource", form="block")

--- a/src/umwelt/sandbox/world_matcher.py
+++ b/src/umwelt/sandbox/world_matcher.py
@@ -19,7 +19,6 @@ from umwelt.sandbox.entities import (
     WorldEntity,
 )
 
-RESOURCE_KINDS = ("memory", "cpu-time", "wall-time", "max-fds", "tmpfs")
 
 
 class WorldMatcher:
@@ -62,7 +61,7 @@ class WorldMatcher:
         if type_name == "dir":
             return list(self._dirs or [])
         if type_name == "resource":
-            return [ResourceEntity(kind=k) for k in RESOURCE_KINDS]
+            return [ResourceEntity()]
         if type_name == "network":
             return [NetworkEntity()]
         if type_name == "env":
@@ -72,7 +71,7 @@ class WorldMatcher:
             result.append(WorldEntity(name=self._world_name))
             result.extend(self._files or [])
             result.extend(self._dirs or [])
-            result.extend(ResourceEntity(kind=k) for k in RESOURCE_KINDS)
+            result.append(ResourceEntity())
             result.append(NetworkEntity())
             result.extend(EnvEntity(name=n) for n in self._env_vars)
             return result
@@ -115,9 +114,6 @@ class WorldMatcher:
         name = getattr(entity, "name", None)
         if name is not None:
             return str(name)
-        kind = getattr(entity, "kind", None)
-        if kind is not None:
-            return str(kind)
         return None
 
 

--- a/src/umwelt/world/parser.py
+++ b/src/umwelt/world/parser.py
@@ -19,7 +19,7 @@ from umwelt.world.shorthands import get_shorthand
 
 _STRUCTURAL_KEYS = frozenset({"entities", "discover", "projections", "overrides", "fixed", "include", "exclude"})
 _RESERVED_KEYS = frozenset({"vars", "when", "version"})
-_PHASE2_KEYS = frozenset({"discover", "overrides", "fixed", "include", "exclude"})
+_PHASE2_KEYS = frozenset({"discover", "overrides", "include", "exclude"})
 
 
 def load_world(path: str | Path) -> WorldFile:
@@ -83,12 +83,14 @@ def load_world(path: str | Path) -> WorldFile:
                 discover_raw = tuple(data[key]) if isinstance(data[key], list) else ()
             elif key == "overrides":
                 overrides_raw = data[key] if isinstance(data[key], dict) else {}
-            elif key == "fixed":
-                fixed_raw = data[key] if isinstance(data[key], dict) else {}
             elif key == "include":
                 include_raw = tuple(str(x) for x in data[key]) if isinstance(data[key], list) else ()
             elif key == "exclude":
                 exclude_raw = tuple(str(x) for x in data[key]) if isinstance(data[key], list) else ()
+
+    # Fixed constraints are implemented — capture without warning
+    if "fixed" in data:
+        fixed_raw = data["fixed"] if isinstance(data["fixed"], dict) else {}
 
     # Warn on reserved and unknown keys
     known_keys = _STRUCTURAL_KEYS | _RESERVED_KEYS

--- a/src/umwelt/world/parser.py
+++ b/src/umwelt/world/parser.py
@@ -162,15 +162,23 @@ def _expand_shorthands(
                 id=str(value),
                 provenance=Provenance.EXPLICIT,
             ))
+        elif shorthand.form == "block" and isinstance(value, dict):
+            attrs = {str(k): str(v) for k, v in value.items()}
+            entities.append(DeclaredEntity(
+                type=shorthand.entity_type,
+                id=shorthand.entity_type,
+                attributes=attrs,
+                provenance=Provenance.EXPLICIT,
+            ))
         elif shorthand.form == "map" and isinstance(value, dict):
             for k, v in value.items():
-                attrs: dict[str, Any] = {}
+                attrs_map: dict[str, Any] = {}
                 if shorthand.attribute_key is not None:
-                    attrs[shorthand.attribute_key] = str(v)
+                    attrs_map[shorthand.attribute_key] = str(v)
                 entities.append(DeclaredEntity(
                     type=shorthand.entity_type,
                     id=str(k),
-                    attributes=attrs,
+                    attributes=attrs_map,
                     provenance=Provenance.EXPLICIT,
                 ))
 

--- a/src/umwelt/world/shorthands.py
+++ b/src/umwelt/world/shorthands.py
@@ -19,7 +19,7 @@ class ShorthandDef:
 
     key: str
     entity_type: str
-    form: Literal["list", "scalar", "map"]
+    form: Literal["list", "scalar", "map", "block"]
     attribute_key: str | None = None
 
 
@@ -27,7 +27,7 @@ def register_shorthand(
     *,
     key: str,
     entity_type: str,
-    form: Literal["list", "scalar", "map"],
+    form: Literal["list", "scalar", "map", "block"],
     attribute_key: str | None = None,
 ) -> None:
     """Register a shorthand key in the active registry scope."""

--- a/tests/core/test_check.py
+++ b/tests/core/test_check.py
@@ -25,7 +25,7 @@ def test_check_clean_fixture_exits_zero():
 
 def test_check_reports_rule_count():
     result = _run(["check", str(FIXTURE)])
-    assert "13 rule" in result.stdout or "13 rules" in result.stdout
+    assert "12 rule" in result.stdout or "12 rules" in result.stdout
 
 
 def test_check_reports_compiler_count():

--- a/tests/core/test_registry_matchers.py
+++ b/tests/core/test_registry_matchers.py
@@ -12,6 +12,7 @@ from umwelt.registry import (
     register_taxon,
     registry_scope,
 )
+from umwelt.registry.matchers import CompositeMatcher
 
 
 class NullMatcher:
@@ -46,12 +47,13 @@ def test_matcher_for_unknown_taxon_raises():
         register_matcher(taxon="ghost", matcher=NullMatcher())
 
 
-def test_duplicate_matcher_raises():
+def test_duplicate_matcher_auto_composes():
     with registry_scope():
         register_taxon(name="world", description="w")
         register_matcher(taxon="world", matcher=NullMatcher())
-        with pytest.raises(RegistryError, match="already registered"):
-            register_matcher(taxon="world", matcher=NullMatcher())
+        register_matcher(taxon="world", matcher=NullMatcher())
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
 
 
 def test_get_unknown_matcher_raises():
@@ -64,3 +66,122 @@ def test_get_unknown_matcher_raises():
 def test_matcher_protocol_is_runtime_checkable():
     # A structural check: NullMatcher satisfies MatcherProtocol
     assert isinstance(NullMatcher(), MatcherProtocol)
+
+
+# --- CompositeMatcher tests ---
+
+
+class _SimpleEntity:
+    """A trivial entity with an id and attributes."""
+
+    def __init__(self, eid: str, attrs: dict[str, Any] | None = None):
+        self.eid = eid
+        self.attrs = attrs or {}
+
+
+class CountingMatcher:
+    """A matcher that returns predictable, identifiable results."""
+
+    def __init__(self, tag: str, entities: list[Any] | None = None):
+        self.tag = tag
+        self._entities = entities or []
+
+    def match_type(self, type_name: str, context: Any = None) -> list[Any]:
+        return [e for e in self._entities if True]
+
+    def children(self, parent: Any, child_type: str) -> list[Any]:
+        return [e for e in self._entities if True]
+
+    def condition_met(self, selector: Any, context: Any = None) -> bool:
+        return self.tag == "yes"
+
+    def get_attribute(self, entity: Any, name: str) -> Any:
+        if isinstance(entity, _SimpleEntity):
+            return entity.attrs.get(name)
+        return None
+
+    def get_id(self, entity: Any) -> str | None:
+        if isinstance(entity, _SimpleEntity):
+            return entity.eid
+        return None
+
+
+def test_composite_match_type_unions():
+    e1, e2 = _SimpleEntity("a"), _SimpleEntity("b")
+    m1 = CountingMatcher("m1", [e1])
+    m2 = CountingMatcher("m2", [e2])
+    comp = CompositeMatcher(m1, m2)
+    result = comp.match_type("any")
+    assert result == [e1, e2]
+
+
+def test_composite_children_unions():
+    parent = _SimpleEntity("p")
+    c1, c2 = _SimpleEntity("c1"), _SimpleEntity("c2")
+    m1 = CountingMatcher("m1", [c1])
+    m2 = CountingMatcher("m2", [c2])
+    comp = CompositeMatcher(m1, m2)
+    result = comp.children(parent, "child")
+    assert result == [c1, c2]
+
+
+def test_composite_condition_met_or_semantics():
+    m_yes = CountingMatcher("yes")
+    m_no = CountingMatcher("no")
+    comp = CompositeMatcher(m_no, m_yes)
+    assert comp.condition_met("anything") is True
+
+    comp_all_no = CompositeMatcher(m_no, CountingMatcher("no"))
+    assert comp_all_no.condition_met("anything") is False
+
+
+def test_composite_get_id_first_non_none():
+    e = _SimpleEntity("found")
+    m_none = CountingMatcher("none", [])  # get_id returns None for non-_SimpleEntity
+    m_found = CountingMatcher("found", [e])
+    comp = CompositeMatcher(m_none, m_found)
+    assert comp.get_id(e) == "found"
+    # first delegate returns "found" too if given the entity
+    comp2 = CompositeMatcher(m_found, m_none)
+    assert comp2.get_id(e) == "found"
+
+
+def test_composite_get_attribute_first_non_none():
+    e = _SimpleEntity("x", {"color": "red"})
+    m_none = CountingMatcher("none")
+    m_attr = CountingMatcher("attr")
+    comp = CompositeMatcher(m_none, m_attr)
+    assert comp.get_attribute(e, "color") == "red"
+    assert comp.get_attribute(e, "missing") is None
+
+
+def test_composite_add():
+    e1, e2 = _SimpleEntity("a"), _SimpleEntity("b")
+    m1 = CountingMatcher("m1", [e1])
+    m2 = CountingMatcher("m2", [e2])
+    comp = CompositeMatcher(m1)
+    assert comp.match_type("any") == [e1]
+    comp.add(m2)
+    assert comp.match_type("any") == [e1, e2]
+
+
+def test_auto_composition_on_collision():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        m1 = NullMatcher()
+        m2 = NullMatcher()
+        register_matcher(taxon="world", matcher=m1)
+        register_matcher(taxon="world", matcher=m2)
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
+
+
+def test_triple_composition():
+    with registry_scope():
+        register_taxon(name="world", description="w")
+        register_matcher(taxon="world", matcher=NullMatcher())
+        register_matcher(taxon="world", matcher=NullMatcher())
+        register_matcher(taxon="world", matcher=NullMatcher())
+        result = get_matcher("world")
+        assert isinstance(result, CompositeMatcher)
+        assert len(result._delegates) == 3

--- a/tests/policy/test_fixed_constraints.py
+++ b/tests/policy/test_fixed_constraints.py
@@ -1,0 +1,214 @@
+# tests/policy/test_fixed_constraints.py
+"""Tests for fixed constraints — post-cascade clamping."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from umwelt.compilers.sql.dialects import SQLiteDialect
+from umwelt.compilers.sql.resolution import create_resolution_views
+from umwelt.compilers.sql.schema import EXPECTED_TABLES, create_schema
+from umwelt.compilers.sql.populate import populate_from_world
+from umwelt.policy.queries import resolve_entity
+from umwelt.world.model import DeclaredEntity, WorldFile
+
+
+@pytest.fixture
+def dialect():
+    return SQLiteDialect()
+
+
+@pytest.fixture
+def db(dialect):
+    """In-memory SQLite with schema created."""
+    con = sqlite3.connect(":memory:")
+    con.executescript(create_schema(dialect))
+    yield con
+    con.close()
+
+
+class TestFixedConstraintsSchema:
+    def test_fixed_constraints_in_expected_tables(self):
+        assert "fixed_constraints" in EXPECTED_TABLES
+
+    def test_fixed_constraints_table_created(self, db):
+        tables = db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='fixed_constraints'"
+        ).fetchall()
+        assert len(tables) == 1
+
+
+class TestEffectivePropertiesView:
+    def test_effective_properties_view_exists(self, db, dialect):
+        """effective_properties view is created after resolution views."""
+        # Insert an entity and cascade candidate so views have something to work with
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Read', 0)"
+        )
+        db.execute(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (1, 'allow', 'true', 'exact', "
+            "'[\"00000\",\"00000\",\"00000\",\"00001\",\"00000\",\"00000\",\"00000\",\"00000\"]', 0, 'p.umw', 1)"
+        )
+        db.commit()
+        create_resolution_views(db, dialect)
+
+        views = db.execute(
+            "SELECT name FROM sqlite_master WHERE type='view' AND name='effective_properties'"
+        ).fetchall()
+        assert len(views) == 1
+
+    def test_fixed_overrides_cascade(self, db, dialect):
+        """When a fixed constraint exists, effective_properties returns the fixed value."""
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Bash', 0)"
+        )
+        db.execute(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (1, 'allow', 'true', 'exact', "
+            "'[\"00000\",\"00000\",\"00000\",\"00001\",\"00000\",\"00000\",\"00000\",\"00000\"]', 0, 'p.umw', 1)"
+        )
+        db.execute(
+            "INSERT INTO fixed_constraints (entity_id, property_name, property_value, selector) "
+            "VALUES (1, 'allow', 'false', 'tool#Bash')"
+        )
+        db.commit()
+        create_resolution_views(db, dialect)
+
+        row = db.execute(
+            "SELECT effective_value, source FROM effective_properties "
+            "WHERE entity_id = 1 AND property_name = 'allow'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "false"
+        assert row[1] == "fixed"
+
+    def test_passthrough_without_fixed(self, db, dialect):
+        """Without a fixed constraint, effective_properties returns cascade value with source='cascade'."""
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Read', 0)"
+        )
+        db.execute(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (1, 'allow', 'true', 'exact', "
+            "'[\"00000\",\"00000\",\"00000\",\"00001\",\"00000\",\"00000\",\"00000\",\"00000\"]', 0, 'p.umw', 1)"
+        )
+        db.commit()
+        create_resolution_views(db, dialect)
+
+        row = db.execute(
+            "SELECT effective_value, source FROM effective_properties "
+            "WHERE entity_id = 1 AND property_name = 'allow'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "true"
+        assert row[1] == "cascade"
+
+
+class TestPopulateFixedConstraints:
+    def test_fixed_raw_populates_table(self, db, dialect):
+        """populate_from_world processes fixed_raw into the fixed_constraints table."""
+        # Insert entity first
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Bash', 0)"
+        )
+        db.commit()
+
+        wf = WorldFile(
+            entities=(),
+            projections=(),
+            warnings=(),
+            fixed_raw={"tool#Bash": {"allow": "false", "max-level": "2"}},
+        )
+        populate_from_world(db, wf)
+
+        rows = db.execute(
+            "SELECT property_name, property_value, selector FROM fixed_constraints ORDER BY property_name"
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0] == ("allow", "false", "tool#Bash")
+        assert rows[1] == ("max-level", "2", "tool#Bash")
+
+    def test_fixed_raw_type_selector(self, db, dialect):
+        """Fixed constraint with type-only selector matches all entities of that type."""
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Read', 0)"
+        )
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (2, 'cap', 'tool', 'Edit', 0)"
+        )
+        db.commit()
+
+        wf = WorldFile(
+            entities=(),
+            projections=(),
+            warnings=(),
+            fixed_raw={"tool": {"max-level": "10"}},
+        )
+        populate_from_world(db, wf)
+
+        rows = db.execute("SELECT entity_id FROM fixed_constraints ORDER BY entity_id").fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == 1
+        assert rows[1][0] == 2
+
+
+class TestResolveEntityUsesEffective:
+    def test_resolve_returns_fixed_value(self, db, dialect):
+        """End-to-end: entity + cascade rule + fixed constraint -> resolve returns fixed value."""
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Bash', 0)"
+        )
+        db.execute(
+            "INSERT INTO entity_closure (ancestor_id, descendant_id, depth) VALUES (1, 1, 0)"
+        )
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        db.execute(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (1, 'allow', 'true', 'exact', ?, 0, 'p.umw', 1)",
+            (spec,),
+        )
+        db.execute(
+            "INSERT INTO fixed_constraints (entity_id, property_name, property_value, selector) "
+            "VALUES (1, 'allow', 'false', 'tool#Bash')"
+        )
+        db.commit()
+        create_resolution_views(db, dialect)
+
+        val = resolve_entity(db, type="tool", id="Bash", property="allow")
+        assert val == "false"
+
+    def test_resolve_passthrough_without_fixed(self, db, dialect):
+        """Without fixed constraint, resolve_entity returns cascade value."""
+        db.execute(
+            "INSERT INTO entities (id, taxon, type_name, entity_id, depth) "
+            "VALUES (1, 'cap', 'tool', 'Read', 0)"
+        )
+        db.execute(
+            "INSERT INTO entity_closure (ancestor_id, descendant_id, depth) VALUES (1, 1, 0)"
+        )
+        spec = '["00000","00000","00000","00001","00000","00000","00000","00000"]'
+        db.execute(
+            "INSERT INTO cascade_candidates "
+            "(entity_id, property_name, property_value, comparison, specificity, rule_index, source_file, source_line) "
+            "VALUES (1, 'allow', 'true', 'exact', ?, 0, 'p.umw', 1)",
+            (spec,),
+        )
+        db.commit()
+        create_resolution_views(db, dialect)
+
+        val = resolve_entity(db, type="tool", id="Read", property="allow")
+        assert val == "true"

--- a/tests/policy/test_mode_filtering.py
+++ b/tests/policy/test_mode_filtering.py
@@ -1,0 +1,157 @@
+"""Tests for mode-filtered PolicyEngine queries.
+
+When mode is passed to resolve()/resolve_all(), only rules gated by
+that mode (or unscoped rules) should contribute to resolution.
+"""
+from __future__ import annotations
+
+import pytest
+
+from umwelt.errors import PolicyDenied
+from umwelt.policy import PolicyEngine
+
+
+@pytest.fixture
+def mode_engine(tmp_path):
+    world = tmp_path / "w.world.yml"
+    world.write_text("""
+entities:
+  - type: tool
+    id: Read
+  - type: tool
+    id: Edit
+  - type: tool
+    id: Bash
+    classes: [dangerous]
+  - type: mode
+    id: implement
+  - type: mode
+    id: review
+  - type: mode
+    id: explore
+""")
+    style = tmp_path / "p.umw"
+    style.write_text("""
+tool { allow: true; max-level: 8; }
+tool.dangerous { max-level: 5; }
+mode#implement tool.dangerous { max-level: 3; }
+mode#review tool { allow: false; }
+mode#review tool[name="Read"] { allow: true; }
+mode#explore tool { allow: false; }
+mode#explore tool[name="Read"] { allow: true; }
+mode#explore tool[name="Grep"] { allow: true; }
+""")
+    return PolicyEngine.from_files(world=world, stylesheet=style)
+
+
+class TestModeFilteredResolve:
+    def test_no_mode_includes_all_rules(self, mode_engine):
+        """Without mode filter, all mode-gated rules compete in cascade."""
+        val = mode_engine.resolve(type="tool", id="Bash", property="allow")
+        assert val is not None
+
+    def test_matching_mode_fires(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Bash", property="max-level", mode="implement")
+        assert val == "3"
+
+    def test_non_matching_mode_dropped(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Bash", property="max-level", mode="review")
+        assert val == "5"
+
+    def test_unscoped_rules_always_apply(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Read", property="allow", mode="implement")
+        assert val == "true"
+
+    def test_review_mode_denies_most_tools(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Bash", property="allow", mode="review")
+        assert val == "false"
+
+    def test_review_mode_allows_read(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Read", property="allow", mode="review")
+        assert val == "true"
+
+    def test_explore_mode_denies_edit(self, mode_engine):
+        val = mode_engine.resolve(type="tool", id="Edit", property="allow", mode="explore")
+        assert val == "false"
+
+    def test_implement_mode_no_allow_override(self, mode_engine):
+        """implement mode has no allow override — unscoped 'allow: true' wins."""
+        val = mode_engine.resolve(type="tool", id="Edit", property="allow", mode="implement")
+        assert val == "true"
+
+
+class TestModeFilteredResolveAll:
+    def test_resolve_all_with_mode(self, mode_engine):
+        tools = mode_engine.resolve_all(type="tool", mode="review")
+        assert len(tools) >= 3
+        bash = next(t for t in tools if t["entity_id"] == "Bash")
+        assert bash["properties"]["allow"] == "false"
+
+    def test_resolve_all_read_allowed_in_review(self, mode_engine):
+        tools = mode_engine.resolve_all(type="tool", mode="review")
+        read = next(t for t in tools if t["entity_id"] == "Read")
+        assert read["properties"]["allow"] == "true"
+
+
+class TestModeFilteredCheck:
+    def test_check_with_mode(self, mode_engine):
+        assert mode_engine.check(type="tool", id="Bash", mode="review", allow="false")
+
+    def test_check_mode_allowed(self, mode_engine):
+        assert mode_engine.check(type="tool", id="Read", mode="review", allow="true")
+
+
+class TestModeFilteredRequire:
+    def test_require_with_mode_passes(self, mode_engine):
+        mode_engine.require(type="tool", id="Read", mode="review", allow="true")
+
+    def test_require_with_mode_raises(self, mode_engine):
+        with pytest.raises(PolicyDenied):
+            mode_engine.require(type="tool", id="Bash", mode="review", allow="true")
+
+
+class TestModeFilteredTrace:
+    def test_trace_with_mode(self, mode_engine):
+        result = mode_engine.trace(type="tool", id="Bash", property="max-level", mode="implement")
+        assert result.value == "3"
+
+    def test_trace_without_mode_shows_all_candidates(self, mode_engine):
+        result = mode_engine.trace(type="tool", id="Bash", property="max-level")
+        assert len(result.candidates) >= 2
+
+
+class TestBackwardCompat:
+    def test_existing_tests_unaffected(self, mode_engine):
+        """All existing resolve patterns work without mode parameter."""
+        assert mode_engine.resolve(type="tool", id="Read", property="max-level") is not None
+        assert mode_engine.resolve(type="tool", id="Bash") is not None
+        tools = mode_engine.resolve_all(type="tool")
+        assert len(tools) >= 3
+
+
+class TestModeQualifierStorage:
+    """Verify mode_qualifier is stored in cascade_candidates."""
+
+    def test_mode_qualifier_column_exists(self, mode_engine):
+        rows = mode_engine.execute(
+            "SELECT mode_qualifier FROM cascade_candidates LIMIT 1"
+        )
+        assert rows is not None
+
+    def test_unscoped_rule_has_null_qualifier(self, mode_engine):
+        rows = mode_engine.execute(
+            "SELECT DISTINCT mode_qualifier FROM cascade_candidates "
+            "WHERE mode_qualifier IS NULL"
+        )
+        assert len(rows) >= 1
+
+    def test_mode_gated_rule_has_qualifier(self, mode_engine):
+        rows = mode_engine.execute(
+            "SELECT DISTINCT mode_qualifier FROM cascade_candidates "
+            "WHERE mode_qualifier IS NOT NULL "
+            "ORDER BY mode_qualifier"
+        )
+        qualifiers = {r[0] for r in rows}
+        assert "implement" in qualifiers
+        assert "review" in qualifiers
+        assert "explore" in qualifiers

--- a/tests/registry/test_plugins.py
+++ b/tests/registry/test_plugins.py
@@ -1,0 +1,66 @@
+"""Tests for plugin autodiscovery and idempotent taxon registration."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from umwelt.errors import RegistryError
+from umwelt.registry.plugins import discover_plugins
+from umwelt.registry.taxa import register_taxon, registry_scope
+
+
+class TestIdempotentRegisterTaxon:
+    """register_taxon is a no-op when re-registering with the same description."""
+
+    def test_same_description_is_noop(self):
+        with registry_scope():
+            register_taxon(name="t", description="desc")
+            register_taxon(name="t", description="desc")  # should not raise
+
+    def test_conflicting_description_raises(self):
+        with registry_scope():
+            register_taxon(name="t", description="desc A")
+            with pytest.raises(RegistryError, match="conflicting"):
+                register_taxon(name="t", description="desc B")
+
+
+class TestDiscoverPlugins:
+    """discover_plugins loads entry points from the umwelt.plugins group."""
+
+    def test_returns_list(self):
+        with registry_scope():
+            result = discover_plugins()
+            assert isinstance(result, list)
+
+    def test_loads_fake_entry_point(self):
+        called = []
+
+        def fake_register():
+            called.append(True)
+
+        fake_ep = SimpleNamespace(name="fake", load=lambda: fake_register)
+
+        with registry_scope():
+            with patch(
+                "umwelt.registry.plugins.entry_points", return_value=[fake_ep]
+            ):
+                loaded = discover_plugins()
+
+        assert loaded == ["fake"]
+        assert called == [True]
+
+    def test_survives_broken_plugin(self):
+        def bad_load():
+            raise ImportError("boom")
+
+        broken_ep = SimpleNamespace(name="broken", load=bad_load)
+
+        with registry_scope():
+            with patch(
+                "umwelt.registry.plugins.entry_points", return_value=[broken_ep]
+            ):
+                loaded = discover_plugins()
+
+        assert loaded == []

--- a/tests/sandbox/test_active_mode.py
+++ b/tests/sandbox/test_active_mode.py
@@ -1,0 +1,161 @@
+"""Tests for runtime mode filtering via active_mode context.
+
+When active_mode is passed to resolve(), only mode-gated rules whose
+mode ID matches active_mode (or unscoped rules) should fire. This
+unblocks Kibitzer's per-mode policy queries without pre-resolving all
+modes at load time.
+"""
+from __future__ import annotations
+
+import pytest
+
+from umwelt.cascade.resolver import ResolvedView, resolve
+from umwelt.parser import parse
+from umwelt.registry import register_matcher, registry_scope
+from umwelt.sandbox.capability_matcher import CapabilityMatcher
+from umwelt.sandbox.entities import ModeEntity, ToolEntity
+from umwelt.sandbox.state_matcher import StateMatcher
+from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+from umwelt.sandbox.world_matcher import WorldMatcher
+
+
+@pytest.fixture
+def sandbox_env(tmp_path):
+    tools = [
+        ToolEntity(name="Read"),
+        ToolEntity(name="Edit"),
+        ToolEntity(name="Bash"),
+    ]
+    modes = [
+        ModeEntity(id="implement"),
+        ModeEntity(id="review"),
+        ModeEntity(id="explore"),
+    ]
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=tmp_path))
+        register_matcher(taxon="capability", matcher=CapabilityMatcher(tools=tools))
+        register_matcher(taxon="state", matcher=StateMatcher(modes=modes))
+        yield tmp_path
+
+
+def _parse(text, tmp_path):
+    p = tmp_path / "test.umw"
+    p.write_text(text)
+    return parse(p)
+
+
+def _tool_props(rv: ResolvedView, tool_name: str) -> dict[str, str]:
+    for e, props in rv.entries("operation"):
+        if isinstance(e, ToolEntity) and e.name == tool_name:
+            return props
+    return {}
+
+
+class TestActiveModeFallback:
+    """Without active_mode, mode-gated rules fire unconditionally (v0.5 compat)."""
+
+    def test_no_active_mode_all_mode_rules_fire(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; }
+            mode#explore tool { allow: false; }
+        ''', sandbox_env)
+        rv = resolve(view)
+        assert _tool_props(rv, "Read").get("allow") == "false"
+
+    def test_none_eval_context_same_as_no_active_mode(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; }
+            mode#review tool { max-level: 2; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context=None)
+        assert _tool_props(rv, "Bash").get("max-level") == "2"
+
+
+class TestActiveModeFiltering:
+    """When active_mode is set, only matching mode qualifiers fire."""
+
+    def test_matching_mode_rule_fires(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; max-level: 8; }
+            mode#implement tool { max-level: 5; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context={"active_mode": "implement"})
+        assert _tool_props(rv, "Bash").get("max-level") == "5"
+
+    def test_non_matching_mode_rule_dropped(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; max-level: 8; }
+            mode#review tool { max-level: 2; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context={"active_mode": "implement"})
+        assert _tool_props(rv, "Bash").get("max-level") == "8"
+
+    def test_unscoped_rules_always_fire(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; }
+            mode#review tool { allow: false; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context={"active_mode": "implement"})
+        assert _tool_props(rv, "Read").get("allow") == "true"
+
+    def test_multiple_mode_rules_only_matching_fires(self, sandbox_env):
+        view = _parse('''
+            tool { allow: true; max-level: 8; }
+            mode#implement tool { max-level: 5; }
+            mode#review tool { max-level: 2; }
+            mode#explore tool { allow: false; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context={"active_mode": "implement"})
+        assert _tool_props(rv, "Bash").get("max-level") == "5"
+        assert _tool_props(rv, "Bash").get("allow") == "true"
+
+    def test_mode_id_selector_matching(self, sandbox_env):
+        """mode#implement matches active_mode='implement' exactly."""
+        view = _parse('''
+            tool { allow: true; }
+            mode#implement tool[name="Bash"] { allow: false; }
+        ''', sandbox_env)
+        rv = resolve(view, eval_context={"active_mode": "implement"})
+        assert _tool_props(rv, "Bash").get("allow") == "false"
+        assert _tool_props(rv, "Read").get("allow") == "true"
+
+
+class TestStateMatcher:
+    """Unit tests for StateMatcher.condition_met with active_mode context."""
+
+    def test_condition_met_mode_no_context(self):
+        matcher = StateMatcher(modes=[ModeEntity(id="implement")])
+        selector = _mock_selector("mode", "implement")
+        assert matcher.condition_met(selector) is True
+
+    def test_condition_met_mode_matching_active(self):
+        matcher = StateMatcher(modes=[ModeEntity(id="implement")])
+        selector = _mock_selector("mode", "implement")
+        assert matcher.condition_met(selector, {"active_mode": "implement"}) is True
+
+    def test_condition_met_mode_non_matching_active(self):
+        matcher = StateMatcher(modes=[ModeEntity(id="implement")])
+        selector = _mock_selector("mode", "review")
+        assert matcher.condition_met(selector, {"active_mode": "implement"}) is False
+
+    def test_condition_met_mode_no_id_with_active(self):
+        """Bare `mode` selector (no #id) always passes — it means any mode."""
+        matcher = StateMatcher(modes=[ModeEntity(id="implement")])
+        selector = _mock_selector("mode", None)
+        assert matcher.condition_met(selector, {"active_mode": "implement"}) is True
+
+    def test_condition_met_non_mode_always_false(self):
+        matcher = StateMatcher()
+        selector = _mock_selector("hook", "after-change")
+        assert matcher.condition_met(selector) is False
+
+
+def _mock_selector(type_name: str, id_value: str | None):
+    """Create a minimal object that looks like a SimpleSelector for condition_met."""
+    class MockSelector:
+        pass
+    s = MockSelector()
+    s.type_name = type_name
+    s.id_value = id_value
+    return s

--- a/tests/sandbox/test_bwrap_compiler.py
+++ b/tests/sandbox/test_bwrap_compiler.py
@@ -121,34 +121,34 @@ class TestBwrapOrdering:
 class TestBwrapResourceLimits:
     def test_memory_limit_emits_prlimit(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
+        rv.add("world", ResourceEntity(), {"memory": "512MB"})
         result = BwrapCompiler().compile_full(rv)
         assert "prlimit" in result.wrapper
         assert "--as=536870912" in result.wrapper  # 512 * 1024 * 1024
 
     def test_wall_time_emits_timeout(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+        rv.add("world", ResourceEntity(), {"wall-time": "60s"})
         result = BwrapCompiler().compile_full(rv)
         assert "timeout" in result.wrapper
         assert "60" in result.wrapper
 
-    def test_cpu_time_emits_prlimit_cpu(self):
+    def test_cpu_emits_prlimit_cpu(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(kind="cpu-time"), {"limit": "30s"})
+        rv.add("world", ResourceEntity(), {"cpu": "30s"})
         result = BwrapCompiler().compile_full(rv)
         assert "prlimit" in result.wrapper
         assert "--cpu=30" in result.wrapper
 
     def test_max_fds_emits_prlimit_nofile(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(kind="max-fds"), {"limit": "128"})
+        rv.add("world", ResourceEntity(), {"max-fds": "128"})
         result = BwrapCompiler().compile_full(rv)
         assert "--nofile=128" in result.wrapper
 
     def test_tmpfs_resource_emits_bwrap_flag(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(kind="tmpfs"), {"limit": "64MB"})
+        rv.add("world", ResourceEntity(), {"tmpfs": "64MB"})
         result = BwrapCompiler().compile_full(rv)
         assert "--tmpfs" in result.argv
         assert "/tmp" in result.argv
@@ -175,9 +175,7 @@ class TestBwrapResourceLimits:
         rv.add("world", MountEntity(path="/workspace/src/common"), {"source": "src/common", "readonly": "true"})
         rv.add("world", MountEntity(path="/tmp/work"), {"source": "/tmp/work", "readonly": "false"})
         rv.add("world", NetworkEntity(), {"deny": "*"})
-        rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
-        rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
-        rv.add("world", ResourceEntity(kind="tmpfs"), {"limit": "64MB"})
+        rv.add("world", ResourceEntity(), {"memory": "512MB", "wall-time": "60s", "tmpfs": "64MB"})
         rv.add("world", EnvEntity(name="CI"), {"allow": "true"})
 
         result = BwrapCompiler().compile_full(rv)

--- a/tests/sandbox/test_bwrap_compiler.py
+++ b/tests/sandbox/test_bwrap_compiler.py
@@ -133,9 +133,9 @@ class TestBwrapResourceLimits:
         assert "timeout" in result.wrapper
         assert "60" in result.wrapper
 
-    def test_cpu_emits_prlimit_cpu(self):
+    def test_cpu_time_emits_prlimit_cpu(self):
         rv = ResolvedView()
-        rv.add("world", ResourceEntity(), {"cpu": "30s"})
+        rv.add("world", ResourceEntity(), {"cpu-time": "30s"})
         result = BwrapCompiler().compile_full(rv)
         assert "prlimit" in result.wrapper
         assert "--cpu=30" in result.wrapper

--- a/tests/sandbox/test_bwrap_runner.py
+++ b/tests/sandbox/test_bwrap_runner.py
@@ -47,7 +47,7 @@ def test_runner_assembles_bwrap_argv_wrapper_command():
     """Verify the runner concatenates: bwrap ARGV -- WRAPPER COMMAND."""
     rv = ResolvedView()
     rv.add("world", MountEntity(path="/workspace/src"), {"source": "./src"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+    rv.add("world", ResourceEntity(), {"wall-time": "60s"})
 
     mock_result = MagicMock()
     mock_result.returncode = 0

--- a/tests/sandbox/test_bwrap_snapshots.py
+++ b/tests/sandbox/test_bwrap_snapshots.py
@@ -77,8 +77,7 @@ def test_snapshot_auth_fix():
         {"editable": "false"},
     )
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "5m"})
+    rv.add("world", ResourceEntity(), {"memory": "512MB", "wall-time": "5m"})
 
     result = BwrapCompiler().compile_full(rv)
     expected_argv = _load_argv("auth-fix.argv")
@@ -109,7 +108,7 @@ def test_snapshot_readonly_exploration():
         {"editable": "false"},
     )
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+    rv.add("world", ResourceEntity(), {"wall-time": "60s"})
 
     result = BwrapCompiler().compile_full(rv)
     expected_argv = _load_argv("readonly-exploration.argv")

--- a/tests/sandbox/test_desugaring.py
+++ b/tests/sandbox/test_desugaring.py
@@ -169,22 +169,18 @@ def test_network_deny_desugars_to_network_rule():
 
 def test_budget_multiple_dimensions_desugar_to_resource_rules():
     view = parse("@budget { memory: 512MB; wall-time: 60s; }", validate=False)
-    assert len(view.rules) == 2
+    assert len(view.rules) == 1
     assert len(view.unknown_at_rules) == 0
 
-    rule_map = {}
-    for r in view.rules:
-        sel = r.selectors[0]
-        simple = sel.parts[0].selector
-        assert simple.type_name == "resource"
-        kind_attr = next((a for a in simple.attributes if a.name == "kind"), None)
-        assert kind_attr is not None
-        rule_map[kind_attr.value] = r.declarations[0].values[0]
+    rule = view.rules[0]
+    sel = rule.selectors[0]
+    simple = sel.parts[0].selector
+    assert simple.type_name == "resource"
+    assert len(simple.attributes) == 0
 
-    assert "memory" in rule_map
-    assert "512MB" in rule_map["memory"]
-    assert "wall-time" in rule_map
-    assert "60s" in rule_map["wall-time"]
+    decl_map = {d.property_name: d.values[0] for d in rule.declarations}
+    assert "512MB" in decl_map["memory"]
+    assert "60s" in decl_map["wall-time"]
 
 
 def test_env_allow_deny_desugars_with_specificity():

--- a/tests/sandbox/test_nsjail_compiler.py
+++ b/tests/sandbox/test_nsjail_compiler.py
@@ -129,6 +129,20 @@ def test_tmpfs_resource():
     assert 'options: "size=64M"' in output
 
 
+def test_all_resource_limits_on_single_entity():
+    rv = ResolvedView()
+    rv.add("world", ResourceEntity(), {
+        "memory": "1GB", "wall-time": "5m", "cpu": "30s",
+        "max-fds": "256", "tmpfs": "128MB",
+    })
+    output = NsjailCompiler().compile(rv)
+    assert "rlimit_as: 1024" in output
+    assert "time_limit: 300" in output
+    assert "rlimit_cpu: 30" in output
+    assert "rlimit_nofile: 256" in output
+    assert 'options: "size=128M"' in output
+
+
 def test_resource_without_limits_is_skipped():
     rv = ResolvedView()
     rv.add("world", ResourceEntity(), {})

--- a/tests/sandbox/test_nsjail_compiler.py
+++ b/tests/sandbox/test_nsjail_compiler.py
@@ -107,9 +107,9 @@ def test_wall_time_limit_minutes():
     assert "time_limit: 300" in output
 
 
-def test_cpu_limit():
+def test_cpu_time_limit():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(), {"cpu": "30s"})
+    rv.add("world", ResourceEntity(), {"cpu-time": "30s"})
     output = NsjailCompiler().compile(rv)
     assert "rlimit_cpu: 30" in output
 
@@ -132,7 +132,7 @@ def test_tmpfs_resource():
 def test_all_resource_limits_on_single_entity():
     rv = ResolvedView()
     rv.add("world", ResourceEntity(), {
-        "memory": "1GB", "wall-time": "5m", "cpu": "30s",
+        "memory": "1GB", "wall-time": "5m", "cpu-time": "30s",
         "max-fds": "256", "tmpfs": "128MB",
     })
     output = NsjailCompiler().compile(rv)

--- a/tests/sandbox/test_nsjail_compiler.py
+++ b/tests/sandbox/test_nsjail_compiler.py
@@ -87,7 +87,7 @@ def test_network_no_deny_does_not_emit_clone_newnet():
 
 def test_memory_limit():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
+    rv.add("world", ResourceEntity(), {"memory": "512MB"})
     output = NsjailCompiler().compile(rv)
     assert "rlimit_as: 512" in output
     assert "rlimit_as_type: SOFT" in output
@@ -95,43 +95,43 @@ def test_memory_limit():
 
 def test_wall_time_limit():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+    rv.add("world", ResourceEntity(), {"wall-time": "60s"})
     output = NsjailCompiler().compile(rv)
     assert "time_limit: 60" in output
 
 
 def test_wall_time_limit_minutes():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "5m"})
+    rv.add("world", ResourceEntity(), {"wall-time": "5m"})
     output = NsjailCompiler().compile(rv)
     assert "time_limit: 300" in output
 
 
-def test_cpu_time_limit():
+def test_cpu_limit():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="cpu-time"), {"limit": "30s"})
+    rv.add("world", ResourceEntity(), {"cpu": "30s"})
     output = NsjailCompiler().compile(rv)
     assert "rlimit_cpu: 30" in output
 
 
 def test_max_fds_limit():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="max-fds"), {"limit": "128"})
+    rv.add("world", ResourceEntity(), {"max-fds": "128"})
     output = NsjailCompiler().compile(rv)
     assert "rlimit_nofile: 128" in output
 
 
 def test_tmpfs_resource():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="tmpfs"), {"limit": "64MB"})
+    rv.add("world", ResourceEntity(), {"tmpfs": "64MB"})
     output = NsjailCompiler().compile(rv)
     assert 'fstype: "tmpfs"' in output
     assert 'options: "size=64M"' in output
 
 
-def test_resource_without_limit_is_skipped():
+def test_resource_without_limits_is_skipped():
     rv = ResolvedView()
-    rv.add("world", ResourceEntity(kind="memory"), {})
+    rv.add("world", ResourceEntity(), {})
     output = NsjailCompiler().compile(rv)
     assert "rlimit_as" not in output
 
@@ -188,9 +188,7 @@ def test_full_worked_example():
     rv.add("world", FileEntity(path="src/common", abs_path=Path("src/common"), name="common"), {"editable": "false"})
     rv.add("world", FileEntity(path="/tmp/work", abs_path=Path("/tmp/work"), name="work"), {"editable": "true"})
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
-    rv.add("world", ResourceEntity(kind="tmpfs"), {"limit": "64MB"})
+    rv.add("world", ResourceEntity(), {"memory": "512MB", "wall-time": "60s", "tmpfs": "64MB"})
     rv.add("world", EnvEntity(name="CI"), {"allow": "true"})
     # These should be silently dropped:
     rv.add("capability", ToolEntity(name="Read"), {"allow": "true"})
@@ -204,7 +202,7 @@ def test_full_worked_example():
     assert "clone_newnet: true" in output
     assert "rlimit_as: 512" in output
     # Three mounts: src/auth (rw), src/common (ro), /tmp/work (rw), plus tmpfs /tmp
-    assert output.count("mount {") == 12  # 8 system + 4 view
+    assert output.count("mount {") == 12  # 8 system + 3 files + 1 tmpfs
     assert 'envar: "CI"' in output
     # Tools and hooks NOT in output
     assert "Read" not in output

--- a/tests/sandbox/test_nsjail_runner.py
+++ b/tests/sandbox/test_nsjail_runner.py
@@ -21,7 +21,7 @@ def _simple_view() -> ResolvedView:
         {"editable": "false"},
     )
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+    rv.add("world", ResourceEntity(), {"wall-time": "60s"})
     return rv
 
 

--- a/tests/sandbox/test_nsjail_snapshots.py
+++ b/tests/sandbox/test_nsjail_snapshots.py
@@ -75,8 +75,7 @@ def test_snapshot_auth_fix():
         {"editable": "false"},
     )
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="memory"), {"limit": "512MB"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "5m"})
+    rv.add("world", ResourceEntity(), {"memory": "512MB", "wall-time": "5m"})
 
     output = NsjailCompiler().compile(rv)
     expected = _load_expected("auth-fix.textproto")
@@ -103,7 +102,7 @@ def test_snapshot_readonly_exploration():
         {"editable": "false"},
     )
     rv.add("world", NetworkEntity(), {"deny": "*"})
-    rv.add("world", ResourceEntity(kind="wall-time"), {"limit": "60s"})
+    rv.add("world", ResourceEntity(), {"wall-time": "60s"})
 
     output = NsjailCompiler().compile(rv)
     expected = _load_expected("readonly-exploration.textproto")

--- a/tests/sandbox/test_vocabulary.py
+++ b/tests/sandbox/test_vocabulary.py
@@ -139,7 +139,7 @@ def test_hook_run_property():
 def test_resource_properties():
     with registry_scope():
         _register_sandbox()
-        for name in ("memory", "wall-time", "cpu", "max-fds", "tmpfs"):
+        for name in ("memory", "wall-time", "cpu-time", "max-fds", "tmpfs"):
             prop = get_property("world", "resource", name)
             assert prop.name == name
             assert prop.restrictive_direction == "min"

--- a/tests/sandbox/test_vocabulary.py
+++ b/tests/sandbox/test_vocabulary.py
@@ -60,7 +60,7 @@ def test_world_resource_entity():
     with registry_scope():
         _register_sandbox()
         entity = get_entity("world", "resource")
-        assert "kind" in entity.attributes
+        assert "name" in entity.attributes
 
 
 def test_world_network_entity():
@@ -136,11 +136,13 @@ def test_hook_run_property():
         assert prop.name == "run"
 
 
-def test_resource_limit_property():
+def test_resource_properties():
     with registry_scope():
         _register_sandbox()
-        prop = get_property("world", "resource", "limit")
-        assert prop.name == "limit"
+        for name in ("memory", "wall-time", "cpu", "max-fds"):
+            prop = get_property("world", "resource", name)
+            assert prop.name == name
+            assert prop.restrictive_direction == "min"
 
 
 def test_network_deny_property():

--- a/tests/sandbox/test_vocabulary.py
+++ b/tests/sandbox/test_vocabulary.py
@@ -139,7 +139,7 @@ def test_hook_run_property():
 def test_resource_properties():
     with registry_scope():
         _register_sandbox()
-        for name in ("memory", "wall-time", "cpu", "max-fds"):
+        for name in ("memory", "wall-time", "cpu", "max-fds", "tmpfs"):
             prop = get_property("world", "resource", name)
             assert prop.name == name
             assert prop.restrictive_direction == "min"

--- a/tests/sandbox/test_world_matcher.py
+++ b/tests/sandbox/test_world_matcher.py
@@ -80,13 +80,11 @@ def test_match_type_unknown_returns_empty(tmp_path):
     assert matcher.match_type("ghost") == []
 
 
-def test_resource_entities(tmp_path):
+def test_resource_entity_singleton(tmp_path):
     tree = _make_tree(tmp_path)
     matcher = WorldMatcher(base_dir=tree)
     resources = matcher.match_type("resource")
-    kinds = {matcher.get_attribute(r, "kind") for r in resources}
-    assert "memory" in kinds
-    assert "wall-time" in kinds
+    assert len(resources) == 1
 
 
 def test_network_entity(tmp_path):

--- a/tests/test_compilers_sql/conftest.py
+++ b/tests/test_compilers_sql/conftest.py
@@ -38,7 +38,7 @@ def populated_db(db):
         (10, "world", "dir",  "src",                None, json.dumps({"path": "src", "name": "src"}), None, 0),
         (11, "world", "dir",  "tests",              None, json.dumps({"path": "tests", "name": "tests"}), None, 0),
         # world: resource (singleton block)
-        (20, "world", "resource", "resource",       None, json.dumps({"name": "resource"}), None, 0),
+        (20, "world", "resource", None,             None, json.dumps({}), None, 0),
         # world: network
         (25, "world", "network", None,               None, json.dumps({}), None, 0),
         # world: exec

--- a/tests/test_compilers_sql/conftest.py
+++ b/tests/test_compilers_sql/conftest.py
@@ -37,9 +37,8 @@ def populated_db(db):
         # world: dirs
         (10, "world", "dir",  "src",                None, json.dumps({"path": "src", "name": "src"}), None, 0),
         (11, "world", "dir",  "tests",              None, json.dumps({"path": "tests", "name": "tests"}), None, 0),
-        # world: resources
-        (20, "world", "resource", "memory",         None, json.dumps({"kind": "memory"}), None, 0),
-        (21, "world", "resource", "wall-time",      None, json.dumps({"kind": "wall-time"}), None, 0),
+        # world: resource (singleton block)
+        (20, "world", "resource", "resource",       None, json.dumps({"name": "resource"}), None, 0),
         # world: network
         (25, "world", "network", None,               None, json.dumps({}), None, 0),
         # world: exec

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -94,10 +94,6 @@ class TestAttributeSelectors:
         sql = compile_selector(parse_selector('tool[altitude="os"]'), DIALECT)
         assert query_ids(populated_db, sql) == {40, 41, 42, 43, 45, 46}
 
-    def test_resource_name_attribute(self, populated_db):
-        sql = compile_selector(parse_selector('resource[name="resource"]'), DIALECT)
-        assert query_ids(populated_db, sql) == {20}
-
 
 # ============================================================================
 # Level 4: Class selectors

--- a/tests/test_compilers_sql/test_compiler.py
+++ b/tests/test_compilers_sql/test_compiler.py
@@ -33,9 +33,9 @@ class TestTypeSelectors:
         sql = compile_selector(parse_selector("mode"), DIALECT)
         assert query_ids(populated_db, sql) == {50, 51, 52, 53, 54}
 
-    def test_bare_resource_matches_all_resources(self, populated_db):
+    def test_bare_resource_matches_singleton(self, populated_db):
         sql = compile_selector(parse_selector("resource"), DIALECT)
-        assert query_ids(populated_db, sql) == {20, 21}
+        assert query_ids(populated_db, sql) == {20}
 
     def test_type_selector_excludes_other_types(self, populated_db):
         sql = compile_selector(parse_selector("tool"), DIALECT)
@@ -94,8 +94,8 @@ class TestAttributeSelectors:
         sql = compile_selector(parse_selector('tool[altitude="os"]'), DIALECT)
         assert query_ids(populated_db, sql) == {40, 41, 42, 43, 45, 46}
 
-    def test_resource_kind_attribute(self, populated_db):
-        sql = compile_selector(parse_selector('resource[kind="memory"]'), DIALECT)
+    def test_resource_name_attribute(self, populated_db):
+        sql = compile_selector(parse_selector('resource[name="resource"]'), DIALECT)
         assert query_ids(populated_db, sql) == {20}
 
 

--- a/tests/test_compilers_sql/test_roundtrip.py
+++ b/tests/test_compilers_sql/test_roundtrip.py
@@ -242,7 +242,7 @@ class TestFullPolicy:
             tool[name="Bash"] { allow-pattern: "pytest *"; }
 
             network { deny: "*"; }
-            resource[kind="memory"] { limit: 512MB; }
+            resource { memory: 512MB; }
         ''')
         assert rv.property("src/auth.py", "editable") == "true"
         assert rv.property("README.md", "editable") == "false"
@@ -256,5 +256,5 @@ class TestFullPolicy:
         assert "pytest *" in patterns
 
         assert rv.property_by_id(25, "deny") == "*"
-        assert rv.property("memory", "limit") == "512MB"
+        assert rv.property("resource", "memory") == "512MB"
         rv.assert_a1()

--- a/tests/test_compilers_sql/test_roundtrip.py
+++ b/tests/test_compilers_sql/test_roundtrip.py
@@ -256,5 +256,5 @@ class TestFullPolicy:
         assert "pytest *" in patterns
 
         assert rv.property_by_id(25, "deny") == "*"
-        assert rv.property("resource", "memory") == "512MB"
+        assert rv.property_by_id(20, "memory") == "512MB"
         rv.assert_a1()

--- a/tests/world/conftest.py
+++ b/tests/world/conftest.py
@@ -29,10 +29,10 @@ def toy_world_vocab():
             attributes={}, description="an inferencer")
         register_taxon(name="world", description="test world")
         register_entity(taxon="world", name="resource",
-            attributes={"limit": AttrSchema(type=str)}, description="a resource")
+            attributes={"name": AttrSchema(type=str)}, description="a resource block")
         register_shorthand(key="tools", entity_type="tool", form="list")
         register_shorthand(key="modes", entity_type="mode", form="list")
         register_shorthand(key="principal", entity_type="principal", form="scalar")
         register_shorthand(key="inferencer", entity_type="inferencer", form="scalar")
-        register_shorthand(key="resources", entity_type="resource", form="map", attribute_key="limit")
+        register_shorthand(key="resources", entity_type="resource", form="block")
         yield

--- a/tests/world/test_integration.py
+++ b/tests/world/test_integration.py
@@ -17,6 +17,9 @@ def test_full_pipeline(tmp_path):
         "tools: [Read, Edit, Bash]\n"
         "modes: [implement]\n"
         "principal: Teague\n"
+        "resources:\n"
+        "  memory: 1GB\n"
+        "  wall-time: 10m\n"
         "entities:\n"
         "  - type: tool\n"
         "    id: Bash\n"
@@ -39,26 +42,32 @@ def test_full_pipeline(tmp_path):
         assert len(bash_entities) == 1
         assert bash_entities[0].classes == ("dangerous",)
 
+        # Resource block should be one entity with attributes
+        resource_entities = [e for e in world.entities if e.type == "resource"]
+        assert len(resource_entities) == 1
+        assert resource_entities[0].attributes["memory"] == "1GB"
+        assert resource_entities[0].attributes["wall-time"] == "10m"
+
         # Full materialization
         mw = materialize(world, DetailLevel.FULL)
-        assert mw.meta.entity_count == 5  # 3 tools + 1 mode + 1 principal
+        assert mw.meta.entity_count == 6  # 3 tools + 1 mode + 1 principal + 1 resource
         assert len(mw.projections) == 1
         assert mw.meta.detail_level == "full"
 
         # Outline strips attributes
         mw_outline = materialize(world, DetailLevel.OUTLINE)
-        assert len(mw_outline.entities) == 5
+        assert len(mw_outline.entities) == 6
         for e in mw_outline.entities:
             assert e.attributes == {}
 
         # Summary has counts only
         mw_summary = materialize(world, DetailLevel.SUMMARY)
         assert len(mw_summary.entities) == 0
-        assert mw_summary.meta.entity_count == 5
+        assert mw_summary.meta.entity_count == 6
         assert mw_summary.meta.type_counts["tool"] == 3
 
         # YAML round-trip
         text = render_yaml(mw)
         parsed = yaml.safe_load(text)
-        assert parsed["meta"]["entity_count"] == 5
-        assert len(parsed["entities"]) == 5
+        assert parsed["meta"]["entity_count"] == 6
+        assert len(parsed["entities"]) == 6

--- a/tests/world/test_parser.py
+++ b/tests/world/test_parser.py
@@ -92,13 +92,16 @@ class TestShorthandExpansion:
         assert wf.entities[0].type == "principal"
         assert wf.entities[0].id == "Teague"
 
-    def test_map_shorthand(self, tmp_path, toy_world_vocab):
+    def test_block_shorthand(self, tmp_path, toy_world_vocab):
         p = tmp_path / "t.world.yml"
         p.write_text("resources:\n  memory: 512MB\n  wall-time: 5m\n")
         wf = load_world(p)
-        assert len(wf.entities) == 2
-        mem = next(e for e in wf.entities if e.id == "memory")
-        assert mem.attributes["limit"] == "512MB"
+        assert len(wf.entities) == 1
+        res = wf.entities[0]
+        assert res.type == "resource"
+        assert res.id == "resource"
+        assert res.attributes["memory"] == "512MB"
+        assert res.attributes["wall-time"] == "5m"
 
     def test_explicit_overrides_shorthand(self, tmp_path, toy_world_vocab):
         p = tmp_path / "t.world.yml"

--- a/tests/world/test_shorthands.py
+++ b/tests/world/test_shorthands.py
@@ -33,6 +33,15 @@ def test_scope_isolation():
         assert get_shorthand("tools") is None
 
 
+def test_block_form():
+    with registry_scope():
+        register_shorthand(key="resources", entity_type="resource", form="block")
+        sd = get_shorthand("resources")
+        assert sd is not None
+        assert sd.form == "block"
+        assert sd.attribute_key is None
+
+
 def test_sandbox_vocabulary_registers_shorthands():
     from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
 
@@ -42,4 +51,17 @@ def test_sandbox_vocabulary_registers_shorthands():
         assert get_shorthand("modes") is not None
         assert get_shorthand("principal") is not None
         assert get_shorthand("inferencer") is not None
-        assert get_shorthand("resources") is not None
+        res = get_shorthand("resources")
+        assert res is not None
+        assert res.form == "block"
+
+
+def test_tool_entity_has_mcp_attributes():
+    from umwelt.registry.entities import get_entity
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+
+    with registry_scope():
+        register_sandbox_vocabulary()
+        tool_def = get_entity("capability", "tool")
+        assert "param-count" in tool_def.attributes
+        assert "output-type" in tool_def.attributes


### PR DESCRIPTION
## Summary

This PR brings together the v0.6 release features:

- **Resource block entity model** — Migrates from N singleton resource entities (memory, cpu-time, wall-time, tmpfs) to a single `resource` block entity with properties, simplifying vocabulary and CSS selectors
- **Runtime mode filtering** — `StateMatcher.condition_met()` filters cascade rules by `active_mode` context for the in-memory resolution path
- **SQL mode filtering** — `mode_qualifier` column on `cascade_candidates` enables mode-gated resolution through PolicyEngine (`resolve`, `resolve_all`, `trace`, `check`, `require` all accept `mode` parameter)
- **Populate fix** — `populate_from_world` now always includes entity `id` as a `name` attribute, fixing `tool[name="Read"]` selectors in the SQL path
- **Plugin guide documentation** — Comprehensive docs for plugins, PolicyEngine API, and world files
- **MCP-projected tool attributes** — `param-count` and `output-type` on tool entity type for future MCP generator integration

## Changes by area

### Core engine (5 files)
- `compilers/sql/schema.py` — `mode_qualifier` column on cascade_candidates
- `compilers/sql/compiler.py` — Extract and store mode qualifier from cross-axis mode selectors
- `compilers/sql/populate.py` — Always include entity id as `name` attribute
- `policy/engine.py` — `mode` parameter on resolve/resolve_all/trace/check/require
- `policy/queries.py` — Mode-filtered inline resolution queries + effective_properties integration

### Sandbox (6 files)
- Resource block migration across vocabulary, entities, desugar, compilers
- `state_matcher.py` — active_mode filtering for cascade resolver path

### Documentation (7 files)
- `docs/guide/plugins.md` — Plugin development guide
- `docs/guide/policy-engine.md` — PolicyEngine API reference
- `docs/guide/world-files.md` — World file format guide
- Updated entity reference, writing-views, and fixture examples

### Tests (19 files)
- `tests/policy/test_mode_filtering.py` — 20 tests for SQL mode filtering
- `tests/sandbox/test_active_mode.py` — 12 tests for cascade mode filtering
- Updated existing tests for resource block migration

## Test plan
- [x] Full test suite: 831 passed, 1 skipped, 0 failures
- [ ] Review mode filtering semantics: unscoped rules apply in all modes, mode-gated rules only apply when that mode is active
- [ ] Review populate fix: verify `name` attribute doesn't conflict with explicit world file attributes
- [ ] Review effective_properties integration: mode-filtered path bypasses fixed constraints (by design — fixed constraints are mode-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)