### PR TITLE
docs: update README, changelog, and landing page for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ project follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-04-26
+
+### Added
+- **Resource block model** — single `resource` entity with properties (`memory`, `wall-time`, `cpu-time`, `tmpfs`) replaces per-resource singletons (`MemoryEntity`, `WallTimeEntity`, etc.). CSS selectors now use `resource { memory: 512MB; }` instead of `memory { limit: 512MB; }`.
+- **Mode filtering** — `mode#review tool { allow: false }` gates rules by active mode. Both in-memory cascade resolver (`StateMatcher.condition_met()` with `active_mode` context) and SQL PolicyEngine (`mode` parameter on `resolve`/`resolve_all`/`trace`/`check`/`require`). Unscoped rules always apply; mode-gated rules only fire when that mode is active. `mode_qualifier` column on `cascade_candidates` table.
+- **Fixed constraints** — post-cascade clamping for safety-critical properties. `fixed_raw` in world files maps selectors to property values that override cascade results. `fixed_constraints` table and `effective_properties` view in SQL schema.
+- **CompositeMatcher** — multiple matchers per taxon via `CompositeMatcher` wrapper. Enables plugin coexistence where two plugins register matchers for the same taxon.
+- **Plugin autodiscovery** — `umwelt.plugins` entry point group. Third-party packages register plugins via `pyproject.toml` entry points; `umwelt.registry.plugins.discover_plugins()` loads them at startup.
+- **MCP-projected tool attributes** — `param-count` and `output-type` attributes on the `tool` entity type, populated by future MCP generator plugins.
+- **Plugin guide documentation** — `docs/guide/plugins.md` (586 lines), `docs/guide/policy-engine.md` (456 lines), `docs/guide/world-files.md` (363 lines).
+- 200+ new tests (832 total). `tests/policy/test_mode_filtering.py` (20 tests), `tests/sandbox/test_active_mode.py` (12 tests).
+
+### Changed
+- `populate_from_world` now always includes entity `id` as a `name` attribute in the JSON column, matching matcher-discovered entity behavior. Fixes `tool[name="Read"]` selectors in the SQL path.
+- PolicyEngine `resolve`, `resolve_all`, `trace`, `check`, `require` methods accept optional `mode` parameter.
+- Sandbox compilers (nsjail, bwrap) updated to read resource properties from block entity instead of individual resource entities.
+- `@budget` at-rule desugars to `resource { ... }` instead of individual `memory { limit: ... }` / `wall-time { limit: ... }` rules.
+
+### Fixed
+- Mode-filtered queries now respect fixed constraints (post-cascade clamping applied after mode-filtered resolution).
+- Projection entities now get `name` attribute fallback, consistent with declared entities.
+
 ## [0.5.2] — 2026-04-16
 
 ### Added
@@ -244,5 +266,13 @@ engine, cascade resolver, compiler protocol, and CLI.
 - `source` / `project` entity — v1.1+.
 - View bank and git-history distillation — v2.
 
-[Unreleased]: https://github.com/teaguesterling/umwelt/compare/v0.1.0-core...HEAD
+[Unreleased]: https://github.com/teaguesterling/umwelt/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/teaguesterling/umwelt/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/teaguesterling/umwelt/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/teaguesterling/umwelt/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/teaguesterling/umwelt/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/teaguesterling/umwelt/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/teaguesterling/umwelt/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/teaguesterling/umwelt/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/teaguesterling/umwelt/compare/v0.1.0-core...v0.1.0
 [0.1.0-core]: https://github.com/teaguesterling/umwelt/releases/tag/v0.1.0-core

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ umwelt is the **common language**. Write one view file. Every enforcement tool r
 ## Install
 
 ```bash
-pip install -e ".[dev]"    # from source (PyPI publish coming in v0.4)
+pip install -e ".[dev]"    # from source
 ```
 
 Requires Python 3.10+.
@@ -134,9 +134,16 @@ See [How umwelt Works](docs/guide/how-it-works.md) for the full architectural pi
 
 ## Status
 
-**v0.1.0** — the sandbox consumer ships. Parser, selector engine, cascade resolver, workspace builder, writeback, hook dispatcher, at-rule sugar desugaring, CLI. 315 tests, mypy strict, ruff clean.
+**v0.6.0** — current release. What's new since v0.5:
 
-**Next:** v0.2 adds the nsjail compiler (first real enforcement target). v0.3 adds bwrap + the ratchet scaffold. v0.4 adds lackpy integration + PyPI.
+- **Resource block model** — single `resource` entity with properties replaces per-resource singletons
+- **World state layer** (`umwelt.world`) — YAML world files with shorthand expansion, vocabulary validation, three-level materialization. `umwelt materialize` CLI command
+- **PolicyEngine** (`umwelt.policy`) — consumer-facing Python API over compiled SQLite. `from_files`, `from_db`, programmatic builder. Resolve, trace, lint, select, check, require. COW `extend()` for fork-and-specialize
+- **Mode filtering** — `mode#review tool { allow: false }` gates rules by active mode. Both in-memory cascade and SQL backends
+- **Fixed constraints** — post-cascade clamping for safety-critical properties
+- **CompositeMatcher** — multiple matchers per taxon
+- **Plugin autodiscovery** — entry point registration for third-party plugins
+- **832 tests**, mypy strict, ruff clean
 
 ## The ecosystem
 
@@ -159,7 +166,7 @@ The theoretical foundation is in [The Ma of Multi-Agent Systems](https://judgeme
 
 ```bash
 pip install -e ".[dev]"
-pytest -q              # 315 tests
+pytest -q              # 832 tests
 ruff check src/ tests/ # lint
 mypy src/              # type check (strict)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,18 @@ umwelt parses this, builds a virtual workspace from it, and translates it into w
 
     Learn to write `.umw` files from scratch — files, tools, hooks, budgets, environments, compound selectors.
 
+- :material-file-document: **[World Files](guide/world-files.md)**
+
+    Declare entities in YAML — tools, modes, principals, resources. Shorthand syntax and materialization.
+
+- :material-database-search: **[PolicyEngine](guide/policy-engine.md)**
+
+    Query resolved policy from Python — resolve, trace, lint, check. The consumer-facing API for plugins.
+
+- :material-puzzle: **[Plugins](guide/plugins.md)**
+
+    Build generators (populate the world) and interactors (consume policy). Matcher protocol, entry points.
+
 - :material-cog: **[How It Works](guide/how-it-works.md)**
 
     The entity model, plugin architecture, pivots between world models, and the ecosystem linker role.

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -125,14 +125,19 @@ privileged; all are regular consumers of the common-language contract.
 
 ## Status
 
-**v0.6 in progress.** Building on v0.5.2 (VSM-aligned taxa, `use[of=...]`, cross-axis cascade, DuckDB compile target). Two new subsystems landed:
+**v0.6.0 released.** Building on v0.5.2 (VSM-aligned taxa, `use[of=...]`, cross-axis cascade, DuckDB compile target). v0.6 adds:
 
+- **Resource block model**: Single `resource` entity with properties replaces per-resource singletons. Cleaner vocabulary and CSS selectors.
 - **World State Layer** (`umwelt.world`): YAML-based world file parser with shorthand expansion, vocabulary validation, and three-level materialization (summary/outline/full). `umwelt materialize` CLI command. PyYAML dependency.
-- **PolicyEngine** (`umwelt.policy`): Consumer-facing Python API wrapping a compiled SQLite database. Three constructors (`from_files`, `from_db`, programmatic builder). Four query modes: resolve (cascade resolution), trace (explain why), lint (smell detection), select (entity filtering). COW `extend()` for immutable fork-and-specialize. World file entities populate the same SQL schema as matchers. Typed projection views (tools, modes, etc.) embedded in compiled databases. 70 new tests.
+- **PolicyEngine** (`umwelt.policy`): Consumer-facing Python API wrapping a compiled SQLite database. Three constructors (`from_files`, `from_db`, programmatic builder). Four query modes: resolve (cascade resolution), trace (explain why), lint (smell detection), select (entity filtering). COW `extend()` for immutable fork-and-specialize. World file entities populate the same SQL schema as matchers. Typed projection views (tools, modes, etc.) embedded in compiled databases.
+- **Mode filtering**: `mode#review tool { allow: false }` gates rules by active mode. Both in-memory cascade resolver and SQL PolicyEngine paths support `mode` parameter. Unscoped rules always apply; mode-gated rules only fire when that mode is active.
+- **Fixed constraints**: Post-cascade clamping for safety-critical properties via `fixed_raw` in world files. Applied after cascade resolution regardless of mode.
+- **CompositeMatcher**: Multiple matchers per taxon, enabling plugin coexistence.
+- **Plugin autodiscovery**: Entry point registration via `umwelt.plugins` for third-party plugins.
 
 PolicyEngine replaces the separate ducklog package for consumers like Kibitzer and Lackpy — they query resolved policy via `engine.resolve()` instead of raw SQL. See [`docs/superpowers/specs/2026-04-20-policy-engine-design.md`](../superpowers/specs/2026-04-20-policy-engine-design.md) for the full design spec.
 
-632+ tests total. See [`docs/superpowers/plans/`](../superpowers/plans/) for the active implementation plans and [`docs/vision/evaluation-framework.md`](./evaluation-framework.md) for the claim ledger.
+832 tests total. See [`docs/superpowers/plans/`](../superpowers/plans/) for the active implementation plans and [`docs/vision/evaluation-framework.md`](./evaluation-framework.md) for the claim ledger.
 
 ## Document map
 


### PR DESCRIPTION
## Summary

- Updated README status to v0.6.0 with feature list and test count (832)
- Updated vision README from "in progress" to "released"
- Added World Files, PolicyEngine, and Plugins cards to mkdocs landing page
- Full v0.6.0 CHANGELOG entry with Added/Changed/Fixed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)