### PR TITLE
Network isolation deny-by-default + honour file visibility (OS altitude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ file[path="src/main.py"] { editable: true; }
 Build up from there:
 
 ```css
-/* Multiple files with cascade — later rules override earlier ones */
+/* Multiple files with cascade — the MOST SPECIFIC rule wins for a given
+   property; document order only breaks ties between equally specific rules.
+   (So the narrower src/auth/ rule below wins over the broader src/ rule.) */
 file[path^="src/"]      { editable: false; }   /* everything read-only */
-file[path^="src/auth/"] { editable: true; }    /* except auth */
+file[path^="src/auth/"] { editable: true; }    /* except auth (more specific) */
 
 /* Tool restrictions */
 tool[name="Read"] { allow: true; }
@@ -149,6 +151,28 @@ See [How umwelt Works](docs/guide/how-it-works.md) for the full architectural pi
 - **Compiler `**options`** — `compile()` accepts caller context (`workspace_root`, `mode`, etc.)
 - **Shared event schema** — common observation properties for audit/monitoring plugins
 - **885 tests**, mypy strict, ruff clean
+
+## Security notes
+
+- **Network egress is deny-by-default at the OS altitude.** The nsjail compiler
+  isolates the jail's network (`clone_newnet`) unless a policy carries an
+  explicit positive `network { allow: true }`. A `deny` value never *opens* the
+  network — in particular `deny: "none"` does not grant egress — and a policy
+  with no `network` rule at all is isolated.
+- **File visibility is honoured at the OS altitude.** A file resolved to
+  `visible: false` is not mounted into the jail (previously only `editable` was
+  consulted).
+- **Permission resolution is by specificity, not restrictiveness.** For boolean
+  permissions (`editable`/`visible`/`allow`) the most-specific rule wins, so a
+  more-specific rule can *loosen* a broader one. This makes the "deny broadly,
+  allow a narrower subset" idiom work (including mode-gated exceptions such as
+  `mode#review tool { allow: false }` + `mode#review tool[name="Read"] { allow: true }`),
+  but it also means an authoritative deny is not automatically un-overridable
+  by a more-specific rule. The intended mechanism for pinning a safety-critical
+  property is a **fixed constraint** (post-cascade clamp) rather than an ordinary
+  cascade rule; extending the clamp's coverage across every enforcement path is
+  tracked upstream. Do not rely on cascade ordering alone as a trust boundary
+  between authoritative and less-trusted policy layers.
 
 ## The ecosystem
 

--- a/src/umwelt/_fixtures/expected/bwrap/minimal.argv
+++ b/src/umwelt/_fixtures/expected/bwrap/minimal.argv
@@ -17,3 +17,4 @@
 --bind
 /workspace/hello.txt
 /workspace/hello.txt
+--unshare-net

--- a/src/umwelt/_fixtures/expected/nsjail/minimal.textproto
+++ b/src/umwelt/_fixtures/expected/nsjail/minimal.textproto
@@ -1,6 +1,8 @@
 name: "umwelt-sandbox"
 hostname: "umwelt"
 
+clone_newnet: true
+
 mount {
   src: "/bin"
   dst: "/bin"

--- a/src/umwelt/sandbox/compilers/bwrap.py
+++ b/src/umwelt/sandbox/compilers/bwrap.py
@@ -70,6 +70,9 @@ class BwrapCompiler:
         binds: list[tuple[str, str, str]] = []    # (flag, src, dst)
         tmpfs_flags: list[tuple[str, ...]] = []
         unshare_flags: list[str] = []
+        # Deny-by-default: the jail is network-isolated (--unshare-net) unless a
+        # policy carries an explicit positive `network { allow: true }`.
+        network_allowed = False
 
         for entity, props in view.entries("world"):
             entity_type = type(entity).__name__
@@ -80,7 +83,8 @@ class BwrapCompiler:
             elif entity_type == "ResourceEntity":
                 self._collect_resource(result, tmpfs_flags, entity, props)
             elif entity_type == "NetworkEntity":
-                self._collect_network(unshare_flags, entity, props)
+                if self._network_allows(props):
+                    network_allowed = True
             elif entity_type == "EnvEntity":
                 self._collect_env(env_setenvs, entity, props)
             elif entity_type == "ExecEntity":
@@ -103,6 +107,8 @@ class BwrapCompiler:
         for parts in tmpfs_flags:
             result.argv.extend(parts)
 
+        if not network_allowed:
+            unshare_flags.append("--unshare-net")
         result.argv.extend(unshare_flags)
 
         return result
@@ -115,7 +121,11 @@ class BwrapCompiler:
         root: str,
     ) -> None:
         path = getattr(entity, "path", "")
-        editable = props.get("editable", "false").lower() == "true"
+        # A file the policy marks invisible must not be exposed inside the jail
+        # at all — not even read-only. Absence of a `visible` rule => visible.
+        if props.get("visible", "true").strip().lower() == "false":
+            return
+        editable = props.get("editable", "false").strip().lower() == "true"
         dst = path if path.startswith("/") else f"{root}/{path}"
         src = str(getattr(entity, "abs_path", path))
         flag = "--bind" if editable else "--ro-bind"
@@ -160,14 +170,15 @@ class BwrapCompiler:
         if props.get("tmpfs"):
             tmpfs_flags.append(("--tmpfs", "/tmp", f"--size={parse_size_for_tmpfs(props['tmpfs'])}"))
 
-    def _collect_network(
-        self,
-        unshare_flags: list[str],
-        entity: Any,
-        props: dict[str, str],
-    ) -> None:
-        if props.get("deny", "") == "*":
-            unshare_flags.append("--unshare-net")
+    def _network_allows(self, props: dict[str, str]) -> bool:
+        """True only for an explicit positive `allow: true`.
+
+        A `deny` value never opens the network (deny-by-default); in particular
+        `deny: "none"` does not grant egress. This closes the isolation-bypass
+        where a broad `deny: "*"` base was loosened by a more-specific
+        `deny: "none"`: absent an explicit allow, the jail stays isolated.
+        """
+        return props.get("allow", "").strip().lower() == "true"
 
     def _collect_env(
         self,

--- a/src/umwelt/sandbox/compilers/nsjail.py
+++ b/src/umwelt/sandbox/compilers/nsjail.py
@@ -34,7 +34,9 @@ class NsjailConfig:
     name: str = "umwelt-sandbox"
     hostname: str = "umwelt"
     time_limit: int | None = None
-    clone_newnet: bool = False
+    # Deny-by-default: the jail is network-isolated unless a policy explicitly
+    # opens egress. Absence of any network rule => isolated (fail-closed).
+    clone_newnet: bool = True
     rlimit_as: int | None = None
     rlimit_cpu: int | None = None
     rlimit_nofile: int | None = None
@@ -87,7 +89,11 @@ class NsjailCompiler:
         root: str,
     ) -> None:
         path = getattr(entity, "path", "")
-        editable = props.get("editable", "false").lower() == "true"
+        # A file the policy marks invisible must not be exposed inside the jail
+        # at all — not even read-only. Absence of a `visible` rule => visible.
+        if props.get("visible", "true").strip().lower() == "false":
+            return
+        editable = props.get("editable", "false").strip().lower() == "true"
         dst = path if path.startswith("/") else f"{root}/{path}"
         src = str(getattr(entity, "abs_path", path))
         cfg.mounts.append({
@@ -151,8 +157,17 @@ class NsjailCompiler:
         entity: Any,
         props: dict[str, str],
     ) -> None:
-        if props.get("deny", "") == "*":
-            cfg.clone_newnet = True
+        # Deny-by-default (security-critical): the jail is network-isolated
+        # (cfg.clone_newnet starts True) and is opened ONLY by an explicit,
+        # positive `allow: true`. A `deny` value is never allowed to *open* the
+        # network — in particular `deny: "none"` does NOT grant egress. This
+        # closes the isolation-bypass where a broad `deny: "*"` base was loosened
+        # by a more-specific `deny: "none"`: absent an explicit allow, the jail
+        # stays isolated regardless of how `deny` resolves. clone_newnet is
+        # all-or-nothing, so finer-grained deny patterns cannot open it either.
+        allow = props.get("allow", "").strip().lower()
+        if allow == "true":
+            cfg.clone_newnet = False
 
     def _compile_env(
         self,

--- a/tests/sandbox/golden/v05/actor-conditioned.bwrap.golden
+++ b/tests/sandbox/golden/v05/actor-conditioned.bwrap.golden
@@ -15,7 +15,8 @@
     "/lib64",
     "--ro-bind",
     "/sbin",
-    "/sbin"
+    "/sbin",
+    "--unshare-net"
   ],
   "wrapper": []
 }

--- a/tests/sandbox/golden/v05/actor-conditioned.nsjail.golden
+++ b/tests/sandbox/golden/v05/actor-conditioned.nsjail.golden
@@ -1,6 +1,8 @@
 name: "umwelt-sandbox"
 hostname: "umwelt"
 
+clone_newnet: true
+
 mount {
   src: "/bin"
   dst: "/bin"

--- a/tests/sandbox/golden/v05/minimal.bwrap.golden
+++ b/tests/sandbox/golden/v05/minimal.bwrap.golden
@@ -15,7 +15,8 @@
     "/lib64",
     "--ro-bind",
     "/sbin",
-    "/sbin"
+    "/sbin",
+    "--unshare-net"
   ],
   "wrapper": []
 }

--- a/tests/sandbox/golden/v05/minimal.nsjail.golden
+++ b/tests/sandbox/golden/v05/minimal.nsjail.golden
@@ -1,6 +1,8 @@
 name: "umwelt-sandbox"
 hostname: "umwelt"
 
+clone_newnet: true
+
 mount {
   src: "/bin"
   dst: "/bin"

--- a/tests/sandbox/test_bwrap_compiler.py
+++ b/tests/sandbox/test_bwrap_compiler.py
@@ -164,7 +164,9 @@ class TestBwrapResourceLimits:
         rv = ResolvedView()
         rv.add("capability", ToolEntity(name="Bash"), {"allow": "false"})
         result = BwrapCompiler().compile_full(rv, include_system_mounts=False)
-        assert result.argv == ["--clearenv"]  # only the default clearenv
+        # Tools produce no bwrap argv; network is deny-by-default (isolated)
+        # since no explicit `network { allow: true }` is present.
+        assert result.argv == ["--clearenv", "--unshare-net"]
         assert result.wrapper == []
 
     def test_full_worked_example(self, monkeypatch):

--- a/tests/sandbox/test_nsjail_compiler.py
+++ b/tests/sandbox/test_nsjail_compiler.py
@@ -78,9 +78,20 @@ def test_network_deny_all_emits_clone_newnet():
     assert "clone_newnet: true" in output
 
 
-def test_network_no_deny_does_not_emit_clone_newnet():
+def test_network_deny_none_stays_isolated():
+    # Deny-by-default: a resolved `deny: "none"` must NOT open the network.
+    # Only an explicit positive `allow: true` opens egress. This closes the
+    # isolation-bypass (GHSA-8fg4-2x93-4q77) where a broad `deny: "*"` base was
+    # loosened by a more-specific `deny: "none"`.
     rv = ResolvedView()
     rv.add("world", NetworkEntity(), {"deny": "none"})
+    output = NsjailCompiler().compile(rv)
+    assert "clone_newnet: true" in output
+
+
+def test_network_explicit_allow_opens_egress():
+    rv = ResolvedView()
+    rv.add("world", NetworkEntity(), {"allow": "true"})
     output = NsjailCompiler().compile(rv)
     assert "clone_newnet" not in output
 

--- a/tests/test_restrictive_resolution.py
+++ b/tests/test_restrictive_resolution.py
@@ -1,0 +1,156 @@
+"""Regression tests for the authorization-soundness hardening (GHSA-8fg4-2x93-4q77).
+
+Scope of the accompanying fix:
+
+* Network egress is **deny-by-default** at the OS altitude (nsjail): the jail is
+  network-isolated unless a policy carries an explicit positive ``allow: true``.
+  A ``deny`` value can never *open* the network, which closes the
+  isolation-bypass where a broad ``network { deny: "*" }`` base was loosened by a
+  more-specific ``network { deny: "none" }`` (or an equal-specificity later
+  rule): absent an explicit allow the jail stays isolated regardless of how
+  ``deny`` resolves.
+* A file the policy marks ``visible: false`` is not mounted into the jail at all.
+
+Deliberately OUT of scope (see the module docstring in ``test_boolean_escalation``
+and the PR body): the boolean permission-escalation via specificity for
+``editable``/``allow`` is an *unresolved threat-model conflict*, because the
+escalation shape is structurally identical to the intended, security-conscious
+"deny-all-except-X in mode Y" exception idiom. The two cannot be distinguished by
+restrictiveness alone. That invariant pair is asserted below (one side xfail) so
+the tension is visible and guarded against a regression that over-denies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from umwelt.cascade.resolver import ResolvedView
+from umwelt.sandbox.compilers.nsjail import NsjailCompiler
+from umwelt.sandbox.entities import FileEntity, NetworkEntity
+
+
+# ---------------------------------------------------------------------------
+# Network egress: deny-by-default (CRITICAL — isolation bypass, GHSA item 1)
+# ---------------------------------------------------------------------------
+
+
+class TestNsjailNetworkDenyByDefault:
+    def test_no_network_rule_is_isolated(self):
+        rv = ResolvedView()
+        rv.add(
+            "world",
+            FileEntity(path="a.py", abs_path=Path("/w/a.py"), name="a.py"),
+            {"editable": "false"},
+        )
+        assert "clone_newnet: true" in NsjailCompiler().compile(rv)
+
+    def test_deny_all_stays_isolated(self):
+        rv = ResolvedView()
+        rv.add("world", NetworkEntity(), {"deny": "*"})
+        assert "clone_newnet: true" in NsjailCompiler().compile(rv)
+
+    def test_resolved_deny_none_does_not_open_network(self):
+        # This is the isolation-bypass shape: whatever loosened `deny` to "none",
+        # the jail must stay isolated because there is no explicit allow.
+        rv = ResolvedView()
+        rv.add("world", NetworkEntity(), {"deny": "none"})
+        assert "clone_newnet: true" in NsjailCompiler().compile(rv)
+
+    def test_explicit_allow_true_opens_network(self):
+        rv = ResolvedView()
+        rv.add("world", NetworkEntity(), {"allow": "true"})
+        assert "clone_newnet" not in NsjailCompiler().compile(rv)
+
+
+# ---------------------------------------------------------------------------
+# Visibility dropped at OS altitude (GHSA item 5)
+# ---------------------------------------------------------------------------
+
+
+class TestNsjailVisibility:
+    def test_invisible_file_not_mounted(self):
+        rv = ResolvedView()
+        rv.add(
+            "world",
+            FileEntity(path="secret.py", abs_path=Path("/w/secret.py"), name="secret.py"),
+            {"editable": "false", "visible": "false"},
+        )
+        assert "secret.py" not in NsjailCompiler().compile(rv)
+
+    def test_visible_file_still_mounted(self):
+        rv = ResolvedView()
+        rv.add(
+            "world",
+            FileEntity(path="app.py", abs_path=Path("/w/app.py"), name="app.py"),
+            {"editable": "false", "visible": "true"},
+        )
+        assert "app.py" in NsjailCompiler().compile(rv)
+
+
+# ---------------------------------------------------------------------------
+# The unresolved core: permission escalation vs the exception idiom.
+# ---------------------------------------------------------------------------
+
+
+def _tree(tmp_path):
+    (tmp_path / "src" / "secrets").mkdir(parents=True)
+    (tmp_path / "src" / "secrets" / "key.py").write_text("# key")
+    (tmp_path / "src" / "app.py").write_text("# app")
+    return tmp_path
+
+
+def _resolve_editable(view_text, tmp_path):
+    from umwelt.cascade.resolver import resolve
+    from umwelt.parser import parse
+    from umwelt.registry import register_matcher, registry_scope
+    from umwelt.sandbox.vocabulary import register_sandbox_vocabulary
+    from umwelt.sandbox.world_matcher import WorldMatcher
+
+    with registry_scope():
+        register_sandbox_vocabulary()
+        register_matcher(taxon="world", matcher=WorldMatcher(base_dir=_tree(tmp_path)))
+        resolved = resolve(parse(view_text, validate=False))
+        return {
+            e.path: props.get("editable")
+            for e, props in resolved.entries("world")
+            if hasattr(e, "path")
+        }
+
+
+class TestBooleanEscalationInvariant:
+    """The fix must eventually satisfy BOTH of these simultaneously.
+
+    They are structurally identical (broad deny + narrower allow), so any model
+    that denies the escalation with plain restrictive-meet also denies the
+    legitimate exception. Distinguishing them needs a trust/layer boundary
+    (e.g. the fixed-constraint clamp — GHSA item 4), not restrictiveness. Until
+    that lands, ``test_escalation_is_denied`` is a known fail-open (xfail) and
+    ``test_exception_idiom_still_grants`` guards against a regression that would
+    "fix" escalation by breaking the idiom.
+    """
+
+    def test_exception_idiom_still_grants(self, tmp_path):
+        # "deny all .py, allow the secrets subtree" — the exception must grant.
+        editable = _resolve_editable(
+            'file[path$=".py"] { editable: false; }\n'
+            'file[path^="src/secrets"] { editable: true; }',
+            tmp_path,
+        )
+        # The intended cascade semantics: the more-specific allow wins.
+        assert editable["src/secrets/key.py"] == "true"
+
+    @pytest.mark.xfail(
+        reason="Unresolved: escalation shape is identical to the exception "
+        "idiom; needs the fixed-constraint clamp (GHSA-8fg4-2x93-4q77 item 4), "
+        "not restrictive-meet. Tracked in the PR / advisory.",
+        strict=True,
+    )
+    def test_escalation_is_denied(self, tmp_path):
+        editable = _resolve_editable(
+            'file[path$=".py"] { editable: false; }\n'
+            'file[path^="src/secrets"] { editable: true; }',
+            tmp_path,
+        )
+        assert editable["src/secrets/key.py"] == "false"


### PR DESCRIPTION
## Summary

Hardens the two OS-altitude enforcement compilers (nsjail and bwrap) so the
sandbox posture is fail-closed, and corrects/expands the resolution + security
documentation. Security-relevant; the private advisory **GHSA-8fg4-2x93-4q77**
tracks the full picture. No attack construction is included here (coordinated
disclosure).

### 1. Network egress is deny-by-default (both compilers)
The nsjail and bwrap compilers now network-isolate the jail by default and open
egress **only** on an explicit, positive `network { allow: true }`.

- A `deny` value is no longer trusted to *open* the network, and a policy with no
  `network` rule at all is isolated. Previously isolation was applied only in a
  narrow case, so it could fail to be applied when the policy intended it.
- Both the nsjail (`clone_newnet`) and bwrap (`--unshare-net`) paths are fixed —
  the two enforcement compilers consume the same resolved view, so fixing only
  one would have relocated the gap rather than closing it.

### 2. File visibility honoured at the OS altitude (both compilers)
The file compilers now consult `visible`: a file resolved to `visible: false` is
not mounted into the jail at all (previously only `editable` was read, so a file
the policy marked invisible was still bind-mounted and readable).

### 3. Docs (issue #13)
- Corrects the README cascade description: the **most-specific** rule wins;
  document order only breaks ties between equally-specific rules.
- Adds a **Security notes** section: deny-by-default network posture, visibility
  handling, and the specificity-based resolution model, with guidance to use
  fixed constraints (not cascade ordering) as a trust boundary between layers.

## Tests / evidence (reproduce-first)

`tests/test_restrictive_resolution.py` was written to fail on the pre-fix code
and pass after. Red -> green (OS-altitude change reverted vs applied):

```
RED  (pre-fix):   3 failed, 4 passed, 1 xfailed
  FAILED ... test_no_network_rule_is_isolated
  FAILED ... test_resolved_deny_none_does_not_open_network
  FAILED ... test_invisible_file_not_mounted
GREEN (with fix): 7 passed, 1 xfailed
```

Affected golden/snapshot fixtures were regenerated; the only diff is the added
network-isolation flag (`clone_newnet: true` / `--unshare-net`) for policies that
were previously left open — verified line-by-line. Full suite: **no new failures
introduced.** The pre-existing failures are environment-only (the CLI tests spawn
`python -m umwelt.cli` in a subprocess that cannot import the non-installed
package; they fail identically on `main`).

## Deliberately NOT included — an open threat-model decision (please review)

The advisory also calls for resolving boolean permissions
(`editable`/`visible`/`allow`) by **restrictiveness / deny-overrides** in the
cascade. Implementing that as a global rule is **refuted by the codebase**: the
escalation shape is structurally identical to the intended, security-conscious
*exception idiom* — deny a class of entities, then re-allow a specific member
(e.g. deny all tools in a review mode, then re-allow a read-only tool). Roughly
**59 existing tests** (mode-filtering + multi-tenant/CI-CD integration suites)
encode that idiom as intended behavior. A global deny-overrides makes the
re-allowed member deny too, breaking it — restrictiveness alone cannot tell the
legitimate exception from an escalation.

Distinguishing them needs a trust/layer boundary — the **fixed-constraint clamp**
(advisory item 4), which today does not reach in-memory enforcement and does not
support attribute selectors. Rather than silently pick deny-overrides and rewrite
~59 legitimate-pattern tests, this PR surfaces the tension: the regression test
asserts the required invariant *pair* — the exception idiom must still grant
(passing guard) and the escalation must eventually be denied (`strict` **xfail**,
documenting the known fail-open). **Recommended follow-up:** close the boolean
escalation via the clamp, not the cascade. This is a semantics decision for the
maintainer, not something an automated fix should choose unilaterally.

## Disclosure / release handoff

**Do not publish GHSA-8fg4-2x93-4q77 against this PR.** The advisory covers the
cascade root cause and the permission-escalation symptom, which remain **open**
after this PR (only the network-isolation posture and the visibility read are
closed here). Publish the advisory only once the resolver/clamp decision above
has shipped.

## Residual risk (calibrated)

- **CONFIRMED closed:** network egress is fail-closed by default across both
  nsjail and bwrap; a file resolved `visible: false` is no longer mounted.
- **Still PLAUSIBLE (documented xfail):** specificity-based resolution of the
  `editable`/`allow`/`visible` booleans within a policy. This includes
  `network { allow: true }` itself (same boolean class): a policy that adds a
  more-specific allow over a broader deny can still enable egress. Deny-by-default
  closes the demonstrated egress gap but does not make the `allow` boolean
  un-overridable.
- **Not a network boundary:** the lackpy (language-altitude) compiler does not
  isolate network or filesystem — that is by design (nsjail/bwrap are the OS
  boundary); reviewed, needs no change here.
- **Fail-closed trade-off:** policies with no `network` rule are now isolated by
  default (intended posture); four golden fixtures were updated to match.
  Legitimate egress now requires an explicit `network { allow: true }`.

Refs GHSA-8fg4-2x93-4q77 (private), #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n
